### PR TITLE
feat(domain): 도메인 및 JPA 엔티티 구현 (#6)

### DIFF
--- a/backend/src/main/java/com/toadzip/backend/housing/domain/Address.java
+++ b/backend/src/main/java/com/toadzip/backend/housing/domain/Address.java
@@ -1,0 +1,109 @@
+package com.toadzip.backend.housing.domain;
+
+import static lombok.AccessLevel.PROTECTED;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.math.BigDecimal;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Embeddable
+@NoArgsConstructor(access = PROTECTED)
+public class Address {
+
+    @Column(nullable = false)
+    private String roadAddress;
+
+    @Column(nullable = false)
+    private String pnu;
+
+    @Column(nullable = false)
+    private String legalDongCode;
+
+    @Column(nullable = false)
+    private String provinceCode;
+
+    @Column(nullable = false)
+    private String provinceName;
+
+    @Column(nullable = false)
+    private String cityCountyDistrictCode;
+
+    @Column(nullable = false)
+    private String cityCountyDistrictName;
+
+    @Column(nullable = false)
+    private BigDecimal latitude;
+
+    @Column(nullable = false)
+    private BigDecimal longitude;
+
+    private Address(
+            String roadAddress,
+            String pnu,
+            String legalDongCode,
+            String provinceCode,
+            String provinceName,
+            String cityCountyDistrictCode,
+            String cityCountyDistrictName,
+            BigDecimal latitude,
+            BigDecimal longitude
+    ) {
+        validateNotBlank(roadAddress, "도로명주소");
+        validateNotBlank(pnu, "PNU");
+        validateNotBlank(legalDongCode, "법정동코드");
+        validateNotBlank(provinceCode, "시·도 코드");
+        validateNotBlank(provinceName, "시·도명");
+        validateNotBlank(cityCountyDistrictCode, "시·군·구 코드");
+        validateNotBlank(cityCountyDistrictName, "시·군·구명");
+        validateRequired(latitude, "위도");
+        validateRequired(longitude, "경도");
+        this.roadAddress = roadAddress;
+        this.pnu = pnu;
+        this.legalDongCode = legalDongCode;
+        this.provinceCode = provinceCode;
+        this.provinceName = provinceName;
+        this.cityCountyDistrictCode = cityCountyDistrictCode;
+        this.cityCountyDistrictName = cityCountyDistrictName;
+        this.latitude = latitude;
+        this.longitude = longitude;
+    }
+
+    public static Address create(
+            String roadAddress,
+            String pnu,
+            String legalDongCode,
+            String provinceCode,
+            String provinceName,
+            String cityCountyDistrictCode,
+            String cityCountyDistrictName,
+            BigDecimal latitude,
+            BigDecimal longitude
+    ) {
+        return new Address(
+                roadAddress,
+                pnu,
+                legalDongCode,
+                provinceCode,
+                provinceName,
+                cityCountyDistrictCode,
+                cityCountyDistrictName,
+                latitude,
+                longitude
+        );
+    }
+
+    private void validateNotBlank(String value, String fieldName) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(fieldName + "은 필수다.");
+        }
+    }
+
+    private void validateRequired(Object value, String fieldName) {
+        if (value == null) {
+            throw new IllegalArgumentException(fieldName + "은 필수다.");
+        }
+    }
+}

--- a/backend/src/main/java/com/toadzip/backend/housing/domain/Address.java
+++ b/backend/src/main/java/com/toadzip/backend/housing/domain/Address.java
@@ -28,10 +28,10 @@ public class Address {
     @Column(nullable = false)
     private String cityCountyDistrictCode;
 
-    @Column(nullable = false)
+    @Column(nullable = false, precision = 9, scale = 6)
     private BigDecimal latitude;
 
-    @Column(nullable = false)
+    @Column(nullable = false, precision = 10, scale = 6)
     private BigDecimal longitude;
 
     private Address(
@@ -48,8 +48,8 @@ public class Address {
         validateNotBlank(legalDongCode, "법정동코드");
         validateNotBlank(provinceCode, "시·도 코드");
         validateNotBlank(cityCountyDistrictCode, "시·군·구 코드");
-        validateRequired(latitude, "위도");
-        validateRequired(longitude, "경도");
+        validateLatitude(latitude);
+        validateLongitude(longitude);
         this.roadAddress = roadAddress;
         this.pnu = pnu;
         this.legalDongCode = legalDongCode;
@@ -88,6 +88,22 @@ public class Address {
     private void validateRequired(Object value, String fieldName) {
         if (value == null) {
             throw new IllegalArgumentException(fieldName + "은 필수다.");
+        }
+    }
+
+    private void validateLatitude(BigDecimal latitude) {
+        validateRequired(latitude, "위도");
+        if (latitude.compareTo(BigDecimal.valueOf(-90)) < 0
+                || latitude.compareTo(BigDecimal.valueOf(90)) > 0) {
+            throw new IllegalArgumentException("위도는 -90도 이상 90도 이하여야 한다.");
+        }
+    }
+
+    private void validateLongitude(BigDecimal longitude) {
+        validateRequired(longitude, "경도");
+        if (longitude.compareTo(BigDecimal.valueOf(-180)) < 0
+                || longitude.compareTo(BigDecimal.valueOf(180)) > 0) {
+            throw new IllegalArgumentException("경도는 -180도 이상 180도 이하여야 한다.");
         }
     }
 }

--- a/backend/src/main/java/com/toadzip/backend/housing/domain/Address.java
+++ b/backend/src/main/java/com/toadzip/backend/housing/domain/Address.java
@@ -26,13 +26,7 @@ public class Address {
     private String provinceCode;
 
     @Column(nullable = false)
-    private String provinceName;
-
-    @Column(nullable = false)
     private String cityCountyDistrictCode;
-
-    @Column(nullable = false)
-    private String cityCountyDistrictName;
 
     @Column(nullable = false)
     private BigDecimal latitude;
@@ -45,9 +39,7 @@ public class Address {
             String pnu,
             String legalDongCode,
             String provinceCode,
-            String provinceName,
             String cityCountyDistrictCode,
-            String cityCountyDistrictName,
             BigDecimal latitude,
             BigDecimal longitude
     ) {
@@ -55,18 +47,14 @@ public class Address {
         validateNotBlank(pnu, "PNU");
         validateNotBlank(legalDongCode, "법정동코드");
         validateNotBlank(provinceCode, "시·도 코드");
-        validateNotBlank(provinceName, "시·도명");
         validateNotBlank(cityCountyDistrictCode, "시·군·구 코드");
-        validateNotBlank(cityCountyDistrictName, "시·군·구명");
         validateRequired(latitude, "위도");
         validateRequired(longitude, "경도");
         this.roadAddress = roadAddress;
         this.pnu = pnu;
         this.legalDongCode = legalDongCode;
         this.provinceCode = provinceCode;
-        this.provinceName = provinceName;
         this.cityCountyDistrictCode = cityCountyDistrictCode;
-        this.cityCountyDistrictName = cityCountyDistrictName;
         this.latitude = latitude;
         this.longitude = longitude;
     }
@@ -76,9 +64,7 @@ public class Address {
             String pnu,
             String legalDongCode,
             String provinceCode,
-            String provinceName,
             String cityCountyDistrictCode,
-            String cityCountyDistrictName,
             BigDecimal latitude,
             BigDecimal longitude
     ) {
@@ -87,9 +73,7 @@ public class Address {
                 pnu,
                 legalDongCode,
                 provinceCode,
-                provinceName,
                 cityCountyDistrictCode,
-                cityCountyDistrictName,
                 latitude,
                 longitude
         );

--- a/backend/src/main/java/com/toadzip/backend/housing/domain/HousingComplex.java
+++ b/backend/src/main/java/com/toadzip/backend/housing/domain/HousingComplex.java
@@ -1,0 +1,167 @@
+package com.toadzip.backend.housing.domain;
+
+import static lombok.AccessLevel.PROTECTED;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "housing_complexes")
+@NoArgsConstructor(access = PROTECTED)
+public class HousingComplex {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private String sourceComplexIdentifier;
+
+    @Column(nullable = false)
+    private String supplyType;
+
+    @Embedded
+    private Address address;
+
+    @Column(nullable = false)
+    private int totalHouseholdCount;
+
+    @Column(nullable = false)
+    private String provider;
+
+    @Column(nullable = false)
+    private LocalDate completionDate;
+
+    @Column(nullable = false)
+    private String heatingType;
+
+    @Column(nullable = false)
+    private String housingType;
+
+    @Column(nullable = false)
+    private String corridorType;
+
+    @Column(nullable = false)
+    private boolean elevatorInstalled;
+
+    @Column(nullable = false)
+    private int parkingSpaceCount;
+
+    private String imageUrl;
+
+    private Integer recentOneYearMoveOutCount;
+
+    private HousingComplex(
+            String name,
+            String sourceComplexIdentifier,
+            String supplyType,
+            Address address,
+            int totalHouseholdCount,
+            String provider,
+            LocalDate completionDate,
+            String heatingType,
+            String housingType,
+            String corridorType,
+            boolean elevatorInstalled,
+            int parkingSpaceCount,
+            String imageUrl,
+            Integer recentOneYearMoveOutCount
+    ) {
+        validateNotBlank(name, "단지명");
+        validateNotBlank(sourceComplexIdentifier, "원천 단지 식별자");
+        validateNotBlank(supplyType, "공급유형");
+        validateRequired(address, "주소");
+        validateNonNegative(totalHouseholdCount, "전체 세대수");
+        validateNotBlank(provider, "공급기관");
+        validateRequired(completionDate, "준공일");
+        validateNotBlank(heatingType, "난방유형");
+        validateNotBlank(housingType, "주택유형");
+        validateNotBlank(corridorType, "복도유형");
+        validateNonNegative(parkingSpaceCount, "주차대수");
+        validateNonNegativeIfPresent(recentOneYearMoveOutCount, "최근 1년 퇴거자 수");
+        this.name = name;
+        this.sourceComplexIdentifier = sourceComplexIdentifier;
+        this.supplyType = supplyType;
+        this.address = address;
+        this.totalHouseholdCount = totalHouseholdCount;
+        this.provider = provider;
+        this.completionDate = completionDate;
+        this.heatingType = heatingType;
+        this.housingType = housingType;
+        this.corridorType = corridorType;
+        this.elevatorInstalled = elevatorInstalled;
+        this.parkingSpaceCount = parkingSpaceCount;
+        this.imageUrl = imageUrl;
+        this.recentOneYearMoveOutCount = recentOneYearMoveOutCount;
+    }
+
+    public static HousingComplex create(
+            String name,
+            String sourceComplexIdentifier,
+            String supplyType,
+            Address address,
+            int totalHouseholdCount,
+            String provider,
+            LocalDate completionDate,
+            String heatingType,
+            String housingType,
+            String corridorType,
+            boolean elevatorInstalled,
+            int parkingSpaceCount,
+            String imageUrl,
+            Integer recentOneYearMoveOutCount
+    ) {
+        return new HousingComplex(
+                name,
+                sourceComplexIdentifier,
+                supplyType,
+                address,
+                totalHouseholdCount,
+                provider,
+                completionDate,
+                heatingType,
+                housingType,
+                corridorType,
+                elevatorInstalled,
+                parkingSpaceCount,
+                imageUrl,
+                recentOneYearMoveOutCount
+        );
+    }
+
+    private void validateNotBlank(String value, String fieldName) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(fieldName + "은 필수다.");
+        }
+    }
+
+    private void validateRequired(Object value, String fieldName) {
+        if (value == null) {
+            throw new IllegalArgumentException(fieldName + "은 필수다.");
+        }
+    }
+
+    private void validateNonNegative(int value, String fieldName) {
+        if (value < 0) {
+            throw new IllegalArgumentException(fieldName + "은 음수일 수 없다.");
+        }
+    }
+
+    private void validateNonNegativeIfPresent(Integer value, String fieldName) {
+        if (value != null && value < 0) {
+            throw new IllegalArgumentException(fieldName + "은 음수일 수 없다.");
+        }
+    }
+}

--- a/backend/src/main/java/com/toadzip/backend/housing/domain/HousingType.java
+++ b/backend/src/main/java/com/toadzip/backend/housing/domain/HousingType.java
@@ -38,9 +38,6 @@ public class HousingType {
     private BigDecimal supplyArea;
 
     @Column(nullable = false)
-    private BigDecimal residentialCommonArea;
-
-    @Column(nullable = false)
     private int totalHouseholdCount;
 
     @Column(nullable = false)
@@ -56,7 +53,6 @@ public class HousingType {
             String name,
             BigDecimal exclusiveArea,
             BigDecimal supplyArea,
-            BigDecimal residentialCommonArea,
             int totalHouseholdCount,
             String floorPlanUrl,
             boolean duplex,
@@ -66,7 +62,6 @@ public class HousingType {
         validateNotBlank(name, "주택형명");
         validateRequiredAmount(exclusiveArea, "전용면적");
         validateNonNegativeIfPresent(supplyArea, "공급면적");
-        validateRequiredAmount(residentialCommonArea, "주거공용면적");
         validateNonNegative(totalHouseholdCount, "전체 세대수");
         validateNotBlank(floorPlanUrl, "평면도");
         validateNonNegativeIfPresent(maintenanceFee, "관리비");
@@ -74,7 +69,6 @@ public class HousingType {
         this.name = name;
         this.exclusiveArea = exclusiveArea;
         this.supplyArea = supplyArea;
-        this.residentialCommonArea = residentialCommonArea;
         this.totalHouseholdCount = totalHouseholdCount;
         this.floorPlanUrl = floorPlanUrl;
         this.duplex = duplex;
@@ -86,7 +80,6 @@ public class HousingType {
             String name,
             BigDecimal exclusiveArea,
             BigDecimal supplyArea,
-            BigDecimal residentialCommonArea,
             int totalHouseholdCount,
             String floorPlanUrl,
             boolean duplex,
@@ -97,7 +90,6 @@ public class HousingType {
                 name,
                 exclusiveArea,
                 supplyArea,
-                residentialCommonArea,
                 totalHouseholdCount,
                 floorPlanUrl,
                 duplex,

--- a/backend/src/main/java/com/toadzip/backend/housing/domain/HousingType.java
+++ b/backend/src/main/java/com/toadzip/backend/housing/domain/HousingType.java
@@ -1,0 +1,136 @@
+package com.toadzip.backend.housing.domain;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static lombok.AccessLevel.PROTECTED;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "housing_types")
+@NoArgsConstructor(access = PROTECTED)
+public class HousingType {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = LAZY, optional = false)
+    @JoinColumn(name = "housing_complex_id", nullable = false)
+    private HousingComplex housingComplex;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private BigDecimal exclusiveArea;
+
+    private BigDecimal supplyArea;
+
+    @Column(nullable = false)
+    private BigDecimal residentialCommonArea;
+
+    @Column(nullable = false)
+    private int totalHouseholdCount;
+
+    @Column(nullable = false)
+    private String floorPlanUrl;
+
+    @Column(nullable = false)
+    private boolean duplex;
+
+    private BigDecimal maintenanceFee;
+
+    private HousingType(
+            HousingComplex housingComplex,
+            String name,
+            BigDecimal exclusiveArea,
+            BigDecimal supplyArea,
+            BigDecimal residentialCommonArea,
+            int totalHouseholdCount,
+            String floorPlanUrl,
+            boolean duplex,
+            BigDecimal maintenanceFee
+    ) {
+        validateRequired(housingComplex, "소속 단지");
+        validateNotBlank(name, "주택형명");
+        validateRequiredAmount(exclusiveArea, "전용면적");
+        validateNonNegativeIfPresent(supplyArea, "공급면적");
+        validateRequiredAmount(residentialCommonArea, "주거공용면적");
+        validateNonNegative(totalHouseholdCount, "전체 세대수");
+        validateNotBlank(floorPlanUrl, "평면도");
+        validateNonNegativeIfPresent(maintenanceFee, "관리비");
+        this.housingComplex = housingComplex;
+        this.name = name;
+        this.exclusiveArea = exclusiveArea;
+        this.supplyArea = supplyArea;
+        this.residentialCommonArea = residentialCommonArea;
+        this.totalHouseholdCount = totalHouseholdCount;
+        this.floorPlanUrl = floorPlanUrl;
+        this.duplex = duplex;
+        this.maintenanceFee = maintenanceFee;
+    }
+
+    public static HousingType create(
+            HousingComplex housingComplex,
+            String name,
+            BigDecimal exclusiveArea,
+            BigDecimal supplyArea,
+            BigDecimal residentialCommonArea,
+            int totalHouseholdCount,
+            String floorPlanUrl,
+            boolean duplex,
+            BigDecimal maintenanceFee
+    ) {
+        return new HousingType(
+                housingComplex,
+                name,
+                exclusiveArea,
+                supplyArea,
+                residentialCommonArea,
+                totalHouseholdCount,
+                floorPlanUrl,
+                duplex,
+                maintenanceFee
+        );
+    }
+
+    private void validateRequired(Object value, String fieldName) {
+        if (value == null) {
+            throw new IllegalArgumentException(fieldName + "은 필수다.");
+        }
+    }
+
+    private void validateNotBlank(String value, String fieldName) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(fieldName + "은 필수다.");
+        }
+    }
+
+    private void validateRequiredAmount(BigDecimal value, String fieldName) {
+        validateRequired(value, fieldName);
+        validateNonNegativeIfPresent(value, fieldName);
+    }
+
+    private void validateNonNegativeIfPresent(BigDecimal value, String fieldName) {
+        if (value != null && value.signum() < 0) {
+            throw new IllegalArgumentException(fieldName + "은 음수일 수 없다.");
+        }
+    }
+
+    private void validateNonNegative(int value, String fieldName) {
+        if (value < 0) {
+            throw new IllegalArgumentException(fieldName + "은 음수일 수 없다.");
+        }
+    }
+}

--- a/backend/src/main/java/com/toadzip/backend/interest/domain/FavoriteHousingComplex.java
+++ b/backend/src/main/java/com/toadzip/backend/interest/domain/FavoriteHousingComplex.java
@@ -1,0 +1,63 @@
+package com.toadzip.backend.interest.domain;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static lombok.AccessLevel.PROTECTED;
+
+import com.toadzip.backend.housing.domain.HousingComplex;
+import com.toadzip.backend.user.domain.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "favorite_housing_complexes")
+@NoArgsConstructor(access = PROTECTED)
+public class FavoriteHousingComplex {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = LAZY, optional = false)
+    @JoinColumn(name = "housing_complex_id", nullable = false)
+    private HousingComplex housingComplex;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    private FavoriteHousingComplex(User user, HousingComplex housingComplex, LocalDateTime createdAt) {
+        validateRequired(user, "유저");
+        validateRequired(housingComplex, "단지");
+        validateRequired(createdAt, "등록일시");
+        this.user = user;
+        this.housingComplex = housingComplex;
+        this.createdAt = createdAt;
+    }
+
+    public static FavoriteHousingComplex create(
+            User user,
+            HousingComplex housingComplex,
+            LocalDateTime createdAt
+    ) {
+        return new FavoriteHousingComplex(user, housingComplex, createdAt);
+    }
+
+    private void validateRequired(Object value, String fieldName) {
+        if (value == null) {
+            throw new IllegalArgumentException(fieldName + "은 필수다.");
+        }
+    }
+}

--- a/backend/src/main/java/com/toadzip/backend/interest/domain/FavoriteNotice.java
+++ b/backend/src/main/java/com/toadzip/backend/interest/domain/FavoriteNotice.java
@@ -31,8 +31,8 @@ public class FavoriteNotice {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @ManyToOne(fetch = LAZY)
-    @JoinColumn(name = "notice_id")
+    @ManyToOne(fetch = LAZY, optional = false)
+    @JoinColumn(name = "notice_id", nullable = false)
     private Notice notice;
 
     @Column(nullable = false)
@@ -40,6 +40,7 @@ public class FavoriteNotice {
 
     private FavoriteNotice(User user, Notice notice, LocalDateTime createdAt) {
         validateRequired(user, "유저");
+        validateRequired(notice, "공고");
         validateRequired(createdAt, "등록일시");
         this.user = user;
         this.notice = notice;

--- a/backend/src/main/java/com/toadzip/backend/interest/domain/FavoriteNotice.java
+++ b/backend/src/main/java/com/toadzip/backend/interest/domain/FavoriteNotice.java
@@ -1,0 +1,58 @@
+package com.toadzip.backend.interest.domain;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static lombok.AccessLevel.PROTECTED;
+
+import com.toadzip.backend.notice.domain.Notice;
+import com.toadzip.backend.user.domain.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "favorite_notices")
+@NoArgsConstructor(access = PROTECTED)
+public class FavoriteNotice {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "notice_id")
+    private Notice notice;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    private FavoriteNotice(User user, Notice notice, LocalDateTime createdAt) {
+        validateRequired(user, "유저");
+        validateRequired(createdAt, "등록일시");
+        this.user = user;
+        this.notice = notice;
+        this.createdAt = createdAt;
+    }
+
+    public static FavoriteNotice create(User user, Notice notice, LocalDateTime createdAt) {
+        return new FavoriteNotice(user, notice, createdAt);
+    }
+
+    private void validateRequired(Object value, String fieldName) {
+        if (value == null) {
+            throw new IllegalArgumentException(fieldName + "은 필수다.");
+        }
+    }
+}

--- a/backend/src/main/java/com/toadzip/backend/interest/domain/FavoriteRegion.java
+++ b/backend/src/main/java/com/toadzip/backend/interest/domain/FavoriteRegion.java
@@ -1,0 +1,99 @@
+package com.toadzip.backend.interest.domain;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static lombok.AccessLevel.PROTECTED;
+
+import com.toadzip.backend.user.domain.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "favorite_regions")
+@NoArgsConstructor(access = PROTECTED)
+public class FavoriteRegion {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false)
+    private String provinceCode;
+
+    @Column(nullable = false)
+    private String provinceName;
+
+    @Column(nullable = false)
+    private String cityCountyDistrictCode;
+
+    @Column(nullable = false)
+    private String cityCountyDistrictName;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    private FavoriteRegion(
+            User user,
+            String provinceCode,
+            String provinceName,
+            String cityCountyDistrictCode,
+            String cityCountyDistrictName,
+            LocalDateTime createdAt
+    ) {
+        validateRequired(user, "유저");
+        validateNotBlank(provinceCode, "시·도 코드");
+        validateNotBlank(provinceName, "시·도명");
+        validateNotBlank(cityCountyDistrictCode, "시·군·구 코드");
+        validateNotBlank(cityCountyDistrictName, "시·군·구명");
+        validateRequired(createdAt, "등록일시");
+        this.user = user;
+        this.provinceCode = provinceCode;
+        this.provinceName = provinceName;
+        this.cityCountyDistrictCode = cityCountyDistrictCode;
+        this.cityCountyDistrictName = cityCountyDistrictName;
+        this.createdAt = createdAt;
+    }
+
+    public static FavoriteRegion create(
+            User user,
+            String provinceCode,
+            String provinceName,
+            String cityCountyDistrictCode,
+            String cityCountyDistrictName,
+            LocalDateTime createdAt
+    ) {
+        return new FavoriteRegion(
+                user,
+                provinceCode,
+                provinceName,
+                cityCountyDistrictCode,
+                cityCountyDistrictName,
+                createdAt
+        );
+    }
+
+    private void validateRequired(Object value, String fieldName) {
+        if (value == null) {
+            throw new IllegalArgumentException(fieldName + "은 필수다.");
+        }
+    }
+
+    private void validateNotBlank(String value, String fieldName) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(fieldName + "은 필수다.");
+        }
+    }
+}

--- a/backend/src/main/java/com/toadzip/backend/interest/domain/FavoriteRegion.java
+++ b/backend/src/main/java/com/toadzip/backend/interest/domain/FavoriteRegion.java
@@ -34,13 +34,7 @@ public class FavoriteRegion {
     private String provinceCode;
 
     @Column(nullable = false)
-    private String provinceName;
-
-    @Column(nullable = false)
     private String cityCountyDistrictCode;
-
-    @Column(nullable = false)
-    private String cityCountyDistrictName;
 
     @Column(nullable = false)
     private LocalDateTime createdAt;
@@ -48,39 +42,29 @@ public class FavoriteRegion {
     private FavoriteRegion(
             User user,
             String provinceCode,
-            String provinceName,
             String cityCountyDistrictCode,
-            String cityCountyDistrictName,
             LocalDateTime createdAt
     ) {
         validateRequired(user, "유저");
         validateNotBlank(provinceCode, "시·도 코드");
-        validateNotBlank(provinceName, "시·도명");
         validateNotBlank(cityCountyDistrictCode, "시·군·구 코드");
-        validateNotBlank(cityCountyDistrictName, "시·군·구명");
         validateRequired(createdAt, "등록일시");
         this.user = user;
         this.provinceCode = provinceCode;
-        this.provinceName = provinceName;
         this.cityCountyDistrictCode = cityCountyDistrictCode;
-        this.cityCountyDistrictName = cityCountyDistrictName;
         this.createdAt = createdAt;
     }
 
     public static FavoriteRegion create(
             User user,
             String provinceCode,
-            String provinceName,
             String cityCountyDistrictCode,
-            String cityCountyDistrictName,
             LocalDateTime createdAt
     ) {
         return new FavoriteRegion(
                 user,
                 provinceCode,
-                provinceName,
                 cityCountyDistrictCode,
-                cityCountyDistrictName,
                 createdAt
         );
     }

--- a/backend/src/main/java/com/toadzip/backend/notice/domain/Notice.java
+++ b/backend/src/main/java/com/toadzip/backend/notice/domain/Notice.java
@@ -112,6 +112,7 @@ public class Notice {
         validateRequired(postedDate, "게시일");
         validateRequired(applicationStartDate, "접수 시작일");
         validateRequired(applicationEndDate, "접수 종료일");
+        validateApplicationPeriod(applicationStartDate, applicationEndDate);
         validateRequired(winnerAnnouncementDate, "당첨자 발표일");
         validateNotBlank(originalUrl, "원문 URL");
         validateNonNegative(viewCount, "조회수");
@@ -187,6 +188,12 @@ public class Notice {
     private void validateNonNegative(long value, String fieldName) {
         if (value < 0) {
             throw new IllegalArgumentException(fieldName + "은 음수일 수 없다.");
+        }
+    }
+
+    private void validateApplicationPeriod(LocalDate startDate, LocalDate endDate) {
+        if (endDate.isBefore(startDate)) {
+            throw new IllegalArgumentException("접수 종료일은 접수 시작일보다 빠를 수 없다.");
         }
     }
 }

--- a/backend/src/main/java/com/toadzip/backend/notice/domain/Notice.java
+++ b/backend/src/main/java/com/toadzip/backend/notice/domain/Notice.java
@@ -1,0 +1,192 @@
+package com.toadzip.backend.notice.domain;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static lombok.AccessLevel.PROTECTED;
+
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.AttributeOverrides;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "notices")
+@NoArgsConstructor(access = PROTECTED)
+public class Notice {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String sourceNoticeIdentifier;
+
+    private String previousSourceNoticeIdentifier;
+
+    @OneToOne(fetch = LAZY)
+    @JoinColumn(name = "previous_notice_id", unique = true)
+    private Notice previousNotice;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private String status;
+
+    @Column(nullable = false)
+    private String supplyType;
+
+    @Column(nullable = false)
+    private String recruitmentType;
+
+    @Column(nullable = false)
+    private String provider;
+
+    @Column(nullable = false)
+    private LocalDate postedDate;
+
+    @Column(nullable = false)
+    private LocalDate applicationStartDate;
+
+    @Column(nullable = false)
+    private LocalDate applicationEndDate;
+
+    @Column(nullable = false)
+    private LocalDate winnerAnnouncementDate;
+
+    @Column(nullable = false)
+    private String originalUrl;
+
+    private String correctionCancellationReason;
+
+    @Column(nullable = false)
+    private long viewCount;
+
+    @Embedded
+    @AttributeOverrides({
+            @AttributeOverride(name = "name", column = @Column(name = "reception_place_name", nullable = false)),
+            @AttributeOverride(name = "method", column = @Column(name = "reception_method", nullable = false)),
+            @AttributeOverride(name = "address", column = @Column(name = "reception_address")),
+            @AttributeOverride(
+                    name = "contact",
+                    column = @Column(name = "reception_contact", nullable = false)
+            ),
+            @AttributeOverride(name = "url", column = @Column(name = "reception_url"))
+    })
+    private ReceptionPlace receptionPlace;
+
+    private Notice(
+            String sourceNoticeIdentifier,
+            String previousSourceNoticeIdentifier,
+            Notice previousNotice,
+            String name,
+            String status,
+            String supplyType,
+            String recruitmentType,
+            String provider,
+            LocalDate postedDate,
+            LocalDate applicationStartDate,
+            LocalDate applicationEndDate,
+            LocalDate winnerAnnouncementDate,
+            String originalUrl,
+            String correctionCancellationReason,
+            long viewCount,
+            ReceptionPlace receptionPlace
+    ) {
+        validateNotBlank(sourceNoticeIdentifier, "원천 공고 식별자");
+        validateNotBlank(name, "공고명");
+        validateNotBlank(status, "공고 상태");
+        validateNotBlank(supplyType, "공급유형");
+        validateNotBlank(recruitmentType, "모집유형");
+        validateNotBlank(provider, "공급기관");
+        validateRequired(postedDate, "게시일");
+        validateRequired(applicationStartDate, "접수 시작일");
+        validateRequired(applicationEndDate, "접수 종료일");
+        validateRequired(winnerAnnouncementDate, "당첨자 발표일");
+        validateNotBlank(originalUrl, "원문 URL");
+        validateNonNegative(viewCount, "조회수");
+        validateRequired(receptionPlace, "접수처");
+        this.sourceNoticeIdentifier = sourceNoticeIdentifier;
+        this.previousSourceNoticeIdentifier = previousSourceNoticeIdentifier;
+        this.previousNotice = previousNotice;
+        this.name = name;
+        this.status = status;
+        this.supplyType = supplyType;
+        this.recruitmentType = recruitmentType;
+        this.provider = provider;
+        this.postedDate = postedDate;
+        this.applicationStartDate = applicationStartDate;
+        this.applicationEndDate = applicationEndDate;
+        this.winnerAnnouncementDate = winnerAnnouncementDate;
+        this.originalUrl = originalUrl;
+        this.correctionCancellationReason = correctionCancellationReason;
+        this.viewCount = viewCount;
+        this.receptionPlace = receptionPlace;
+    }
+
+    public static Notice create(
+            String sourceNoticeIdentifier,
+            String previousSourceNoticeIdentifier,
+            Notice previousNotice,
+            String name,
+            String status,
+            String supplyType,
+            String recruitmentType,
+            String provider,
+            LocalDate postedDate,
+            LocalDate applicationStartDate,
+            LocalDate applicationEndDate,
+            LocalDate winnerAnnouncementDate,
+            String originalUrl,
+            String correctionCancellationReason,
+            long viewCount,
+            ReceptionPlace receptionPlace
+    ) {
+        return new Notice(
+                sourceNoticeIdentifier,
+                previousSourceNoticeIdentifier,
+                previousNotice,
+                name,
+                status,
+                supplyType,
+                recruitmentType,
+                provider,
+                postedDate,
+                applicationStartDate,
+                applicationEndDate,
+                winnerAnnouncementDate,
+                originalUrl,
+                correctionCancellationReason,
+                viewCount,
+                receptionPlace
+        );
+    }
+
+    private void validateNotBlank(String value, String fieldName) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(fieldName + "은 필수다.");
+        }
+    }
+
+    private void validateRequired(Object value, String fieldName) {
+        if (value == null) {
+            throw new IllegalArgumentException(fieldName + "은 필수다.");
+        }
+    }
+
+    private void validateNonNegative(long value, String fieldName) {
+        if (value < 0) {
+            throw new IllegalArgumentException(fieldName + "은 음수일 수 없다.");
+        }
+    }
+}

--- a/backend/src/main/java/com/toadzip/backend/notice/domain/NoticeAttachment.java
+++ b/backend/src/main/java/com/toadzip/backend/notice/domain/NoticeAttachment.java
@@ -1,0 +1,89 @@
+package com.toadzip.backend.notice.domain;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static lombok.AccessLevel.PROTECTED;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "notice_attachments")
+@NoArgsConstructor(access = PROTECTED)
+public class NoticeAttachment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = LAZY, optional = false)
+    @JoinColumn(name = "notice_id", nullable = false)
+    private Notice notice;
+
+    @Column(nullable = false)
+    private String fileName;
+
+    @Column(nullable = false)
+    private String fileType;
+
+    @Column(nullable = false)
+    private String fileUrl;
+
+    @Column(nullable = false)
+    private int displayOrder;
+
+    private NoticeAttachment(
+            Notice notice,
+            String fileName,
+            String fileType,
+            String fileUrl,
+            int displayOrder
+    ) {
+        validateRequired(notice, "공고");
+        validateNotBlank(fileName, "파일명");
+        validateNotBlank(fileType, "파일종류");
+        validateNotBlank(fileUrl, "파일 URL");
+        validateNonNegative(displayOrder, "표시순서");
+        this.notice = notice;
+        this.fileName = fileName;
+        this.fileType = fileType;
+        this.fileUrl = fileUrl;
+        this.displayOrder = displayOrder;
+    }
+
+    public static NoticeAttachment create(
+            Notice notice,
+            String fileName,
+            String fileType,
+            String fileUrl,
+            int displayOrder
+    ) {
+        return new NoticeAttachment(notice, fileName, fileType, fileUrl, displayOrder);
+    }
+
+    private void validateRequired(Object value, String fieldName) {
+        if (value == null) {
+            throw new IllegalArgumentException(fieldName + "은 필수다.");
+        }
+    }
+
+    private void validateNotBlank(String value, String fieldName) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(fieldName + "은 필수다.");
+        }
+    }
+
+    private void validateNonNegative(int value, String fieldName) {
+        if (value < 0) {
+            throw new IllegalArgumentException(fieldName + "은 음수일 수 없다.");
+        }
+    }
+}

--- a/backend/src/main/java/com/toadzip/backend/notice/domain/NoticeSchedule.java
+++ b/backend/src/main/java/com/toadzip/backend/notice/domain/NoticeSchedule.java
@@ -1,0 +1,97 @@
+package com.toadzip.backend.notice.domain;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static lombok.AccessLevel.PROTECTED;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "notice_schedules")
+@NoArgsConstructor(access = PROTECTED)
+public class NoticeSchedule {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = LAZY, optional = false)
+    @JoinColumn(name = "notice_id", nullable = false)
+    private Notice notice;
+
+    @Column(nullable = false)
+    private String scheduleType;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private LocalDateTime startAt;
+
+    @Column(nullable = false)
+    private LocalDateTime endAt;
+
+    @Column(nullable = false)
+    private int displayOrder;
+
+    private NoticeSchedule(
+            Notice notice,
+            String scheduleType,
+            String name,
+            LocalDateTime startAt,
+            LocalDateTime endAt,
+            int displayOrder
+    ) {
+        validateRequired(notice, "공고");
+        validateNotBlank(scheduleType, "일정유형");
+        validateNotBlank(name, "일정명");
+        validateRequired(startAt, "시작일시");
+        validateRequired(endAt, "종료일시");
+        validateNonNegative(displayOrder, "표시순서");
+        this.notice = notice;
+        this.scheduleType = scheduleType;
+        this.name = name;
+        this.startAt = startAt;
+        this.endAt = endAt;
+        this.displayOrder = displayOrder;
+    }
+
+    public static NoticeSchedule create(
+            Notice notice,
+            String scheduleType,
+            String name,
+            LocalDateTime startAt,
+            LocalDateTime endAt,
+            int displayOrder
+    ) {
+        return new NoticeSchedule(notice, scheduleType, name, startAt, endAt, displayOrder);
+    }
+
+    private void validateRequired(Object value, String fieldName) {
+        if (value == null) {
+            throw new IllegalArgumentException(fieldName + "은 필수다.");
+        }
+    }
+
+    private void validateNotBlank(String value, String fieldName) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(fieldName + "은 필수다.");
+        }
+    }
+
+    private void validateNonNegative(int value, String fieldName) {
+        if (value < 0) {
+            throw new IllegalArgumentException(fieldName + "은 음수일 수 없다.");
+        }
+    }
+}

--- a/backend/src/main/java/com/toadzip/backend/notice/domain/NoticeSchedule.java
+++ b/backend/src/main/java/com/toadzip/backend/notice/domain/NoticeSchedule.java
@@ -57,6 +57,7 @@ public class NoticeSchedule {
         validateNotBlank(name, "일정명");
         validateRequired(startAt, "시작일시");
         validateRequired(endAt, "종료일시");
+        validatePeriod(startAt, endAt);
         validateNonNegative(displayOrder, "표시순서");
         this.notice = notice;
         this.scheduleType = scheduleType;
@@ -92,6 +93,12 @@ public class NoticeSchedule {
     private void validateNonNegative(int value, String fieldName) {
         if (value < 0) {
             throw new IllegalArgumentException(fieldName + "은 음수일 수 없다.");
+        }
+    }
+
+    private void validatePeriod(LocalDateTime startAt, LocalDateTime endAt) {
+        if (endAt.isBefore(startAt)) {
+            throw new IllegalArgumentException("일정 종료일시는 시작일시보다 빠를 수 없다.");
         }
     }
 }

--- a/backend/src/main/java/com/toadzip/backend/notice/domain/ReceptionPlace.java
+++ b/backend/src/main/java/com/toadzip/backend/notice/domain/ReceptionPlace.java
@@ -1,0 +1,48 @@
+package com.toadzip.backend.notice.domain;
+
+import static lombok.AccessLevel.PROTECTED;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Embeddable
+@NoArgsConstructor(access = PROTECTED)
+public class ReceptionPlace {
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private String method;
+
+    private String address;
+
+    @Column(nullable = false)
+    private String contact;
+
+    private String url;
+
+    private ReceptionPlace(String name, String method, String address, String contact, String url) {
+        validateNotBlank(name, "접수처명");
+        validateNotBlank(method, "접수방식");
+        validateNotBlank(contact, "연락처");
+        this.name = name;
+        this.method = method;
+        this.address = address;
+        this.contact = contact;
+        this.url = url;
+    }
+
+    public static ReceptionPlace create(String name, String method, String address, String contact, String url) {
+        return new ReceptionPlace(name, method, address, contact, url);
+    }
+
+    private void validateNotBlank(String value, String fieldName) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(fieldName + "은 필수다.");
+        }
+    }
+}

--- a/backend/src/main/java/com/toadzip/backend/notice/domain/SupplyCategory.java
+++ b/backend/src/main/java/com/toadzip/backend/notice/domain/SupplyCategory.java
@@ -1,0 +1,6 @@
+package com.toadzip.backend.notice.domain;
+
+public enum SupplyCategory {
+    NEW_SUPPLY,
+    RESUPPLY
+}

--- a/backend/src/main/java/com/toadzip/backend/notice/domain/SupplyRow.java
+++ b/backend/src/main/java/com/toadzip/backend/notice/domain/SupplyRow.java
@@ -1,0 +1,157 @@
+package com.toadzip.backend.notice.domain;
+
+import static jakarta.persistence.EnumType.STRING;
+import static jakarta.persistence.FetchType.LAZY;
+import static lombok.AccessLevel.PROTECTED;
+
+import com.toadzip.backend.housing.domain.HousingComplex;
+import com.toadzip.backend.housing.domain.HousingType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.YearMonth;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "supply_rows")
+@NoArgsConstructor(access = PROTECTED)
+public class SupplyRow {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = LAZY, optional = false)
+    @JoinColumn(name = "notice_id", nullable = false)
+    private Notice notice;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "housing_complex_id")
+    private HousingComplex housingComplex;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "housing_type_id")
+    private HousingType housingType;
+
+    @Column(nullable = false)
+    private String sourceSupplyRowIdentifier;
+
+    @Column(nullable = false)
+    private int displayOrder;
+
+    @Column(nullable = false)
+    private String sourceComplexName;
+
+    @Column(nullable = false)
+    private String sourceHousingTypeName;
+
+    @Column(nullable = false)
+    private String supplyPnu;
+
+    @Convert(converter = YearMonthAttributeConverter.class)
+    @Column(nullable = false)
+    private YearMonth expectedMoveInMonth;
+
+    @Enumerated(STRING)
+    @Column(nullable = false)
+    private SupplyCategory supplyCategory;
+
+    private String matchingFailureReason;
+
+    @Column(nullable = false)
+    private int totalSupplyHouseholdCount;
+
+    private SupplyRow(
+            Notice notice,
+            HousingComplex housingComplex,
+            HousingType housingType,
+            String sourceSupplyRowIdentifier,
+            int displayOrder,
+            String sourceComplexName,
+            String sourceHousingTypeName,
+            String supplyPnu,
+            YearMonth expectedMoveInMonth,
+            SupplyCategory supplyCategory,
+            String matchingFailureReason,
+            int totalSupplyHouseholdCount
+    ) {
+        validateRequired(notice, "공고");
+        validateNotBlank(sourceSupplyRowIdentifier, "원천 공급행 식별자");
+        validateNonNegative(displayOrder, "표시순서");
+        validateNotBlank(sourceComplexName, "원천 단지명");
+        validateNotBlank(sourceHousingTypeName, "원천 주택형명");
+        validateNotBlank(supplyPnu, "공급 PNU");
+        validateRequired(expectedMoveInMonth, "입주 예정 연월");
+        validateRequired(supplyCategory, "공급구분");
+        validateNonNegative(totalSupplyHouseholdCount, "전체 공급세대수");
+        this.notice = notice;
+        this.housingComplex = housingComplex;
+        this.housingType = housingType;
+        this.sourceSupplyRowIdentifier = sourceSupplyRowIdentifier;
+        this.displayOrder = displayOrder;
+        this.sourceComplexName = sourceComplexName;
+        this.sourceHousingTypeName = sourceHousingTypeName;
+        this.supplyPnu = supplyPnu;
+        this.expectedMoveInMonth = expectedMoveInMonth;
+        this.supplyCategory = supplyCategory;
+        this.matchingFailureReason = matchingFailureReason;
+        this.totalSupplyHouseholdCount = totalSupplyHouseholdCount;
+    }
+
+    public static SupplyRow create(
+            Notice notice,
+            HousingComplex housingComplex,
+            HousingType housingType,
+            String sourceSupplyRowIdentifier,
+            int displayOrder,
+            String sourceComplexName,
+            String sourceHousingTypeName,
+            String supplyPnu,
+            YearMonth expectedMoveInMonth,
+            SupplyCategory supplyCategory,
+            String matchingFailureReason,
+            int totalSupplyHouseholdCount
+    ) {
+        return new SupplyRow(
+                notice,
+                housingComplex,
+                housingType,
+                sourceSupplyRowIdentifier,
+                displayOrder,
+                sourceComplexName,
+                sourceHousingTypeName,
+                supplyPnu,
+                expectedMoveInMonth,
+                supplyCategory,
+                matchingFailureReason,
+                totalSupplyHouseholdCount
+        );
+    }
+
+    private void validateRequired(Object value, String fieldName) {
+        if (value == null) {
+            throw new IllegalArgumentException(fieldName + "은 필수다.");
+        }
+    }
+
+    private void validateNotBlank(String value, String fieldName) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(fieldName + "은 필수다.");
+        }
+    }
+
+    private void validateNonNegative(int value, String fieldName) {
+        if (value < 0) {
+            throw new IllegalArgumentException(fieldName + "은 음수일 수 없다.");
+        }
+    }
+}

--- a/backend/src/main/java/com/toadzip/backend/notice/domain/SupplyTarget.java
+++ b/backend/src/main/java/com/toadzip/backend/notice/domain/SupplyTarget.java
@@ -1,0 +1,146 @@
+package com.toadzip.backend.notice.domain;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static lombok.AccessLevel.PROTECTED;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "supply_targets")
+@NoArgsConstructor(access = PROTECTED)
+public class SupplyTarget {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = LAZY, optional = false)
+    @JoinColumn(name = "supply_row_id", nullable = false)
+    private SupplyRow supplyRow;
+
+    @Column(nullable = false)
+    private String target;
+
+    @Column(nullable = false)
+    private String supplyRank;
+
+    @Column(nullable = false)
+    private int supplyHouseholdCount;
+
+    @Column(nullable = false)
+    private int reserveCount;
+
+    @Column(nullable = false)
+    private BigDecimal rentalDeposit;
+
+    @Column(nullable = false)
+    private BigDecimal monthlyRent;
+
+    private BigDecimal convertedDeposit;
+
+    @Column(nullable = false)
+    private String applicationCondition;
+
+    @Column(nullable = false)
+    private int displayOrder;
+
+    private SupplyTarget(
+            SupplyRow supplyRow,
+            String target,
+            String supplyRank,
+            int supplyHouseholdCount,
+            int reserveCount,
+            BigDecimal rentalDeposit,
+            BigDecimal monthlyRent,
+            BigDecimal convertedDeposit,
+            String applicationCondition,
+            int displayOrder
+    ) {
+        validateRequired(supplyRow, "공급행");
+        validateNotBlank(target, "대상");
+        validateNotBlank(supplyRank, "공급순위");
+        validateNonNegative(supplyHouseholdCount, "공급세대수");
+        validateNonNegative(reserveCount, "예비자수");
+        validateRequiredAmount(rentalDeposit, "임대보증금");
+        validateRequiredAmount(monthlyRent, "월임대료");
+        validateNonNegativeIfPresent(convertedDeposit, "전환보증금");
+        validateNotBlank(applicationCondition, "신청조건");
+        validateNonNegative(displayOrder, "표시순서");
+        this.supplyRow = supplyRow;
+        this.target = target;
+        this.supplyRank = supplyRank;
+        this.supplyHouseholdCount = supplyHouseholdCount;
+        this.reserveCount = reserveCount;
+        this.rentalDeposit = rentalDeposit;
+        this.monthlyRent = monthlyRent;
+        this.convertedDeposit = convertedDeposit;
+        this.applicationCondition = applicationCondition;
+        this.displayOrder = displayOrder;
+    }
+
+    public static SupplyTarget create(
+            SupplyRow supplyRow,
+            String target,
+            String supplyRank,
+            int supplyHouseholdCount,
+            int reserveCount,
+            BigDecimal rentalDeposit,
+            BigDecimal monthlyRent,
+            BigDecimal convertedDeposit,
+            String applicationCondition,
+            int displayOrder
+    ) {
+        return new SupplyTarget(
+                supplyRow,
+                target,
+                supplyRank,
+                supplyHouseholdCount,
+                reserveCount,
+                rentalDeposit,
+                monthlyRent,
+                convertedDeposit,
+                applicationCondition,
+                displayOrder
+        );
+    }
+
+    private void validateRequired(Object value, String fieldName) {
+        if (value == null) {
+            throw new IllegalArgumentException(fieldName + "은 필수다.");
+        }
+    }
+
+    private void validateNotBlank(String value, String fieldName) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(fieldName + "은 필수다.");
+        }
+    }
+
+    private void validateNonNegative(int value, String fieldName) {
+        if (value < 0) {
+            throw new IllegalArgumentException(fieldName + "은 음수일 수 없다.");
+        }
+    }
+
+    private void validateRequiredAmount(BigDecimal value, String fieldName) {
+        validateRequired(value, fieldName);
+        validateNonNegativeIfPresent(value, fieldName);
+    }
+
+    private void validateNonNegativeIfPresent(BigDecimal value, String fieldName) {
+        if (value != null && value.signum() < 0) {
+            throw new IllegalArgumentException(fieldName + "은 음수일 수 없다.");
+        }
+    }
+}

--- a/backend/src/main/java/com/toadzip/backend/notice/domain/YearMonthAttributeConverter.java
+++ b/backend/src/main/java/com/toadzip/backend/notice/domain/YearMonthAttributeConverter.java
@@ -1,0 +1,25 @@
+package com.toadzip.backend.notice.domain;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import java.time.YearMonth;
+
+@Converter
+public class YearMonthAttributeConverter implements AttributeConverter<YearMonth, String> {
+
+    @Override
+    public String convertToDatabaseColumn(YearMonth attribute) {
+        if (attribute == null) {
+            return null;
+        }
+        return attribute.toString();
+    }
+
+    @Override
+    public YearMonth convertToEntityAttribute(String databaseData) {
+        if (databaseData == null) {
+            return null;
+        }
+        return YearMonth.parse(databaseData);
+    }
+}

--- a/backend/src/main/java/com/toadzip/backend/user/domain/User.java
+++ b/backend/src/main/java/com/toadzip/backend/user/domain/User.java
@@ -1,0 +1,53 @@
+package com.toadzip.backend.user.domain;
+
+import static lombok.AccessLevel.PROTECTED;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "users")
+@NoArgsConstructor(access = PROTECTED)
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String loginIdentifier;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    private User(String loginIdentifier, LocalDateTime createdAt) {
+        validateLoginIdentifier(loginIdentifier);
+        validateCreatedAt(createdAt);
+        this.loginIdentifier = loginIdentifier;
+        this.createdAt = createdAt;
+    }
+
+    public static User create(String loginIdentifier, LocalDateTime createdAt) {
+        return new User(loginIdentifier, createdAt);
+    }
+
+    private void validateLoginIdentifier(String loginIdentifier) {
+        if (loginIdentifier == null || loginIdentifier.isBlank()) {
+            throw new IllegalArgumentException("로그인 식별정보는 필수다.");
+        }
+    }
+
+    private void validateCreatedAt(LocalDateTime createdAt) {
+        if (createdAt == null) {
+            throw new IllegalArgumentException("생성일시는 필수다.");
+        }
+    }
+}

--- a/backend/src/main/java/com/toadzip/backend/user/domain/UserEligibilityInfo.java
+++ b/backend/src/main/java/com/toadzip/backend/user/domain/UserEligibilityInfo.java
@@ -17,9 +17,9 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
-@Table(name = "user_infos")
+@Table(name = "user_eligibility_infos")
 @NoArgsConstructor(access = PROTECTED)
-public class UserInfo {
+public class UserEligibilityInfo {
 
     @Id
     @Column(name = "user_id")
@@ -100,7 +100,7 @@ public class UserInfo {
 
     private LocalDate newbornBirthDate;
 
-    private UserInfo(
+    private UserEligibilityInfo(
             User user,
             LocalDate birthDate,
             String currentResidenceRegion,
@@ -169,7 +169,7 @@ public class UserInfo {
         this.newbornBirthDate = newbornBirthDate;
     }
 
-    public static UserInfo create(
+    public static UserEligibilityInfo create(
             User user,
             LocalDate birthDate,
             String currentResidenceRegion,
@@ -197,7 +197,7 @@ public class UserInfo {
             boolean veteran,
             LocalDate newbornBirthDate
     ) {
-        return new UserInfo(
+        return new UserEligibilityInfo(
                 user,
                 birthDate,
                 currentResidenceRegion,

--- a/backend/src/main/java/com/toadzip/backend/user/domain/UserInfo.java
+++ b/backend/src/main/java/com/toadzip/backend/user/domain/UserInfo.java
@@ -1,0 +1,264 @@
+package com.toadzip.backend.user.domain;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static lombok.AccessLevel.PROTECTED;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "user_infos")
+@NoArgsConstructor(access = PROTECTED)
+public class UserInfo {
+
+    @Id
+    @Column(name = "user_id")
+    private Long userId;
+
+    @MapsId
+    @OneToOne(fetch = LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false)
+    private LocalDate birthDate;
+
+    @Column(nullable = false)
+    private String currentResidenceRegion;
+
+    @Column(nullable = false)
+    private boolean headOfHousehold;
+
+    @Column(nullable = false)
+    private int householdMemberCount;
+
+    @Column(nullable = false)
+    private boolean singleParentFamily;
+
+    @Column(nullable = false)
+    private boolean nonHomeowner;
+
+    @Column(nullable = false)
+    private String maritalStatus;
+
+    private LocalDate marriageDate;
+
+    private BigDecimal spouseMonthlyIncome;
+
+    @Column(nullable = false)
+    private int childCount;
+
+    @Column(nullable = false)
+    private boolean student;
+
+    @Column(nullable = false)
+    private boolean employed;
+
+    @Column(nullable = false)
+    private BigDecimal personalAverageMonthlyIncome;
+
+    @Column(nullable = false)
+    private BigDecimal householdAverageMonthlyIncome;
+
+    @Column(nullable = false)
+    private BigDecimal parentsAverageMonthlyIncome;
+
+    @Column(nullable = false)
+    private BigDecimal totalAssets;
+
+    @Column(nullable = false)
+    private BigDecimal vehicleValue;
+
+    @Column(nullable = false)
+    private boolean housingSubscriptionAccount;
+
+    private LocalDate housingSubscriptionAccountJoinDate;
+
+    private Integer housingSubscriptionPaymentCount;
+
+    @Column(nullable = false)
+    private boolean housingBenefitRecipient;
+
+    @Column(nullable = false)
+    private boolean basicLivingRecipient;
+
+    @Column(nullable = false)
+    private boolean disabled;
+
+    @Column(nullable = false)
+    private boolean veteran;
+
+    private LocalDate newbornBirthDate;
+
+    private UserInfo(
+            User user,
+            LocalDate birthDate,
+            String currentResidenceRegion,
+            boolean headOfHousehold,
+            int householdMemberCount,
+            boolean singleParentFamily,
+            boolean nonHomeowner,
+            String maritalStatus,
+            LocalDate marriageDate,
+            BigDecimal spouseMonthlyIncome,
+            int childCount,
+            boolean student,
+            boolean employed,
+            BigDecimal personalAverageMonthlyIncome,
+            BigDecimal householdAverageMonthlyIncome,
+            BigDecimal parentsAverageMonthlyIncome,
+            BigDecimal totalAssets,
+            BigDecimal vehicleValue,
+            boolean housingSubscriptionAccount,
+            LocalDate housingSubscriptionAccountJoinDate,
+            Integer housingSubscriptionPaymentCount,
+            boolean housingBenefitRecipient,
+            boolean basicLivingRecipient,
+            boolean disabled,
+            boolean veteran,
+            LocalDate newbornBirthDate
+    ) {
+        validateRequired(user, "유저");
+        validateRequired(birthDate, "생년월일");
+        validateNotBlank(currentResidenceRegion, "현재 거주지역");
+        validateNonNegative(householdMemberCount, "가구원 수");
+        validateNotBlank(maritalStatus, "혼인 상태");
+        validateNonNegativeIfPresent(spouseMonthlyIncome, "배우자 소득");
+        validateNonNegative(childCount, "자녀 수");
+        validateRequiredAmount(personalAverageMonthlyIncome, "본인 월평균 소득");
+        validateRequiredAmount(householdAverageMonthlyIncome, "가구 월평균 소득");
+        validateRequiredAmount(parentsAverageMonthlyIncome, "부모 월평균 소득");
+        validateRequiredAmount(totalAssets, "총자산");
+        validateRequiredAmount(vehicleValue, "자동차 가액");
+        validateNonNegativeIfPresent(housingSubscriptionPaymentCount, "청약통장 납입 횟수");
+        this.user = user;
+        this.birthDate = birthDate;
+        this.currentResidenceRegion = currentResidenceRegion;
+        this.headOfHousehold = headOfHousehold;
+        this.householdMemberCount = householdMemberCount;
+        this.singleParentFamily = singleParentFamily;
+        this.nonHomeowner = nonHomeowner;
+        this.maritalStatus = maritalStatus;
+        this.marriageDate = marriageDate;
+        this.spouseMonthlyIncome = spouseMonthlyIncome;
+        this.childCount = childCount;
+        this.student = student;
+        this.employed = employed;
+        this.personalAverageMonthlyIncome = personalAverageMonthlyIncome;
+        this.householdAverageMonthlyIncome = householdAverageMonthlyIncome;
+        this.parentsAverageMonthlyIncome = parentsAverageMonthlyIncome;
+        this.totalAssets = totalAssets;
+        this.vehicleValue = vehicleValue;
+        this.housingSubscriptionAccount = housingSubscriptionAccount;
+        this.housingSubscriptionAccountJoinDate = housingSubscriptionAccountJoinDate;
+        this.housingSubscriptionPaymentCount = housingSubscriptionPaymentCount;
+        this.housingBenefitRecipient = housingBenefitRecipient;
+        this.basicLivingRecipient = basicLivingRecipient;
+        this.disabled = disabled;
+        this.veteran = veteran;
+        this.newbornBirthDate = newbornBirthDate;
+    }
+
+    public static UserInfo create(
+            User user,
+            LocalDate birthDate,
+            String currentResidenceRegion,
+            boolean headOfHousehold,
+            int householdMemberCount,
+            boolean singleParentFamily,
+            boolean nonHomeowner,
+            String maritalStatus,
+            LocalDate marriageDate,
+            BigDecimal spouseMonthlyIncome,
+            int childCount,
+            boolean student,
+            boolean employed,
+            BigDecimal personalAverageMonthlyIncome,
+            BigDecimal householdAverageMonthlyIncome,
+            BigDecimal parentsAverageMonthlyIncome,
+            BigDecimal totalAssets,
+            BigDecimal vehicleValue,
+            boolean housingSubscriptionAccount,
+            LocalDate housingSubscriptionAccountJoinDate,
+            Integer housingSubscriptionPaymentCount,
+            boolean housingBenefitRecipient,
+            boolean basicLivingRecipient,
+            boolean disabled,
+            boolean veteran,
+            LocalDate newbornBirthDate
+    ) {
+        return new UserInfo(
+                user,
+                birthDate,
+                currentResidenceRegion,
+                headOfHousehold,
+                householdMemberCount,
+                singleParentFamily,
+                nonHomeowner,
+                maritalStatus,
+                marriageDate,
+                spouseMonthlyIncome,
+                childCount,
+                student,
+                employed,
+                personalAverageMonthlyIncome,
+                householdAverageMonthlyIncome,
+                parentsAverageMonthlyIncome,
+                totalAssets,
+                vehicleValue,
+                housingSubscriptionAccount,
+                housingSubscriptionAccountJoinDate,
+                housingSubscriptionPaymentCount,
+                housingBenefitRecipient,
+                basicLivingRecipient,
+                disabled,
+                veteran,
+                newbornBirthDate
+        );
+    }
+
+    private void validateRequired(Object value, String fieldName) {
+        if (value == null) {
+            throw new IllegalArgumentException(fieldName + "은 필수다.");
+        }
+    }
+
+    private void validateNotBlank(String value, String fieldName) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(fieldName + "은 필수다.");
+        }
+    }
+
+    private void validateNonNegative(int value, String fieldName) {
+        if (value < 0) {
+            throw new IllegalArgumentException(fieldName + "은 음수일 수 없다.");
+        }
+    }
+
+    private void validateRequiredAmount(BigDecimal value, String fieldName) {
+        validateRequired(value, fieldName);
+        validateNonNegativeIfPresent(value, fieldName);
+    }
+
+    private void validateNonNegativeIfPresent(BigDecimal value, String fieldName) {
+        if (value != null && value.signum() < 0) {
+            throw new IllegalArgumentException(fieldName + "은 음수일 수 없다.");
+        }
+    }
+
+    private void validateNonNegativeIfPresent(Integer value, String fieldName) {
+        if (value != null && value < 0) {
+            throw new IllegalArgumentException(fieldName + "은 음수일 수 없다.");
+        }
+    }
+}

--- a/backend/src/main/java/com/toadzip/backend/user/domain/UserPlace.java
+++ b/backend/src/main/java/com/toadzip/backend/user/domain/UserPlace.java
@@ -1,0 +1,92 @@
+package com.toadzip.backend.user.domain;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static lombok.AccessLevel.PROTECTED;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "user_places")
+@NoArgsConstructor(access = PROTECTED)
+public class UserPlace {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private String address;
+
+    @Column(nullable = false)
+    private BigDecimal latitude;
+
+    @Column(nullable = false)
+    private BigDecimal longitude;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    private UserPlace(
+            User user,
+            String name,
+            String address,
+            BigDecimal latitude,
+            BigDecimal longitude,
+            LocalDateTime createdAt
+    ) {
+        validateRequired(user, "소유 유저");
+        validateNotBlank(name, "장소명");
+        validateNotBlank(address, "주소");
+        validateRequired(latitude, "위도");
+        validateRequired(longitude, "경도");
+        validateRequired(createdAt, "등록일시");
+        this.user = user;
+        this.name = name;
+        this.address = address;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.createdAt = createdAt;
+    }
+
+    public static UserPlace create(
+            User user,
+            String name,
+            String address,
+            BigDecimal latitude,
+            BigDecimal longitude,
+            LocalDateTime createdAt
+    ) {
+        return new UserPlace(user, name, address, latitude, longitude, createdAt);
+    }
+
+    private void validateNotBlank(String value, String fieldName) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(fieldName + "은 필수다.");
+        }
+    }
+
+    private void validateRequired(Object value, String fieldName) {
+        if (value == null) {
+            throw new IllegalArgumentException(fieldName + "은 필수다.");
+        }
+    }
+}

--- a/backend/src/main/java/com/toadzip/backend/user/domain/UserPlace.java
+++ b/backend/src/main/java/com/toadzip/backend/user/domain/UserPlace.java
@@ -36,10 +36,10 @@ public class UserPlace {
     @Column(nullable = false)
     private String address;
 
-    @Column(nullable = false)
+    @Column(nullable = false, precision = 9, scale = 6)
     private BigDecimal latitude;
 
-    @Column(nullable = false)
+    @Column(nullable = false, precision = 10, scale = 6)
     private BigDecimal longitude;
 
     @Column(nullable = false)
@@ -56,8 +56,8 @@ public class UserPlace {
         validateRequired(user, "소유 유저");
         validateNotBlank(name, "장소명");
         validateNotBlank(address, "주소");
-        validateRequired(latitude, "위도");
-        validateRequired(longitude, "경도");
+        validateLatitude(latitude);
+        validateLongitude(longitude);
         validateRequired(createdAt, "등록일시");
         this.user = user;
         this.name = name;
@@ -87,6 +87,22 @@ public class UserPlace {
     private void validateRequired(Object value, String fieldName) {
         if (value == null) {
             throw new IllegalArgumentException(fieldName + "은 필수다.");
+        }
+    }
+
+    private void validateLatitude(BigDecimal latitude) {
+        validateRequired(latitude, "위도");
+        if (latitude.compareTo(BigDecimal.valueOf(-90)) < 0
+                || latitude.compareTo(BigDecimal.valueOf(90)) > 0) {
+            throw new IllegalArgumentException("위도는 -90도 이상 90도 이하여야 한다.");
+        }
+    }
+
+    private void validateLongitude(BigDecimal longitude) {
+        validateRequired(longitude, "경도");
+        if (longitude.compareTo(BigDecimal.valueOf(-180)) < 0
+                || longitude.compareTo(BigDecimal.valueOf(180)) > 0) {
+            throw new IllegalArgumentException("경도는 -180도 이상 180도 이하여야 한다.");
         }
     }
 }

--- a/backend/src/test/java/com/toadzip/backend/DomainJpaPersistenceTest.java
+++ b/backend/src/test/java/com/toadzip/backend/DomainJpaPersistenceTest.java
@@ -1,0 +1,407 @@
+package com.toadzip.backend;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.toadzip.backend.housing.domain.Address;
+import com.toadzip.backend.housing.domain.HousingComplex;
+import com.toadzip.backend.housing.domain.HousingType;
+import com.toadzip.backend.interest.domain.FavoriteHousingComplex;
+import com.toadzip.backend.interest.domain.FavoriteNotice;
+import com.toadzip.backend.interest.domain.FavoriteRegion;
+import com.toadzip.backend.notice.domain.Notice;
+import com.toadzip.backend.notice.domain.NoticeAttachment;
+import com.toadzip.backend.notice.domain.NoticeSchedule;
+import com.toadzip.backend.notice.domain.ReceptionPlace;
+import com.toadzip.backend.notice.domain.SupplyCategory;
+import com.toadzip.backend.notice.domain.SupplyRow;
+import com.toadzip.backend.notice.domain.SupplyTarget;
+import com.toadzip.backend.user.domain.User;
+import com.toadzip.backend.user.domain.UserInfo;
+import com.toadzip.backend.user.domain.UserPlace;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.PersistenceException;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@SpringBootTest
+class DomainJpaPersistenceTest {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Test
+    void 접수처_연락처_컬럼은_null을_허용하지_않는다() {
+        Object isNullable = entityManager.createNativeQuery(
+                        """
+                        SELECT is_nullable
+                        FROM information_schema.columns
+                        WHERE LOWER(table_name) = 'notices'
+                          AND LOWER(column_name) = 'reception_contact'
+                        """
+                )
+                .getSingleResult();
+
+        assertEquals("NO", isNullable);
+    }
+
+    @Test
+    void 하나의_이전_공고는_하나의_후속_공고만_참조한다() {
+        Notice originalNotice = createNotice(null, null, null, "source-notice-id-1", "원공고");
+        entityManager.persist(originalNotice);
+
+        Notice firstCorrectedNotice = createNotice(
+                originalNotice,
+                "source-notice-id-1",
+                "접수일 변경",
+                "source-notice-id-2",
+                "정정공고"
+        );
+        entityManager.persist(firstCorrectedNotice);
+        entityManager.flush();
+
+        Notice secondCorrectedNotice = createNotice(
+                originalNotice,
+                "source-notice-id-1",
+                "발표일 변경",
+                "source-notice-id-3",
+                "정정공고"
+        );
+
+        assertThrows(
+                PersistenceException.class,
+                () -> {
+                    entityManager.persist(secondCorrectedNotice);
+                    entityManager.flush();
+                }
+        );
+    }
+
+    @Test
+    void ERD의_연관관계와_값을_저장하고_다시_조회한다() {
+        User user = createUser();
+        entityManager.persist(user);
+
+        UserInfo userInfo = createUserInfo(user);
+        UserPlace userPlace = createUserPlace(user);
+        entityManager.persist(userInfo);
+        entityManager.persist(userPlace);
+
+        HousingComplex housingComplex = createHousingComplex();
+        entityManager.persist(housingComplex);
+
+        HousingType housingType = createHousingType(housingComplex);
+        entityManager.persist(housingType);
+
+        Notice originalNotice = createNotice(null, null, null, "source-notice-id-1", "원공고");
+        entityManager.persist(originalNotice);
+
+        Notice correctedNotice = createNotice(
+                originalNotice,
+                "source-notice-id-1",
+                "접수일 변경",
+                "source-notice-id-2",
+                "정정공고"
+        );
+        entityManager.persist(correctedNotice);
+
+        SupplyRow matchedSupplyRow = createSupplyRow(correctedNotice, housingComplex, housingType, 1, null);
+        SupplyRow unmatchedSupplyRow = createSupplyRow(
+                correctedNotice,
+                null,
+                null,
+                2,
+                "단지 식별자 불일치"
+        );
+        entityManager.persist(matchedSupplyRow);
+        entityManager.persist(unmatchedSupplyRow);
+
+        SupplyTarget supplyTarget = createSupplyTarget(matchedSupplyRow);
+        NoticeSchedule noticeSchedule = createNoticeSchedule(correctedNotice);
+        NoticeAttachment noticeAttachment = createNoticeAttachment(correctedNotice);
+        entityManager.persist(supplyTarget);
+        entityManager.persist(noticeSchedule);
+        entityManager.persist(noticeAttachment);
+
+        FavoriteNotice favoriteNotice = FavoriteNotice.create(
+                user,
+                correctedNotice,
+                LocalDateTime.of(2026, 8, 19, 13, 0)
+        );
+        FavoriteNotice unmatchedFavoriteNotice = FavoriteNotice.create(
+                user,
+                null,
+                LocalDateTime.of(2026, 8, 19, 13, 1)
+        );
+        FavoriteHousingComplex favoriteHousingComplex = FavoriteHousingComplex.create(
+                user,
+                housingComplex,
+                LocalDateTime.of(2026, 8, 19, 13, 2)
+        );
+        FavoriteRegion favoriteRegion = FavoriteRegion.create(
+                user,
+                "11",
+                "서울특별시",
+                "11140",
+                "중구",
+                LocalDateTime.of(2026, 8, 19, 13, 3)
+        );
+        entityManager.persist(favoriteNotice);
+        entityManager.persist(unmatchedFavoriteNotice);
+        entityManager.persist(favoriteHousingComplex);
+        entityManager.persist(favoriteRegion);
+
+        entityManager.flush();
+
+        Long userId = user.getId();
+        Long userPlaceId = userPlace.getId();
+        Long housingTypeId = housingType.getId();
+        Long correctedNoticeId = correctedNotice.getId();
+        Long matchedSupplyRowId = matchedSupplyRow.getId();
+        Long unmatchedSupplyRowId = unmatchedSupplyRow.getId();
+        Long supplyTargetId = supplyTarget.getId();
+        Long noticeScheduleId = noticeSchedule.getId();
+        Long noticeAttachmentId = noticeAttachment.getId();
+        Long favoriteNoticeId = favoriteNotice.getId();
+        Long unmatchedFavoriteNoticeId = unmatchedFavoriteNotice.getId();
+        Long favoriteHousingComplexId = favoriteHousingComplex.getId();
+        Long favoriteRegionId = favoriteRegion.getId();
+
+        entityManager.clear();
+
+        UserInfo foundUserInfo = entityManager.find(UserInfo.class, userId);
+        UserPlace foundUserPlace = entityManager.find(UserPlace.class, userPlaceId);
+        HousingType foundHousingType = entityManager.find(HousingType.class, housingTypeId);
+        Notice foundCorrectedNotice = entityManager.find(Notice.class, correctedNoticeId);
+        SupplyRow foundMatchedSupplyRow = entityManager.find(SupplyRow.class, matchedSupplyRowId);
+        SupplyRow foundUnmatchedSupplyRow = entityManager.find(SupplyRow.class, unmatchedSupplyRowId);
+        SupplyTarget foundSupplyTarget = entityManager.find(SupplyTarget.class, supplyTargetId);
+        NoticeSchedule foundNoticeSchedule = entityManager.find(NoticeSchedule.class, noticeScheduleId);
+        NoticeAttachment foundNoticeAttachment = entityManager.find(NoticeAttachment.class, noticeAttachmentId);
+        FavoriteNotice foundFavoriteNotice = entityManager.find(FavoriteNotice.class, favoriteNoticeId);
+        FavoriteNotice foundUnmatchedFavoriteNotice = entityManager.find(
+                FavoriteNotice.class,
+                unmatchedFavoriteNoticeId
+        );
+        FavoriteHousingComplex foundFavoriteHousingComplex = entityManager.find(
+                FavoriteHousingComplex.class,
+                favoriteHousingComplexId
+        );
+        FavoriteRegion foundFavoriteRegion = entityManager.find(FavoriteRegion.class, favoriteRegionId);
+
+        assertAll(
+                () -> assertEquals(userId, foundUserInfo.getUserId()),
+                () -> assertEquals(userId, foundUserInfo.getUser().getId()),
+                () -> assertEquals(userId, foundUserPlace.getUser().getId()),
+                () -> assertEquals(housingComplex.getId(), foundHousingType.getHousingComplex().getId()),
+                () -> assertEquals(originalNotice.getId(), foundCorrectedNotice.getPreviousNotice().getId()),
+                () -> assertEquals("source-notice-id-1", foundCorrectedNotice.getPreviousSourceNoticeIdentifier()),
+                () -> assertEquals(housingComplex.getId(), foundMatchedSupplyRow.getHousingComplex().getId()),
+                () -> assertEquals(housingTypeId, foundMatchedSupplyRow.getHousingType().getId()),
+                () -> assertEquals(YearMonth.of(2027, 3), foundMatchedSupplyRow.getExpectedMoveInMonth()),
+                () -> assertNull(foundUnmatchedSupplyRow.getHousingComplex()),
+                () -> assertNull(foundUnmatchedSupplyRow.getHousingType()),
+                () -> assertEquals(matchedSupplyRowId, foundSupplyTarget.getSupplyRow().getId()),
+                () -> assertEquals(correctedNoticeId, foundNoticeSchedule.getNotice().getId()),
+                () -> assertEquals(correctedNoticeId, foundNoticeAttachment.getNotice().getId()),
+                () -> assertEquals(correctedNoticeId, foundFavoriteNotice.getNotice().getId()),
+                () -> assertNull(foundUnmatchedFavoriteNotice.getNotice()),
+                () -> assertEquals(housingComplex.getId(), foundFavoriteHousingComplex.getHousingComplex().getId()),
+                () -> assertEquals(userId, foundFavoriteRegion.getUser().getId()),
+                () -> assertEquals("서울특별시", foundFavoriteRegion.getProvinceName()),
+                () -> assertNotNull(foundCorrectedNotice.getReceptionPlace())
+        );
+    }
+
+    private User createUser() {
+        return User.create("login-id", LocalDateTime.of(2026, 8, 19, 12, 0));
+    }
+
+    private UserInfo createUserInfo(User user) {
+        BigDecimal income = new BigDecimal("3000000");
+        return UserInfo.create(
+                user,
+                LocalDate.of(1995, 5, 10),
+                "서울특별시",
+                true,
+                3,
+                false,
+                true,
+                "기혼",
+                LocalDate.of(2024, 3, 1),
+                new BigDecimal("2500000"),
+                1,
+                false,
+                true,
+                income,
+                new BigDecimal("5500000"),
+                new BigDecimal("6000000"),
+                new BigDecimal("150000000"),
+                new BigDecimal("20000000"),
+                true,
+                LocalDate.of(2020, 1, 15),
+                36,
+                false,
+                false,
+                false,
+                false,
+                LocalDate.of(2026, 2, 1)
+        );
+    }
+
+    private UserPlace createUserPlace(User user) {
+        return UserPlace.create(
+                user,
+                "회사",
+                "서울특별시 중구 세종대로 110",
+                new BigDecimal("37.5665"),
+                new BigDecimal("126.9780"),
+                LocalDateTime.of(2026, 8, 19, 12, 30)
+        );
+    }
+
+    private HousingComplex createHousingComplex() {
+        return HousingComplex.create(
+                "두꺼비 행복주택",
+                "source-complex-id",
+                "행복주택",
+                Address.create(
+                        "서울특별시 중구 세종대로 110",
+                        "1114010100100010000",
+                        "1114010100",
+                        "11",
+                        "서울특별시",
+                        "11140",
+                        "중구",
+                        new BigDecimal("37.5665"),
+                        new BigDecimal("126.9780")
+                ),
+                500,
+                "LH",
+                LocalDate.of(2020, 6, 30),
+                "개별난방",
+                "아파트",
+                "계단식",
+                true,
+                420,
+                "https://example.com/complex.png",
+                25
+        );
+    }
+
+    private HousingType createHousingType(HousingComplex housingComplex) {
+        return HousingType.create(
+                housingComplex,
+                "36A",
+                new BigDecimal("36.00"),
+                new BigDecimal("48.00"),
+                new BigDecimal("12.00"),
+                120,
+                "https://example.com/floor-plan.png",
+                false,
+                new BigDecimal("120000")
+        );
+    }
+
+    private Notice createNotice(
+            Notice previousNotice,
+            String previousSourceNoticeIdentifier,
+            String correctionCancellationReason,
+            String sourceNoticeIdentifier,
+            String status
+    ) {
+        return Notice.create(
+                sourceNoticeIdentifier,
+                previousSourceNoticeIdentifier,
+                previousNotice,
+                "행복주택 모집공고",
+                status,
+                "행복주택",
+                "신규모집",
+                "LH",
+                LocalDate.of(2026, 8, 1),
+                LocalDate.of(2026, 8, 10),
+                LocalDate.of(2026, 8, 14),
+                LocalDate.of(2026, 9, 1),
+                "https://example.com/notices/" + sourceNoticeIdentifier,
+                correctionCancellationReason,
+                100L,
+                ReceptionPlace.create(
+                        "LH 청약센터",
+                        "인터넷",
+                        null,
+                        "1600-1004",
+                        "https://apply.lh.or.kr"
+                )
+        );
+    }
+
+    private SupplyRow createSupplyRow(
+            Notice notice,
+            HousingComplex housingComplex,
+            HousingType housingType,
+            int displayOrder,
+            String matchingFailureReason
+    ) {
+        return SupplyRow.create(
+                notice,
+                housingComplex,
+                housingType,
+                "source-supply-row-id-" + displayOrder,
+                displayOrder,
+                "원천 단지명",
+                "36A",
+                "1114010100100010000",
+                YearMonth.of(2027, 3),
+                SupplyCategory.NEW_SUPPLY,
+                matchingFailureReason,
+                20
+        );
+    }
+
+    private SupplyTarget createSupplyTarget(SupplyRow supplyRow) {
+        return SupplyTarget.create(
+                supplyRow,
+                "청년",
+                "1순위",
+                10,
+                20,
+                new BigDecimal("50000000"),
+                new BigDecimal("250000"),
+                new BigDecimal("70000000"),
+                "소득 기준 충족",
+                1
+        );
+    }
+
+    private NoticeSchedule createNoticeSchedule(Notice notice) {
+        return NoticeSchedule.create(
+                notice,
+                "접수",
+                "인터넷 접수",
+                LocalDateTime.of(2026, 8, 10, 10, 0),
+                LocalDateTime.of(2026, 8, 14, 17, 0),
+                1
+        );
+    }
+
+    private NoticeAttachment createNoticeAttachment(Notice notice) {
+        return NoticeAttachment.create(
+                notice,
+                "모집공고문.pdf",
+                "공고문",
+                "https://example.com/files/notice.pdf",
+                1
+        );
+    }
+}

--- a/backend/src/test/java/com/toadzip/backend/DomainJpaPersistenceTest.java
+++ b/backend/src/test/java/com/toadzip/backend/DomainJpaPersistenceTest.java
@@ -201,7 +201,21 @@ class DomainJpaPersistenceTest {
                 () -> assertEquals(userId, foundUserEligibilityInfo.getUserId()),
                 () -> assertEquals(userId, foundUserEligibilityInfo.getUser().getId()),
                 () -> assertEquals(userId, foundUserPlace.getUser().getId()),
+                () -> assertEquals(0, new BigDecimal("37.5665").compareTo(foundUserPlace.getLatitude())),
+                () -> assertEquals(0, new BigDecimal("126.9780").compareTo(foundUserPlace.getLongitude())),
                 () -> assertEquals(housingComplex.getId(), foundHousingType.getHousingComplex().getId()),
+                () -> assertEquals(
+                        0,
+                        new BigDecimal("37.5665").compareTo(
+                                foundHousingType.getHousingComplex().getAddress().getLatitude()
+                        )
+                ),
+                () -> assertEquals(
+                        0,
+                        new BigDecimal("126.9780").compareTo(
+                                foundHousingType.getHousingComplex().getAddress().getLongitude()
+                        )
+                ),
                 () -> assertEquals(originalNotice.getId(), foundCorrectedNotice.getPreviousNotice().getId()),
                 () -> assertEquals("source-notice-id-1", foundCorrectedNotice.getPreviousSourceNoticeIdentifier()),
                 () -> assertEquals(housingComplex.getId(), foundMatchedSupplyRow.getHousingComplex().getId()),

--- a/backend/src/test/java/com/toadzip/backend/DomainJpaPersistenceTest.java
+++ b/backend/src/test/java/com/toadzip/backend/DomainJpaPersistenceTest.java
@@ -30,6 +30,8 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.YearMonth;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -53,6 +55,44 @@ class DomainJpaPersistenceTest {
                 .getSingleResult();
 
         assertEquals("NO", isNullable);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "user_eligibility_infos, user_id, NO",
+            "user_places, user_id, NO",
+            "favorite_notices, user_id, NO",
+            "favorite_notices, notice_id, NO",
+            "favorite_housing_complexes, user_id, NO",
+            "favorite_housing_complexes, housing_complex_id, NO",
+            "favorite_regions, user_id, NO",
+            "housing_types, housing_complex_id, NO",
+            "notices, previous_notice_id, YES",
+            "supply_rows, notice_id, NO",
+            "supply_rows, housing_complex_id, YES",
+            "supply_rows, housing_type_id, YES",
+            "supply_targets, supply_row_id, NO",
+            "notice_schedules, notice_id, NO",
+            "notice_attachments, notice_id, NO"
+    })
+    void 연관관계_외래키의_null_허용_여부를_보장한다(
+            String tableName,
+            String columnName,
+            String expectedNullability
+    ) {
+        Object actualNullability = entityManager.createNativeQuery(
+                        """
+                        SELECT is_nullable
+                        FROM information_schema.columns
+                        WHERE LOWER(table_name) = :tableName
+                          AND LOWER(column_name) = :columnName
+                        """
+                )
+                .setParameter("tableName", tableName)
+                .setParameter("columnName", columnName)
+                .getSingleResult();
+
+        assertEquals(expectedNullability, actualNullability);
     }
 
     @Test
@@ -138,11 +178,6 @@ class DomainJpaPersistenceTest {
                 correctedNotice,
                 LocalDateTime.of(2026, 8, 19, 13, 0)
         );
-        FavoriteNotice unmatchedFavoriteNotice = FavoriteNotice.create(
-                user,
-                null,
-                LocalDateTime.of(2026, 8, 19, 13, 1)
-        );
         FavoriteHousingComplex favoriteHousingComplex = FavoriteHousingComplex.create(
                 user,
                 housingComplex,
@@ -155,7 +190,6 @@ class DomainJpaPersistenceTest {
                 LocalDateTime.of(2026, 8, 19, 13, 3)
         );
         entityManager.persist(favoriteNotice);
-        entityManager.persist(unmatchedFavoriteNotice);
         entityManager.persist(favoriteHousingComplex);
         entityManager.persist(favoriteRegion);
 
@@ -171,7 +205,6 @@ class DomainJpaPersistenceTest {
         Long noticeScheduleId = noticeSchedule.getId();
         Long noticeAttachmentId = noticeAttachment.getId();
         Long favoriteNoticeId = favoriteNotice.getId();
-        Long unmatchedFavoriteNoticeId = unmatchedFavoriteNotice.getId();
         Long favoriteHousingComplexId = favoriteHousingComplex.getId();
         Long favoriteRegionId = favoriteRegion.getId();
 
@@ -187,10 +220,6 @@ class DomainJpaPersistenceTest {
         NoticeSchedule foundNoticeSchedule = entityManager.find(NoticeSchedule.class, noticeScheduleId);
         NoticeAttachment foundNoticeAttachment = entityManager.find(NoticeAttachment.class, noticeAttachmentId);
         FavoriteNotice foundFavoriteNotice = entityManager.find(FavoriteNotice.class, favoriteNoticeId);
-        FavoriteNotice foundUnmatchedFavoriteNotice = entityManager.find(
-                FavoriteNotice.class,
-                unmatchedFavoriteNoticeId
-        );
         FavoriteHousingComplex foundFavoriteHousingComplex = entityManager.find(
                 FavoriteHousingComplex.class,
                 favoriteHousingComplexId
@@ -227,7 +256,6 @@ class DomainJpaPersistenceTest {
                 () -> assertEquals(correctedNoticeId, foundNoticeSchedule.getNotice().getId()),
                 () -> assertEquals(correctedNoticeId, foundNoticeAttachment.getNotice().getId()),
                 () -> assertEquals(correctedNoticeId, foundFavoriteNotice.getNotice().getId()),
-                () -> assertNull(foundUnmatchedFavoriteNotice.getNotice()),
                 () -> assertEquals(housingComplex.getId(), foundFavoriteHousingComplex.getHousingComplex().getId()),
                 () -> assertEquals(userId, foundFavoriteRegion.getUser().getId()),
                 () -> assertEquals("11", foundFavoriteRegion.getProvinceCode()),

--- a/backend/src/test/java/com/toadzip/backend/DomainJpaPersistenceTest.java
+++ b/backend/src/test/java/com/toadzip/backend/DomainJpaPersistenceTest.java
@@ -20,7 +20,7 @@ import com.toadzip.backend.notice.domain.SupplyCategory;
 import com.toadzip.backend.notice.domain.SupplyRow;
 import com.toadzip.backend.notice.domain.SupplyTarget;
 import com.toadzip.backend.user.domain.User;
-import com.toadzip.backend.user.domain.UserInfo;
+import com.toadzip.backend.user.domain.UserEligibilityInfo;
 import com.toadzip.backend.user.domain.UserPlace;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
@@ -92,9 +92,9 @@ class DomainJpaPersistenceTest {
         User user = createUser();
         entityManager.persist(user);
 
-        UserInfo userInfo = createUserInfo(user);
+        UserEligibilityInfo userEligibilityInfo = createUserEligibilityInfo(user);
         UserPlace userPlace = createUserPlace(user);
-        entityManager.persist(userInfo);
+        entityManager.persist(userEligibilityInfo);
         entityManager.persist(userPlace);
 
         HousingComplex housingComplex = createHousingComplex();
@@ -151,9 +151,7 @@ class DomainJpaPersistenceTest {
         FavoriteRegion favoriteRegion = FavoriteRegion.create(
                 user,
                 "11",
-                "서울특별시",
                 "11140",
-                "중구",
                 LocalDateTime.of(2026, 8, 19, 13, 3)
         );
         entityManager.persist(favoriteNotice);
@@ -179,7 +177,7 @@ class DomainJpaPersistenceTest {
 
         entityManager.clear();
 
-        UserInfo foundUserInfo = entityManager.find(UserInfo.class, userId);
+        UserEligibilityInfo foundUserEligibilityInfo = entityManager.find(UserEligibilityInfo.class, userId);
         UserPlace foundUserPlace = entityManager.find(UserPlace.class, userPlaceId);
         HousingType foundHousingType = entityManager.find(HousingType.class, housingTypeId);
         Notice foundCorrectedNotice = entityManager.find(Notice.class, correctedNoticeId);
@@ -200,8 +198,8 @@ class DomainJpaPersistenceTest {
         FavoriteRegion foundFavoriteRegion = entityManager.find(FavoriteRegion.class, favoriteRegionId);
 
         assertAll(
-                () -> assertEquals(userId, foundUserInfo.getUserId()),
-                () -> assertEquals(userId, foundUserInfo.getUser().getId()),
+                () -> assertEquals(userId, foundUserEligibilityInfo.getUserId()),
+                () -> assertEquals(userId, foundUserEligibilityInfo.getUser().getId()),
                 () -> assertEquals(userId, foundUserPlace.getUser().getId()),
                 () -> assertEquals(housingComplex.getId(), foundHousingType.getHousingComplex().getId()),
                 () -> assertEquals(originalNotice.getId(), foundCorrectedNotice.getPreviousNotice().getId()),
@@ -218,7 +216,8 @@ class DomainJpaPersistenceTest {
                 () -> assertNull(foundUnmatchedFavoriteNotice.getNotice()),
                 () -> assertEquals(housingComplex.getId(), foundFavoriteHousingComplex.getHousingComplex().getId()),
                 () -> assertEquals(userId, foundFavoriteRegion.getUser().getId()),
-                () -> assertEquals("서울특별시", foundFavoriteRegion.getProvinceName()),
+                () -> assertEquals("11", foundFavoriteRegion.getProvinceCode()),
+                () -> assertEquals("11140", foundFavoriteRegion.getCityCountyDistrictCode()),
                 () -> assertNotNull(foundCorrectedNotice.getReceptionPlace())
         );
     }
@@ -227,9 +226,9 @@ class DomainJpaPersistenceTest {
         return User.create("login-id", LocalDateTime.of(2026, 8, 19, 12, 0));
     }
 
-    private UserInfo createUserInfo(User user) {
+    private UserEligibilityInfo createUserEligibilityInfo(User user) {
         BigDecimal income = new BigDecimal("3000000");
-        return UserInfo.create(
+        return UserEligibilityInfo.create(
                 user,
                 LocalDate.of(1995, 5, 10),
                 "서울특별시",
@@ -280,9 +279,7 @@ class DomainJpaPersistenceTest {
                         "1114010100100010000",
                         "1114010100",
                         "11",
-                        "서울특별시",
                         "11140",
-                        "중구",
                         new BigDecimal("37.5665"),
                         new BigDecimal("126.9780")
                 ),
@@ -305,7 +302,6 @@ class DomainJpaPersistenceTest {
                 "36A",
                 new BigDecimal("36.00"),
                 new BigDecimal("48.00"),
-                new BigDecimal("12.00"),
                 120,
                 "https://example.com/floor-plan.png",
                 false,

--- a/backend/src/test/java/com/toadzip/backend/housing/domain/AddressTest.java
+++ b/backend/src/test/java/com/toadzip/backend/housing/domain/AddressTest.java
@@ -1,5 +1,6 @@
 package com.toadzip.backend.housing.domain;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -86,6 +87,38 @@ class AddressTest {
         assertThrows(
                 IllegalArgumentException.class,
                 () -> createAddress(new BigDecimal("37.5665"), null)
+        );
+    }
+
+    @Test
+    void 위도는_영하_90도에서_90도_사이여야_한다() {
+        assertAll(
+                () -> assertDoesNotThrow(() -> createAddress(new BigDecimal("-90"), BigDecimal.ZERO)),
+                () -> assertDoesNotThrow(() -> createAddress(new BigDecimal("90"), BigDecimal.ZERO)),
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> createAddress(new BigDecimal("-90.0001"), BigDecimal.ZERO)
+                ),
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> createAddress(new BigDecimal("90.0001"), BigDecimal.ZERO)
+                )
+        );
+    }
+
+    @Test
+    void 경도는_영하_180도에서_180도_사이여야_한다() {
+        assertAll(
+                () -> assertDoesNotThrow(() -> createAddress(BigDecimal.ZERO, new BigDecimal("-180"))),
+                () -> assertDoesNotThrow(() -> createAddress(BigDecimal.ZERO, new BigDecimal("180"))),
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> createAddress(BigDecimal.ZERO, new BigDecimal("-180.0001"))
+                ),
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> createAddress(BigDecimal.ZERO, new BigDecimal("180.0001"))
+                )
         );
     }
 

--- a/backend/src/test/java/com/toadzip/backend/housing/domain/AddressTest.java
+++ b/backend/src/test/java/com/toadzip/backend/housing/domain/AddressTest.java
@@ -24,8 +24,6 @@ class AddressTest {
                         String.class,
                         String.class,
                         String.class,
-                        String.class,
-                        String.class,
                         BigDecimal.class,
                         BigDecimal.class
                 )
@@ -38,9 +36,7 @@ class AddressTest {
                         "1114010100100010000",
                         "1114010100",
                         "11",
-                        "서울특별시",
                         "11140",
-                        "중구",
                         latitude,
                         longitude
                 )
@@ -50,24 +46,20 @@ class AddressTest {
         assertEquals("1114010100100010000", address.getPnu());
         assertEquals("1114010100", address.getLegalDongCode());
         assertEquals("11", address.getProvinceCode());
-        assertEquals("서울특별시", address.getProvinceName());
         assertEquals("11140", address.getCityCountyDistrictCode());
-        assertEquals("중구", address.getCityCountyDistrictName());
         assertEquals(latitude, address.getLatitude());
         assertEquals(longitude, address.getLongitude());
     }
 
     @ParameterizedTest
-    @ValueSource(ints = {0, 1, 2, 3, 4, 5, 6})
+    @ValueSource(ints = {0, 1, 2, 3, 4})
     void 주소의_문자열_정보는_비어_있을_수_없다(int blankFieldIndex) {
         String[] fields = {
                 "서울특별시 중구 세종대로 110",
                 "1114010100100010000",
                 "1114010100",
                 "11",
-                "서울특별시",
-                "11140",
-                "중구"
+                "11140"
         };
         fields[blankFieldIndex] = " ";
 
@@ -79,8 +71,6 @@ class AddressTest {
                         fields[2],
                         fields[3],
                         fields[4],
-                        fields[5],
-                        fields[6],
                         new BigDecimal("37.5665"),
                         new BigDecimal("126.9780")
                 )
@@ -105,9 +95,7 @@ class AddressTest {
                 "1114010100100010000",
                 "1114010100",
                 "11",
-                "서울특별시",
                 "11140",
-                "중구",
                 latitude,
                 longitude
         );

--- a/backend/src/test/java/com/toadzip/backend/housing/domain/AddressTest.java
+++ b/backend/src/test/java/com/toadzip/backend/housing/domain/AddressTest.java
@@ -1,0 +1,115 @@
+package com.toadzip.backend.housing.domain;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.lang.reflect.Method;
+import java.math.BigDecimal;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class AddressTest {
+
+    @Test
+    void 단지_주소를_생성한다() {
+        BigDecimal latitude = new BigDecimal("37.5665");
+        BigDecimal longitude = new BigDecimal("126.9780");
+        Method createMethod = assertDoesNotThrow(
+                () -> Address.class.getDeclaredMethod(
+                        "create",
+                        String.class,
+                        String.class,
+                        String.class,
+                        String.class,
+                        String.class,
+                        String.class,
+                        String.class,
+                        BigDecimal.class,
+                        BigDecimal.class
+                )
+        );
+
+        Address address = assertDoesNotThrow(
+                () -> (Address) createMethod.invoke(
+                        null,
+                        "서울특별시 중구 세종대로 110",
+                        "1114010100100010000",
+                        "1114010100",
+                        "11",
+                        "서울특별시",
+                        "11140",
+                        "중구",
+                        latitude,
+                        longitude
+                )
+        );
+
+        assertEquals("서울특별시 중구 세종대로 110", address.getRoadAddress());
+        assertEquals("1114010100100010000", address.getPnu());
+        assertEquals("1114010100", address.getLegalDongCode());
+        assertEquals("11", address.getProvinceCode());
+        assertEquals("서울특별시", address.getProvinceName());
+        assertEquals("11140", address.getCityCountyDistrictCode());
+        assertEquals("중구", address.getCityCountyDistrictName());
+        assertEquals(latitude, address.getLatitude());
+        assertEquals(longitude, address.getLongitude());
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1, 2, 3, 4, 5, 6})
+    void 주소의_문자열_정보는_비어_있을_수_없다(int blankFieldIndex) {
+        String[] fields = {
+                "서울특별시 중구 세종대로 110",
+                "1114010100100010000",
+                "1114010100",
+                "11",
+                "서울특별시",
+                "11140",
+                "중구"
+        };
+        fields[blankFieldIndex] = " ";
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> Address.create(
+                        fields[0],
+                        fields[1],
+                        fields[2],
+                        fields[3],
+                        fields[4],
+                        fields[5],
+                        fields[6],
+                        new BigDecimal("37.5665"),
+                        new BigDecimal("126.9780")
+                )
+        );
+    }
+
+    @Test
+    void 위도와_경도는_필수다() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> createAddress(null, new BigDecimal("126.9780"))
+        );
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> createAddress(new BigDecimal("37.5665"), null)
+        );
+    }
+
+    private Address createAddress(BigDecimal latitude, BigDecimal longitude) {
+        return Address.create(
+                "서울특별시 중구 세종대로 110",
+                "1114010100100010000",
+                "1114010100",
+                "11",
+                "서울특별시",
+                "11140",
+                "중구",
+                latitude,
+                longitude
+        );
+    }
+}

--- a/backend/src/test/java/com/toadzip/backend/housing/domain/HousingComplexTest.java
+++ b/backend/src/test/java/com/toadzip/backend/housing/domain/HousingComplexTest.java
@@ -183,9 +183,7 @@ class HousingComplexTest {
                 "1114010100100010000",
                 "1114010100",
                 "11",
-                "서울특별시",
                 "11140",
-                "중구",
                 new BigDecimal("37.5665"),
                 new BigDecimal("126.9780")
         );

--- a/backend/src/test/java/com/toadzip/backend/housing/domain/HousingComplexTest.java
+++ b/backend/src/test/java/com/toadzip/backend/housing/domain/HousingComplexTest.java
@@ -1,0 +1,193 @@
+package com.toadzip.backend.housing.domain;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Method;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class HousingComplexTest {
+
+    @Test
+    void 공급유형별_단지를_생성한다() {
+        Address address = createAddress();
+        LocalDate completionDate = LocalDate.of(2020, 6, 30);
+        Method createMethod = assertDoesNotThrow(
+                () -> HousingComplex.class.getDeclaredMethod(
+                        "create",
+                        String.class,
+                        String.class,
+                        String.class,
+                        Address.class,
+                        int.class,
+                        String.class,
+                        LocalDate.class,
+                        String.class,
+                        String.class,
+                        String.class,
+                        boolean.class,
+                        int.class,
+                        String.class,
+                        Integer.class
+                )
+        );
+
+        HousingComplex housingComplex = assertDoesNotThrow(
+                () -> (HousingComplex) createMethod.invoke(
+                        null,
+                        "두꺼비 행복주택",
+                        "source-complex-id",
+                        "행복주택",
+                        address,
+                        500,
+                        "LH",
+                        completionDate,
+                        "개별난방",
+                        "아파트",
+                        "계단식",
+                        true,
+                        420,
+                        "https://example.com/complex.png",
+                        25
+                )
+        );
+
+        assertEquals("두꺼비 행복주택", housingComplex.getName());
+        assertEquals("source-complex-id", housingComplex.getSourceComplexIdentifier());
+        assertEquals("행복주택", housingComplex.getSupplyType());
+        assertEquals(address, housingComplex.getAddress());
+        assertEquals(500, housingComplex.getTotalHouseholdCount());
+        assertEquals("LH", housingComplex.getProvider());
+        assertEquals(completionDate, housingComplex.getCompletionDate());
+        assertEquals("개별난방", housingComplex.getHeatingType());
+        assertEquals("아파트", housingComplex.getHousingType());
+        assertEquals("계단식", housingComplex.getCorridorType());
+        assertTrue(housingComplex.isElevatorInstalled());
+        assertEquals(420, housingComplex.getParkingSpaceCount());
+        assertEquals("https://example.com/complex.png", housingComplex.getImageUrl());
+        assertEquals(25, housingComplex.getRecentOneYearMoveOutCount());
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1, 2, 3, 4, 5, 6})
+    void 단지의_문자열_정보는_비어_있을_수_없다(int blankFieldIndex) {
+        String[] fields = {
+                "두꺼비 행복주택",
+                "source-complex-id",
+                "행복주택",
+                "LH",
+                "개별난방",
+                "아파트",
+                "계단식"
+        };
+        fields[blankFieldIndex] = " ";
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> createHousingComplex(
+                        fields,
+                        createAddress(),
+                        500,
+                        LocalDate.of(2020, 6, 30),
+                        420,
+                        25
+                )
+        );
+    }
+
+    @Test
+    void 주소와_준공일은_필수다() {
+        String[] fields = validStringFields();
+
+        assertAll(
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> createHousingComplex(fields, null, 500, LocalDate.of(2020, 6, 30), 420, 25)
+                ),
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> createHousingComplex(fields, createAddress(), 500, null, 420, 25)
+                )
+        );
+    }
+
+    @Test
+    void 세대수와_주차대수와_퇴거자수는_음수일_수_없다() {
+        String[] fields = validStringFields();
+        LocalDate completionDate = LocalDate.of(2020, 6, 30);
+
+        assertAll(
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> createHousingComplex(fields, createAddress(), -1, completionDate, 420, 25)
+                ),
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> createHousingComplex(fields, createAddress(), 500, completionDate, -1, 25)
+                ),
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> createHousingComplex(fields, createAddress(), 500, completionDate, 420, -1)
+                )
+        );
+    }
+
+    private HousingComplex createHousingComplex(
+            String[] fields,
+            Address address,
+            int totalHouseholdCount,
+            LocalDate completionDate,
+            int parkingSpaceCount,
+            Integer recentOneYearMoveOutCount
+    ) {
+        return HousingComplex.create(
+                fields[0],
+                fields[1],
+                fields[2],
+                address,
+                totalHouseholdCount,
+                fields[3],
+                completionDate,
+                fields[4],
+                fields[5],
+                fields[6],
+                true,
+                parkingSpaceCount,
+                "https://example.com/complex.png",
+                recentOneYearMoveOutCount
+        );
+    }
+
+    private String[] validStringFields() {
+        return new String[]{
+                "두꺼비 행복주택",
+                "source-complex-id",
+                "행복주택",
+                "LH",
+                "개별난방",
+                "아파트",
+                "계단식"
+        };
+    }
+
+    private Address createAddress() {
+        return Address.create(
+                "서울특별시 중구 세종대로 110",
+                "1114010100100010000",
+                "1114010100",
+                "11",
+                "서울특별시",
+                "11140",
+                "중구",
+                new BigDecimal("37.5665"),
+                new BigDecimal("126.9780")
+        );
+    }
+}

--- a/backend/src/test/java/com/toadzip/backend/housing/domain/HousingJpaMappingTest.java
+++ b/backend/src/test/java/com/toadzip/backend/housing/domain/HousingJpaMappingTest.java
@@ -50,7 +50,6 @@ class HousingJpaMappingTest {
                         "name",
                         "exclusiveArea",
                         "supplyArea",
-                        "residentialCommonArea",
                         "totalHouseholdCount",
                         "floorPlanUrl",
                         "duplex",
@@ -64,9 +63,7 @@ class HousingJpaMappingTest {
                         "pnu",
                         "legalDongCode",
                         "provinceCode",
-                        "provinceName",
                         "cityCountyDistrictCode",
-                        "cityCountyDistrictName",
                         "latitude",
                         "longitude"
                 )

--- a/backend/src/test/java/com/toadzip/backend/housing/domain/HousingJpaMappingTest.java
+++ b/backend/src/test/java/com/toadzip/backend/housing/domain/HousingJpaMappingTest.java
@@ -1,0 +1,104 @@
+package com.toadzip.backend.housing.domain;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.metamodel.Attribute;
+import jakarta.persistence.metamodel.ManagedType;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class HousingJpaMappingTest {
+
+    private static final String DOMAIN_PACKAGE = "com.toadzip.backend.housing.domain.";
+
+    @Autowired
+    private EntityManagerFactory entityManagerFactory;
+
+    @Test
+    void 단지_도메인을_JPA_관리_타입으로_등록한다() {
+        assertEntityAttributes(
+                "HousingComplex",
+                Set.of(
+                        "id",
+                        "name",
+                        "sourceComplexIdentifier",
+                        "supplyType",
+                        "address",
+                        "totalHouseholdCount",
+                        "provider",
+                        "completionDate",
+                        "heatingType",
+                        "housingType",
+                        "corridorType",
+                        "elevatorInstalled",
+                        "parkingSpaceCount",
+                        "imageUrl",
+                        "recentOneYearMoveOutCount"
+                )
+        );
+        assertEntityAttributes(
+                "HousingType",
+                Set.of(
+                        "id",
+                        "housingComplex",
+                        "name",
+                        "exclusiveArea",
+                        "supplyArea",
+                        "residentialCommonArea",
+                        "totalHouseholdCount",
+                        "floorPlanUrl",
+                        "duplex",
+                        "maintenanceFee"
+                )
+        );
+        assertEmbeddableAttributes(
+                "Address",
+                Set.of(
+                        "roadAddress",
+                        "pnu",
+                        "legalDongCode",
+                        "provinceCode",
+                        "provinceName",
+                        "cityCountyDistrictCode",
+                        "cityCountyDistrictName",
+                        "latitude",
+                        "longitude"
+                )
+        );
+    }
+
+    private void assertEntityAttributes(String simpleClassName, Set<String> expectedAttributes) {
+        Class<?> entityClass = loadClass(simpleClassName);
+        ManagedType<?> managedType = assertDoesNotThrow(
+                () -> entityManagerFactory.getMetamodel().entity(entityClass)
+        );
+
+        assertEquals(expectedAttributes, attributeNames(managedType));
+    }
+
+    private void assertEmbeddableAttributes(String simpleClassName, Set<String> expectedAttributes) {
+        Class<?> embeddableClass = loadClass(simpleClassName);
+        ManagedType<?> managedType = assertDoesNotThrow(
+                () -> entityManagerFactory.getMetamodel().embeddable(embeddableClass)
+        );
+
+        assertEquals(expectedAttributes, attributeNames(managedType));
+    }
+
+    private Class<?> loadClass(String simpleClassName) {
+        return assertDoesNotThrow(() -> Class.forName(DOMAIN_PACKAGE + simpleClassName));
+    }
+
+    private Set<String> attributeNames(ManagedType<?> managedType) {
+        return managedType.getAttributes()
+                .stream()
+                .map(Attribute::getName)
+                .collect(Collectors.toSet());
+    }
+}

--- a/backend/src/test/java/com/toadzip/backend/housing/domain/HousingTypeTest.java
+++ b/backend/src/test/java/com/toadzip/backend/housing/domain/HousingTypeTest.java
@@ -1,0 +1,188 @@
+package com.toadzip.backend.housing.domain;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.lang.reflect.Method;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import org.junit.jupiter.api.Test;
+
+class HousingTypeTest {
+
+    @Test
+    void 단지에_속한_주택형을_생성한다() {
+        HousingComplex housingComplex = createHousingComplex();
+        BigDecimal exclusiveArea = new BigDecimal("36.00");
+        BigDecimal supplyArea = new BigDecimal("48.00");
+        BigDecimal residentialCommonArea = new BigDecimal("12.00");
+        BigDecimal maintenanceFee = new BigDecimal("120000");
+        Method createMethod = assertDoesNotThrow(
+                () -> HousingType.class.getDeclaredMethod(
+                        "create",
+                        HousingComplex.class,
+                        String.class,
+                        BigDecimal.class,
+                        BigDecimal.class,
+                        BigDecimal.class,
+                        int.class,
+                        String.class,
+                        boolean.class,
+                        BigDecimal.class
+                )
+        );
+
+        HousingType housingType = assertDoesNotThrow(
+                () -> (HousingType) createMethod.invoke(
+                        null,
+                        housingComplex,
+                        "36A",
+                        exclusiveArea,
+                        supplyArea,
+                        residentialCommonArea,
+                        120,
+                        "https://example.com/floor-plan.png",
+                        false,
+                        maintenanceFee
+                )
+        );
+
+        assertEquals(housingComplex, housingType.getHousingComplex());
+        assertEquals("36A", housingType.getName());
+        assertEquals(exclusiveArea, housingType.getExclusiveArea());
+        assertEquals(supplyArea, housingType.getSupplyArea());
+        assertEquals(residentialCommonArea, housingType.getResidentialCommonArea());
+        assertEquals(120, housingType.getTotalHouseholdCount());
+        assertEquals("https://example.com/floor-plan.png", housingType.getFloorPlanUrl());
+        assertFalse(housingType.isDuplex());
+        assertEquals(maintenanceFee, housingType.getMaintenanceFee());
+    }
+
+    @Test
+    void 소속_단지와_주택형명과_평면도는_필수다() {
+        HousingComplex housingComplex = createHousingComplex();
+        BigDecimal area = new BigDecimal("36.00");
+
+        assertAll(
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> createHousingType(null, "36A", area, area, area, 120, "floor-plan", area)
+                ),
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> createHousingType(housingComplex, " ", area, area, area, 120, "floor-plan", area)
+                ),
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> createHousingType(housingComplex, "36A", area, area, area, 120, " ", area)
+                )
+        );
+    }
+
+    @Test
+    void 전용면적과_주거공용면적은_필수다() {
+        HousingComplex housingComplex = createHousingComplex();
+        BigDecimal area = new BigDecimal("36.00");
+
+        assertAll(
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> createHousingType(housingComplex, "36A", null, area, area, 120, "floor-plan", area)
+                ),
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> createHousingType(housingComplex, "36A", area, area, null, 120, "floor-plan", area)
+                )
+        );
+    }
+
+    @Test
+    void 면적과_세대수와_관리비는_음수일_수_없다() {
+        HousingComplex housingComplex = createHousingComplex();
+        BigDecimal area = new BigDecimal("36.00");
+        BigDecimal negative = BigDecimal.ONE.negate();
+
+        assertAll(
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> createHousingType(housingComplex, "36A", negative, area, area, 120,
+                                "floor-plan", area)
+                ),
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> createHousingType(housingComplex, "36A", area, negative, area, 120,
+                                "floor-plan", area)
+                ),
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> createHousingType(housingComplex, "36A", area, area, negative, 120,
+                                "floor-plan", area)
+                ),
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> createHousingType(housingComplex, "36A", area, area, area, -1,
+                                "floor-plan", area)
+                ),
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> createHousingType(housingComplex, "36A", area, area, area, 120,
+                                "floor-plan", negative)
+                )
+        );
+    }
+
+    private HousingType createHousingType(
+            HousingComplex housingComplex,
+            String name,
+            BigDecimal exclusiveArea,
+            BigDecimal supplyArea,
+            BigDecimal residentialCommonArea,
+            int totalHouseholdCount,
+            String floorPlanUrl,
+            BigDecimal maintenanceFee
+    ) {
+        return HousingType.create(
+                housingComplex,
+                name,
+                exclusiveArea,
+                supplyArea,
+                residentialCommonArea,
+                totalHouseholdCount,
+                floorPlanUrl,
+                false,
+                maintenanceFee
+        );
+    }
+
+    private HousingComplex createHousingComplex() {
+        return HousingComplex.create(
+                "두꺼비 행복주택",
+                "source-complex-id",
+                "행복주택",
+                Address.create(
+                        "서울특별시 중구 세종대로 110",
+                        "1114010100100010000",
+                        "1114010100",
+                        "11",
+                        "서울특별시",
+                        "11140",
+                        "중구",
+                        new BigDecimal("37.5665"),
+                        new BigDecimal("126.9780")
+                ),
+                500,
+                "LH",
+                LocalDate.of(2020, 6, 30),
+                "개별난방",
+                "아파트",
+                "계단식",
+                true,
+                420,
+                "https://example.com/complex.png",
+                25
+        );
+    }
+}

--- a/backend/src/test/java/com/toadzip/backend/housing/domain/HousingTypeTest.java
+++ b/backend/src/test/java/com/toadzip/backend/housing/domain/HousingTypeTest.java
@@ -18,14 +18,12 @@ class HousingTypeTest {
         HousingComplex housingComplex = createHousingComplex();
         BigDecimal exclusiveArea = new BigDecimal("36.00");
         BigDecimal supplyArea = new BigDecimal("48.00");
-        BigDecimal residentialCommonArea = new BigDecimal("12.00");
         BigDecimal maintenanceFee = new BigDecimal("120000");
         Method createMethod = assertDoesNotThrow(
                 () -> HousingType.class.getDeclaredMethod(
                         "create",
                         HousingComplex.class,
                         String.class,
-                        BigDecimal.class,
                         BigDecimal.class,
                         BigDecimal.class,
                         int.class,
@@ -42,7 +40,6 @@ class HousingTypeTest {
                         "36A",
                         exclusiveArea,
                         supplyArea,
-                        residentialCommonArea,
                         120,
                         "https://example.com/floor-plan.png",
                         false,
@@ -54,7 +51,6 @@ class HousingTypeTest {
         assertEquals("36A", housingType.getName());
         assertEquals(exclusiveArea, housingType.getExclusiveArea());
         assertEquals(supplyArea, housingType.getSupplyArea());
-        assertEquals(residentialCommonArea, housingType.getResidentialCommonArea());
         assertEquals(120, housingType.getTotalHouseholdCount());
         assertEquals("https://example.com/floor-plan.png", housingType.getFloorPlanUrl());
         assertFalse(housingType.isDuplex());
@@ -69,33 +65,27 @@ class HousingTypeTest {
         assertAll(
                 () -> assertThrows(
                         IllegalArgumentException.class,
-                        () -> createHousingType(null, "36A", area, area, area, 120, "floor-plan", area)
+                        () -> createHousingType(null, "36A", area, area, 120, "floor-plan", area)
                 ),
                 () -> assertThrows(
                         IllegalArgumentException.class,
-                        () -> createHousingType(housingComplex, " ", area, area, area, 120, "floor-plan", area)
+                        () -> createHousingType(housingComplex, " ", area, area, 120, "floor-plan", area)
                 ),
                 () -> assertThrows(
                         IllegalArgumentException.class,
-                        () -> createHousingType(housingComplex, "36A", area, area, area, 120, " ", area)
+                        () -> createHousingType(housingComplex, "36A", area, area, 120, " ", area)
                 )
         );
     }
 
     @Test
-    void 전용면적과_주거공용면적은_필수다() {
+    void 전용면적은_필수다() {
         HousingComplex housingComplex = createHousingComplex();
         BigDecimal area = new BigDecimal("36.00");
 
-        assertAll(
-                () -> assertThrows(
-                        IllegalArgumentException.class,
-                        () -> createHousingType(housingComplex, "36A", null, area, area, 120, "floor-plan", area)
-                ),
-                () -> assertThrows(
-                        IllegalArgumentException.class,
-                        () -> createHousingType(housingComplex, "36A", area, area, null, 120, "floor-plan", area)
-                )
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> createHousingType(housingComplex, "36A", null, area, 120, "floor-plan", area)
         );
     }
 
@@ -108,27 +98,22 @@ class HousingTypeTest {
         assertAll(
                 () -> assertThrows(
                         IllegalArgumentException.class,
-                        () -> createHousingType(housingComplex, "36A", negative, area, area, 120,
+                        () -> createHousingType(housingComplex, "36A", negative, area, 120,
                                 "floor-plan", area)
                 ),
                 () -> assertThrows(
                         IllegalArgumentException.class,
-                        () -> createHousingType(housingComplex, "36A", area, negative, area, 120,
+                        () -> createHousingType(housingComplex, "36A", area, negative, 120,
                                 "floor-plan", area)
                 ),
                 () -> assertThrows(
                         IllegalArgumentException.class,
-                        () -> createHousingType(housingComplex, "36A", area, area, negative, 120,
+                        () -> createHousingType(housingComplex, "36A", area, area, -1,
                                 "floor-plan", area)
                 ),
                 () -> assertThrows(
                         IllegalArgumentException.class,
-                        () -> createHousingType(housingComplex, "36A", area, area, area, -1,
-                                "floor-plan", area)
-                ),
-                () -> assertThrows(
-                        IllegalArgumentException.class,
-                        () -> createHousingType(housingComplex, "36A", area, area, area, 120,
+                        () -> createHousingType(housingComplex, "36A", area, area, 120,
                                 "floor-plan", negative)
                 )
         );
@@ -139,7 +124,6 @@ class HousingTypeTest {
             String name,
             BigDecimal exclusiveArea,
             BigDecimal supplyArea,
-            BigDecimal residentialCommonArea,
             int totalHouseholdCount,
             String floorPlanUrl,
             BigDecimal maintenanceFee
@@ -149,7 +133,6 @@ class HousingTypeTest {
                 name,
                 exclusiveArea,
                 supplyArea,
-                residentialCommonArea,
                 totalHouseholdCount,
                 floorPlanUrl,
                 false,
@@ -167,9 +150,7 @@ class HousingTypeTest {
                         "1114010100100010000",
                         "1114010100",
                         "11",
-                        "서울특별시",
                         "11140",
-                        "중구",
                         new BigDecimal("37.5665"),
                         new BigDecimal("126.9780")
                 ),

--- a/backend/src/test/java/com/toadzip/backend/interest/domain/InterestDomainCreationTest.java
+++ b/backend/src/test/java/com/toadzip/backend/interest/domain/InterestDomainCreationTest.java
@@ -2,11 +2,11 @@ package com.toadzip.backend.interest.domain;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.toadzip.backend.housing.domain.Address;
 import com.toadzip.backend.housing.domain.HousingComplex;
 import com.toadzip.backend.notice.domain.Notice;
+import com.toadzip.backend.notice.domain.ReceptionPlace;
 import com.toadzip.backend.user.domain.User;
 import java.lang.reflect.Method;
 import java.math.BigDecimal;
@@ -17,8 +17,9 @@ import org.junit.jupiter.api.Test;
 class InterestDomainCreationTest {
 
     @Test
-    void 매칭된_공고가_없어도_관심공고를_생성한다() {
+    void 관심공고를_생성한다() {
         User user = createUser();
+        Notice notice = createNotice();
         LocalDateTime createdAt = LocalDateTime.of(2026, 8, 19, 12, 30);
         Method createMethod = findCreateMethod(
                 FavoriteNotice.class,
@@ -27,10 +28,10 @@ class InterestDomainCreationTest {
                 LocalDateTime.class
         );
 
-        FavoriteNotice favoriteNotice = invoke(createMethod, user, null, createdAt);
+        FavoriteNotice favoriteNotice = invoke(createMethod, user, notice, createdAt);
 
         assertEquals(user, favoriteNotice.getUser());
-        assertNull(favoriteNotice.getNotice());
+        assertEquals(notice, favoriteNotice.getNotice());
         assertEquals(createdAt, favoriteNotice.getCreatedAt());
     }
 
@@ -86,6 +87,27 @@ class InterestDomainCreationTest {
 
     private User createUser() {
         return User.create("login-id", LocalDateTime.of(2026, 8, 19, 12, 0));
+    }
+
+    private Notice createNotice() {
+        return Notice.create(
+                "source-notice-id",
+                null,
+                null,
+                "행복주택 모집공고",
+                "원공고",
+                "행복주택",
+                "신규모집",
+                "LH",
+                LocalDate.of(2026, 8, 1),
+                LocalDate.of(2026, 8, 10),
+                LocalDate.of(2026, 8, 14),
+                LocalDate.of(2026, 9, 1),
+                "https://example.com/notices/1",
+                null,
+                0L,
+                ReceptionPlace.create("LH 청약센터", "인터넷", null, "1600-1004", null)
+        );
     }
 
     private HousingComplex createHousingComplex() {

--- a/backend/src/test/java/com/toadzip/backend/interest/domain/InterestDomainCreationTest.java
+++ b/backend/src/test/java/com/toadzip/backend/interest/domain/InterestDomainCreationTest.java
@@ -67,8 +67,6 @@ class InterestDomainCreationTest {
                 User.class,
                 String.class,
                 String.class,
-                String.class,
-                String.class,
                 LocalDateTime.class
         );
 
@@ -76,17 +74,13 @@ class InterestDomainCreationTest {
                 createMethod,
                 user,
                 "11",
-                "서울특별시",
                 "11140",
-                "중구",
                 createdAt
         );
 
         assertEquals(user, favoriteRegion.getUser());
         assertEquals("11", favoriteRegion.getProvinceCode());
-        assertEquals("서울특별시", favoriteRegion.getProvinceName());
         assertEquals("11140", favoriteRegion.getCityCountyDistrictCode());
-        assertEquals("중구", favoriteRegion.getCityCountyDistrictName());
         assertEquals(createdAt, favoriteRegion.getCreatedAt());
     }
 
@@ -104,9 +98,7 @@ class InterestDomainCreationTest {
                         "1114010100100010000",
                         "1114010100",
                         "11",
-                        "서울특별시",
                         "11140",
-                        "중구",
                         new BigDecimal("37.5665"),
                         new BigDecimal("126.9780")
                 ),

--- a/backend/src/test/java/com/toadzip/backend/interest/domain/InterestDomainCreationTest.java
+++ b/backend/src/test/java/com/toadzip/backend/interest/domain/InterestDomainCreationTest.java
@@ -1,0 +1,134 @@
+package com.toadzip.backend.interest.domain;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.toadzip.backend.housing.domain.Address;
+import com.toadzip.backend.housing.domain.HousingComplex;
+import com.toadzip.backend.notice.domain.Notice;
+import com.toadzip.backend.user.domain.User;
+import java.lang.reflect.Method;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+
+class InterestDomainCreationTest {
+
+    @Test
+    void 매칭된_공고가_없어도_관심공고를_생성한다() {
+        User user = createUser();
+        LocalDateTime createdAt = LocalDateTime.of(2026, 8, 19, 12, 30);
+        Method createMethod = findCreateMethod(
+                FavoriteNotice.class,
+                User.class,
+                Notice.class,
+                LocalDateTime.class
+        );
+
+        FavoriteNotice favoriteNotice = invoke(createMethod, user, null, createdAt);
+
+        assertEquals(user, favoriteNotice.getUser());
+        assertNull(favoriteNotice.getNotice());
+        assertEquals(createdAt, favoriteNotice.getCreatedAt());
+    }
+
+    @Test
+    void 관심단지를_생성한다() {
+        User user = createUser();
+        HousingComplex housingComplex = createHousingComplex();
+        LocalDateTime createdAt = LocalDateTime.of(2026, 8, 19, 12, 30);
+        Method createMethod = findCreateMethod(
+                FavoriteHousingComplex.class,
+                User.class,
+                HousingComplex.class,
+                LocalDateTime.class
+        );
+
+        FavoriteHousingComplex favoriteHousingComplex = invoke(
+                createMethod,
+                user,
+                housingComplex,
+                createdAt
+        );
+
+        assertEquals(user, favoriteHousingComplex.getUser());
+        assertEquals(housingComplex, favoriteHousingComplex.getHousingComplex());
+        assertEquals(createdAt, favoriteHousingComplex.getCreatedAt());
+    }
+
+    @Test
+    void 관심지역을_생성한다() {
+        User user = createUser();
+        LocalDateTime createdAt = LocalDateTime.of(2026, 8, 19, 12, 30);
+        Method createMethod = findCreateMethod(
+                FavoriteRegion.class,
+                User.class,
+                String.class,
+                String.class,
+                String.class,
+                String.class,
+                LocalDateTime.class
+        );
+
+        FavoriteRegion favoriteRegion = invoke(
+                createMethod,
+                user,
+                "11",
+                "서울특별시",
+                "11140",
+                "중구",
+                createdAt
+        );
+
+        assertEquals(user, favoriteRegion.getUser());
+        assertEquals("11", favoriteRegion.getProvinceCode());
+        assertEquals("서울특별시", favoriteRegion.getProvinceName());
+        assertEquals("11140", favoriteRegion.getCityCountyDistrictCode());
+        assertEquals("중구", favoriteRegion.getCityCountyDistrictName());
+        assertEquals(createdAt, favoriteRegion.getCreatedAt());
+    }
+
+    private User createUser() {
+        return User.create("login-id", LocalDateTime.of(2026, 8, 19, 12, 0));
+    }
+
+    private HousingComplex createHousingComplex() {
+        return HousingComplex.create(
+                "두꺼비 행복주택",
+                "source-complex-id",
+                "행복주택",
+                Address.create(
+                        "서울특별시 중구 세종대로 110",
+                        "1114010100100010000",
+                        "1114010100",
+                        "11",
+                        "서울특별시",
+                        "11140",
+                        "중구",
+                        new BigDecimal("37.5665"),
+                        new BigDecimal("126.9780")
+                ),
+                500,
+                "LH",
+                LocalDate.of(2020, 6, 30),
+                "개별난방",
+                "아파트",
+                "계단식",
+                true,
+                420,
+                "https://example.com/complex.png",
+                25
+        );
+    }
+
+    private Method findCreateMethod(Class<?> type, Class<?>... parameterTypes) {
+        return assertDoesNotThrow(() -> type.getDeclaredMethod("create", parameterTypes));
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> T invoke(Method method, Object... arguments) {
+        return assertDoesNotThrow(() -> (T) method.invoke(null, arguments));
+    }
+}

--- a/backend/src/test/java/com/toadzip/backend/interest/domain/InterestJpaMappingTest.java
+++ b/backend/src/test/java/com/toadzip/backend/interest/domain/InterestJpaMappingTest.java
@@ -36,9 +36,7 @@ class InterestJpaMappingTest {
                         "id",
                         "user",
                         "provinceCode",
-                        "provinceName",
                         "cityCountyDistrictCode",
-                        "cityCountyDistrictName",
                         "createdAt"
                 )
         );

--- a/backend/src/test/java/com/toadzip/backend/interest/domain/InterestJpaMappingTest.java
+++ b/backend/src/test/java/com/toadzip/backend/interest/domain/InterestJpaMappingTest.java
@@ -1,0 +1,57 @@
+package com.toadzip.backend.interest.domain;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.metamodel.Attribute;
+import jakarta.persistence.metamodel.EntityType;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class InterestJpaMappingTest {
+
+    private static final String DOMAIN_PACKAGE = "com.toadzip.backend.interest.domain.";
+
+    @Autowired
+    private EntityManagerFactory entityManagerFactory;
+
+    @Test
+    void 관심_도메인을_JPA_엔티티로_등록한다() {
+        assertEntityAttributes(
+                "FavoriteNotice",
+                Set.of("id", "user", "notice", "createdAt")
+        );
+        assertEntityAttributes(
+                "FavoriteHousingComplex",
+                Set.of("id", "user", "housingComplex", "createdAt")
+        );
+        assertEntityAttributes(
+                "FavoriteRegion",
+                Set.of(
+                        "id",
+                        "user",
+                        "provinceCode",
+                        "provinceName",
+                        "cityCountyDistrictCode",
+                        "cityCountyDistrictName",
+                        "createdAt"
+                )
+        );
+    }
+
+    private void assertEntityAttributes(String simpleClassName, Set<String> expectedAttributes) {
+        Class<?> entityClass = assertDoesNotThrow(() -> Class.forName(DOMAIN_PACKAGE + simpleClassName));
+        EntityType<?> entityType = assertDoesNotThrow(() -> entityManagerFactory.getMetamodel().entity(entityClass));
+        Set<String> actualAttributes = entityType.getAttributes()
+                .stream()
+                .map(Attribute::getName)
+                .collect(Collectors.toSet());
+
+        assertEquals(expectedAttributes, actualAttributes);
+    }
+}

--- a/backend/src/test/java/com/toadzip/backend/interest/domain/InterestValidationTest.java
+++ b/backend/src/test/java/com/toadzip/backend/interest/domain/InterestValidationTest.java
@@ -1,0 +1,125 @@
+package com.toadzip.backend.interest.domain;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.toadzip.backend.housing.domain.Address;
+import com.toadzip.backend.housing.domain.HousingComplex;
+import com.toadzip.backend.user.domain.User;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class InterestValidationTest {
+
+    @Test
+    void 관심공고의_유저와_등록일시는_필수다() {
+        User user = createUser();
+        LocalDateTime createdAt = LocalDateTime.of(2026, 8, 19, 12, 30);
+
+        assertAll(
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> FavoriteNotice.create(null, null, createdAt)
+                ),
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> FavoriteNotice.create(user, null, null)
+                )
+        );
+    }
+
+    @Test
+    void 관심단지의_유저와_단지와_등록일시는_필수다() {
+        User user = createUser();
+        HousingComplex housingComplex = createHousingComplex();
+        LocalDateTime createdAt = LocalDateTime.of(2026, 8, 19, 12, 30);
+
+        assertAll(
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> FavoriteHousingComplex.create(null, housingComplex, createdAt)
+                ),
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> FavoriteHousingComplex.create(user, null, createdAt)
+                ),
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> FavoriteHousingComplex.create(user, housingComplex, null)
+                )
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1, 2, 3})
+    void 관심지역의_지역_문자열은_비어_있을_수_없다(int blankFieldIndex) {
+        String[] fields = {"11", "서울특별시", "11140", "중구"};
+        fields[blankFieldIndex] = " ";
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FavoriteRegion.create(
+                        createUser(),
+                        fields[0],
+                        fields[1],
+                        fields[2],
+                        fields[3],
+                        LocalDateTime.of(2026, 8, 19, 12, 30)
+                )
+        );
+    }
+
+    @Test
+    void 관심지역의_유저와_등록일시는_필수다() {
+        User user = createUser();
+        LocalDateTime createdAt = LocalDateTime.of(2026, 8, 19, 12, 30);
+
+        assertAll(
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> FavoriteRegion.create(null, "11", "서울특별시", "11140", "중구", createdAt)
+                ),
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> FavoriteRegion.create(user, "11", "서울특별시", "11140", "중구", null)
+                )
+        );
+    }
+
+    private User createUser() {
+        return User.create("login-id", LocalDateTime.of(2026, 8, 19, 12, 0));
+    }
+
+    private HousingComplex createHousingComplex() {
+        return HousingComplex.create(
+                "두꺼비 행복주택",
+                "source-complex-id",
+                "행복주택",
+                Address.create(
+                        "서울특별시 중구 세종대로 110",
+                        "1114010100100010000",
+                        "1114010100",
+                        "11",
+                        "서울특별시",
+                        "11140",
+                        "중구",
+                        new BigDecimal("37.5665"),
+                        new BigDecimal("126.9780")
+                ),
+                500,
+                "LH",
+                LocalDate.of(2020, 6, 30),
+                "개별난방",
+                "아파트",
+                "계단식",
+                true,
+                420,
+                "https://example.com/complex.png",
+                25
+        );
+    }
+}

--- a/backend/src/test/java/com/toadzip/backend/interest/domain/InterestValidationTest.java
+++ b/backend/src/test/java/com/toadzip/backend/interest/domain/InterestValidationTest.java
@@ -5,6 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.toadzip.backend.housing.domain.Address;
 import com.toadzip.backend.housing.domain.HousingComplex;
+import com.toadzip.backend.notice.domain.Notice;
+import com.toadzip.backend.notice.domain.ReceptionPlace;
 import com.toadzip.backend.user.domain.User;
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -16,18 +18,23 @@ import org.junit.jupiter.params.provider.ValueSource;
 class InterestValidationTest {
 
     @Test
-    void 관심공고의_유저와_등록일시는_필수다() {
+    void 관심공고의_유저와_공고와_등록일시는_필수다() {
         User user = createUser();
+        Notice notice = createNotice();
         LocalDateTime createdAt = LocalDateTime.of(2026, 8, 19, 12, 30);
 
         assertAll(
                 () -> assertThrows(
                         IllegalArgumentException.class,
-                        () -> FavoriteNotice.create(null, null, createdAt)
+                        () -> FavoriteNotice.create(null, notice, createdAt)
                 ),
                 () -> assertThrows(
                         IllegalArgumentException.class,
-                        () -> FavoriteNotice.create(user, null, null)
+                        () -> FavoriteNotice.create(user, null, createdAt)
+                ),
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> FavoriteNotice.create(user, notice, null)
                 )
         );
     }
@@ -90,6 +97,27 @@ class InterestValidationTest {
 
     private User createUser() {
         return User.create("login-id", LocalDateTime.of(2026, 8, 19, 12, 0));
+    }
+
+    private Notice createNotice() {
+        return Notice.create(
+                "source-notice-id",
+                null,
+                null,
+                "행복주택 모집공고",
+                "원공고",
+                "행복주택",
+                "신규모집",
+                "LH",
+                LocalDate.of(2026, 8, 1),
+                LocalDate.of(2026, 8, 10),
+                LocalDate.of(2026, 8, 14),
+                LocalDate.of(2026, 9, 1),
+                "https://example.com/notices/1",
+                null,
+                0L,
+                ReceptionPlace.create("LH 청약센터", "인터넷", null, "1600-1004", null)
+        );
     }
 
     private HousingComplex createHousingComplex() {

--- a/backend/src/test/java/com/toadzip/backend/interest/domain/InterestValidationTest.java
+++ b/backend/src/test/java/com/toadzip/backend/interest/domain/InterestValidationTest.java
@@ -55,9 +55,9 @@ class InterestValidationTest {
     }
 
     @ParameterizedTest
-    @ValueSource(ints = {0, 1, 2, 3})
+    @ValueSource(ints = {0, 1})
     void 관심지역의_지역_문자열은_비어_있을_수_없다(int blankFieldIndex) {
-        String[] fields = {"11", "서울특별시", "11140", "중구"};
+        String[] fields = {"11", "11140"};
         fields[blankFieldIndex] = " ";
 
         assertThrows(
@@ -66,8 +66,6 @@ class InterestValidationTest {
                         createUser(),
                         fields[0],
                         fields[1],
-                        fields[2],
-                        fields[3],
                         LocalDateTime.of(2026, 8, 19, 12, 30)
                 )
         );
@@ -81,11 +79,11 @@ class InterestValidationTest {
         assertAll(
                 () -> assertThrows(
                         IllegalArgumentException.class,
-                        () -> FavoriteRegion.create(null, "11", "서울특별시", "11140", "중구", createdAt)
+                        () -> FavoriteRegion.create(null, "11", "11140", createdAt)
                 ),
                 () -> assertThrows(
                         IllegalArgumentException.class,
-                        () -> FavoriteRegion.create(user, "11", "서울특별시", "11140", "중구", null)
+                        () -> FavoriteRegion.create(user, "11", "11140", null)
                 )
         );
     }
@@ -104,9 +102,7 @@ class InterestValidationTest {
                         "1114010100100010000",
                         "1114010100",
                         "11",
-                        "서울특별시",
                         "11140",
-                        "중구",
                         new BigDecimal("37.5665"),
                         new BigDecimal("126.9780")
                 ),

--- a/backend/src/test/java/com/toadzip/backend/notice/domain/NoticeChildValidationTest.java
+++ b/backend/src/test/java/com/toadzip/backend/notice/domain/NoticeChildValidationTest.java
@@ -52,6 +52,21 @@ class NoticeChildValidationTest {
     }
 
     @Test
+    void 일정_종료일시는_시작일시보다_빠를_수_없다() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> NoticeSchedule.create(
+                        createNotice(),
+                        "접수",
+                        "인터넷 접수",
+                        LocalDateTime.of(2026, 8, 14, 17, 0),
+                        LocalDateTime.of(2026, 8, 10, 10, 0),
+                        1
+                )
+        );
+    }
+
+    @Test
     void 공고일정의_표시순서는_음수일_수_없다() {
         assertThrows(
                 IllegalArgumentException.class,

--- a/backend/src/test/java/com/toadzip/backend/notice/domain/NoticeChildValidationTest.java
+++ b/backend/src/test/java/com/toadzip/backend/notice/domain/NoticeChildValidationTest.java
@@ -1,0 +1,127 @@
+package com.toadzip.backend.notice.domain;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class NoticeChildValidationTest {
+
+    @Test
+    void 공고일정의_공고와_시작일시와_종료일시는_필수다() {
+        Notice notice = createNotice();
+        LocalDateTime startAt = LocalDateTime.of(2026, 8, 10, 10, 0);
+        LocalDateTime endAt = LocalDateTime.of(2026, 8, 14, 17, 0);
+
+        assertAll(
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> NoticeSchedule.create(null, "접수", "인터넷 접수", startAt, endAt, 1)
+                ),
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> NoticeSchedule.create(notice, "접수", "인터넷 접수", null, endAt, 1)
+                ),
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> NoticeSchedule.create(notice, "접수", "인터넷 접수", startAt, null, 1)
+                )
+        );
+    }
+
+    @Test
+    void 일정유형과_일정명은_비어_있을_수_없다() {
+        Notice notice = createNotice();
+        LocalDateTime startAt = LocalDateTime.of(2026, 8, 10, 10, 0);
+        LocalDateTime endAt = LocalDateTime.of(2026, 8, 14, 17, 0);
+
+        assertAll(
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> NoticeSchedule.create(notice, " ", "인터넷 접수", startAt, endAt, 1)
+                ),
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> NoticeSchedule.create(notice, "접수", " ", startAt, endAt, 1)
+                )
+        );
+    }
+
+    @Test
+    void 공고일정의_표시순서는_음수일_수_없다() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> NoticeSchedule.create(
+                        createNotice(),
+                        "접수",
+                        "인터넷 접수",
+                        LocalDateTime.of(2026, 8, 10, 10, 0),
+                        LocalDateTime.of(2026, 8, 14, 17, 0),
+                        -1
+                )
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1, 2})
+    void 첨부파일의_문자열은_비어_있을_수_없다(int blankFieldIndex) {
+        String[] fields = {"모집공고문.pdf", "공고문", "https://example.com/files/notice.pdf"};
+        fields[blankFieldIndex] = " ";
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> NoticeAttachment.create(createNotice(), fields[0], fields[1], fields[2], 1)
+        );
+    }
+
+    @Test
+    void 첨부파일의_공고는_필수이고_표시순서는_음수일_수_없다() {
+        assertAll(
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> NoticeAttachment.create(
+                                null,
+                                "모집공고문.pdf",
+                                "공고문",
+                                "https://example.com/files/notice.pdf",
+                                1
+                        )
+                ),
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> NoticeAttachment.create(
+                                createNotice(),
+                                "모집공고문.pdf",
+                                "공고문",
+                                "https://example.com/files/notice.pdf",
+                                -1
+                        )
+                )
+        );
+    }
+
+    private Notice createNotice() {
+        return Notice.create(
+                "source-notice-id",
+                null,
+                null,
+                "행복주택 모집공고",
+                "원공고",
+                "행복주택",
+                "신규모집",
+                "LH",
+                LocalDate.of(2026, 8, 1),
+                LocalDate.of(2026, 8, 10),
+                LocalDate.of(2026, 8, 14),
+                LocalDate.of(2026, 9, 1),
+                "https://example.com/notices/1",
+                null,
+                0L,
+                ReceptionPlace.create("LH 청약센터", "인터넷", null, "1600-1004", "https://apply.lh.or.kr")
+        );
+    }
+}

--- a/backend/src/test/java/com/toadzip/backend/notice/domain/NoticeDomainCreationTest.java
+++ b/backend/src/test/java/com/toadzip/backend/notice/domain/NoticeDomainCreationTest.java
@@ -1,0 +1,276 @@
+package com.toadzip.backend.notice.domain;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.toadzip.backend.housing.domain.HousingComplex;
+import com.toadzip.backend.housing.domain.HousingType;
+import java.lang.reflect.Method;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import org.junit.jupiter.api.Test;
+
+class NoticeDomainCreationTest {
+
+    @Test
+    void 공고_접수처를_생성한다() {
+        Method createMethod = findCreateMethod(
+                ReceptionPlace.class,
+                String.class,
+                String.class,
+                String.class,
+                String.class,
+                String.class
+        );
+
+        ReceptionPlace receptionPlace = invoke(
+                createMethod,
+                "LH 청약센터",
+                "인터넷",
+                null,
+                "1600-1004",
+                "https://apply.lh.or.kr"
+        );
+
+        assertEquals("LH 청약센터", receptionPlace.getName());
+        assertEquals("인터넷", receptionPlace.getMethod());
+        assertNull(receptionPlace.getAddress());
+        assertEquals("1600-1004", receptionPlace.getContact());
+        assertEquals("https://apply.lh.or.kr", receptionPlace.getUrl());
+    }
+
+    @Test
+    void 원공고와_정정공고를_각각_생성한다() {
+        Notice previousNotice = new Notice();
+        ReceptionPlace receptionPlace = new ReceptionPlace();
+        LocalDate postedDate = LocalDate.of(2026, 8, 1);
+        LocalDate applicationStartDate = LocalDate.of(2026, 8, 10);
+        LocalDate applicationEndDate = LocalDate.of(2026, 8, 14);
+        LocalDate winnerAnnouncementDate = LocalDate.of(2026, 9, 1);
+        Method createMethod = findCreateMethod(
+                Notice.class,
+                String.class,
+                String.class,
+                Notice.class,
+                String.class,
+                String.class,
+                String.class,
+                String.class,
+                String.class,
+                LocalDate.class,
+                LocalDate.class,
+                LocalDate.class,
+                LocalDate.class,
+                String.class,
+                String.class,
+                long.class,
+                ReceptionPlace.class
+        );
+
+        Notice notice = invoke(
+                createMethod,
+                "source-notice-id-2",
+                "source-notice-id-1",
+                previousNotice,
+                "행복주택 정정 모집공고",
+                "정정공고",
+                "행복주택",
+                "신규모집",
+                "LH",
+                postedDate,
+                applicationStartDate,
+                applicationEndDate,
+                winnerAnnouncementDate,
+                "https://example.com/notices/2",
+                "접수일 변경",
+                100L,
+                receptionPlace
+        );
+
+        assertEquals("source-notice-id-2", notice.getSourceNoticeIdentifier());
+        assertEquals("source-notice-id-1", notice.getPreviousSourceNoticeIdentifier());
+        assertEquals(previousNotice, notice.getPreviousNotice());
+        assertEquals("행복주택 정정 모집공고", notice.getName());
+        assertEquals("정정공고", notice.getStatus());
+        assertEquals("행복주택", notice.getSupplyType());
+        assertEquals("신규모집", notice.getRecruitmentType());
+        assertEquals("LH", notice.getProvider());
+        assertEquals(postedDate, notice.getPostedDate());
+        assertEquals(applicationStartDate, notice.getApplicationStartDate());
+        assertEquals(applicationEndDate, notice.getApplicationEndDate());
+        assertEquals(winnerAnnouncementDate, notice.getWinnerAnnouncementDate());
+        assertEquals("https://example.com/notices/2", notice.getOriginalUrl());
+        assertEquals("접수일 변경", notice.getCorrectionCancellationReason());
+        assertEquals(100L, notice.getViewCount());
+        assertEquals(receptionPlace, notice.getReceptionPlace());
+    }
+
+    @Test
+    void 매칭되지_않은_원천_공급행도_생성한다() {
+        Notice notice = new Notice();
+        YearMonth expectedMoveInMonth = YearMonth.of(2027, 3);
+        Method createMethod = findCreateMethod(
+                SupplyRow.class,
+                Notice.class,
+                HousingComplex.class,
+                HousingType.class,
+                String.class,
+                int.class,
+                String.class,
+                String.class,
+                String.class,
+                YearMonth.class,
+                SupplyCategory.class,
+                String.class,
+                int.class
+        );
+
+        SupplyRow supplyRow = invoke(
+                createMethod,
+                notice,
+                null,
+                null,
+                "source-supply-row-id",
+                1,
+                "원천 단지명",
+                "36A",
+                "1114010100100010000",
+                expectedMoveInMonth,
+                SupplyCategory.NEW_SUPPLY,
+                "단지 식별자 불일치",
+                20
+        );
+
+        assertEquals(notice, supplyRow.getNotice());
+        assertNull(supplyRow.getHousingComplex());
+        assertNull(supplyRow.getHousingType());
+        assertEquals("source-supply-row-id", supplyRow.getSourceSupplyRowIdentifier());
+        assertEquals(1, supplyRow.getDisplayOrder());
+        assertEquals("원천 단지명", supplyRow.getSourceComplexName());
+        assertEquals("36A", supplyRow.getSourceHousingTypeName());
+        assertEquals("1114010100100010000", supplyRow.getSupplyPnu());
+        assertEquals(expectedMoveInMonth, supplyRow.getExpectedMoveInMonth());
+        assertEquals(SupplyCategory.NEW_SUPPLY, supplyRow.getSupplyCategory());
+        assertEquals("단지 식별자 불일치", supplyRow.getMatchingFailureReason());
+        assertEquals(20, supplyRow.getTotalSupplyHouseholdCount());
+    }
+
+    @Test
+    void 신청_대상별_공급정보를_생성한다() {
+        SupplyRow supplyRow = new SupplyRow();
+        BigDecimal rentalDeposit = new BigDecimal("50000000");
+        BigDecimal monthlyRent = new BigDecimal("250000");
+        BigDecimal convertedDeposit = new BigDecimal("70000000");
+        Method createMethod = findCreateMethod(
+                SupplyTarget.class,
+                SupplyRow.class,
+                String.class,
+                String.class,
+                int.class,
+                int.class,
+                BigDecimal.class,
+                BigDecimal.class,
+                BigDecimal.class,
+                String.class,
+                int.class
+        );
+
+        SupplyTarget supplyTarget = invoke(
+                createMethod,
+                supplyRow,
+                "청년",
+                "1순위",
+                10,
+                20,
+                rentalDeposit,
+                monthlyRent,
+                convertedDeposit,
+                "소득 기준 충족",
+                1
+        );
+
+        assertEquals(supplyRow, supplyTarget.getSupplyRow());
+        assertEquals("청년", supplyTarget.getTarget());
+        assertEquals("1순위", supplyTarget.getSupplyRank());
+        assertEquals(10, supplyTarget.getSupplyHouseholdCount());
+        assertEquals(20, supplyTarget.getReserveCount());
+        assertEquals(rentalDeposit, supplyTarget.getRentalDeposit());
+        assertEquals(monthlyRent, supplyTarget.getMonthlyRent());
+        assertEquals(convertedDeposit, supplyTarget.getConvertedDeposit());
+        assertEquals("소득 기준 충족", supplyTarget.getApplicationCondition());
+        assertEquals(1, supplyTarget.getDisplayOrder());
+    }
+
+    @Test
+    void 공고_일정을_생성한다() {
+        Notice notice = new Notice();
+        LocalDateTime startAt = LocalDateTime.of(2026, 8, 10, 10, 0);
+        LocalDateTime endAt = LocalDateTime.of(2026, 8, 14, 17, 0);
+        Method createMethod = findCreateMethod(
+                NoticeSchedule.class,
+                Notice.class,
+                String.class,
+                String.class,
+                LocalDateTime.class,
+                LocalDateTime.class,
+                int.class
+        );
+
+        NoticeSchedule schedule = invoke(
+                createMethod,
+                notice,
+                "접수",
+                "인터넷 접수",
+                startAt,
+                endAt,
+                1
+        );
+
+        assertEquals(notice, schedule.getNotice());
+        assertEquals("접수", schedule.getScheduleType());
+        assertEquals("인터넷 접수", schedule.getName());
+        assertEquals(startAt, schedule.getStartAt());
+        assertEquals(endAt, schedule.getEndAt());
+        assertEquals(1, schedule.getDisplayOrder());
+    }
+
+    @Test
+    void 공고_첨부파일을_생성한다() {
+        Notice notice = new Notice();
+        Method createMethod = findCreateMethod(
+                NoticeAttachment.class,
+                Notice.class,
+                String.class,
+                String.class,
+                String.class,
+                int.class
+        );
+
+        NoticeAttachment attachment = invoke(
+                createMethod,
+                notice,
+                "모집공고문.pdf",
+                "공고문",
+                "https://example.com/files/notice.pdf",
+                1
+        );
+
+        assertEquals(notice, attachment.getNotice());
+        assertEquals("모집공고문.pdf", attachment.getFileName());
+        assertEquals("공고문", attachment.getFileType());
+        assertEquals("https://example.com/files/notice.pdf", attachment.getFileUrl());
+        assertEquals(1, attachment.getDisplayOrder());
+    }
+
+    private Method findCreateMethod(Class<?> type, Class<?>... parameterTypes) {
+        return assertDoesNotThrow(() -> type.getDeclaredMethod("create", parameterTypes));
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> T invoke(Method method, Object... arguments) {
+        return assertDoesNotThrow(() -> (T) method.invoke(null, arguments));
+    }
+}

--- a/backend/src/test/java/com/toadzip/backend/notice/domain/NoticeJpaMappingTest.java
+++ b/backend/src/test/java/com/toadzip/backend/notice/domain/NoticeJpaMappingTest.java
@@ -1,0 +1,123 @@
+package com.toadzip.backend.notice.domain;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.metamodel.Attribute;
+import jakarta.persistence.metamodel.ManagedType;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class NoticeJpaMappingTest {
+
+    private static final String DOMAIN_PACKAGE = "com.toadzip.backend.notice.domain.";
+
+    @Autowired
+    private EntityManagerFactory entityManagerFactory;
+
+    @Test
+    void 공고_도메인을_JPA_관리_타입으로_등록한다() {
+        assertEntityAttributes(
+                "Notice",
+                Set.of(
+                        "id",
+                        "sourceNoticeIdentifier",
+                        "previousSourceNoticeIdentifier",
+                        "previousNotice",
+                        "name",
+                        "status",
+                        "supplyType",
+                        "recruitmentType",
+                        "provider",
+                        "postedDate",
+                        "applicationStartDate",
+                        "applicationEndDate",
+                        "winnerAnnouncementDate",
+                        "originalUrl",
+                        "correctionCancellationReason",
+                        "viewCount",
+                        "receptionPlace"
+                )
+        );
+        assertEntityAttributes(
+                "SupplyRow",
+                Set.of(
+                        "id",
+                        "notice",
+                        "housingComplex",
+                        "housingType",
+                        "sourceSupplyRowIdentifier",
+                        "displayOrder",
+                        "sourceComplexName",
+                        "sourceHousingTypeName",
+                        "supplyPnu",
+                        "expectedMoveInMonth",
+                        "supplyCategory",
+                        "matchingFailureReason",
+                        "totalSupplyHouseholdCount"
+                )
+        );
+        assertEntityAttributes(
+                "SupplyTarget",
+                Set.of(
+                        "id",
+                        "supplyRow",
+                        "target",
+                        "supplyRank",
+                        "supplyHouseholdCount",
+                        "reserveCount",
+                        "rentalDeposit",
+                        "monthlyRent",
+                        "convertedDeposit",
+                        "applicationCondition",
+                        "displayOrder"
+                )
+        );
+        assertEntityAttributes(
+                "NoticeSchedule",
+                Set.of("id", "notice", "scheduleType", "name", "startAt", "endAt", "displayOrder")
+        );
+        assertEntityAttributes(
+                "NoticeAttachment",
+                Set.of("id", "notice", "fileName", "fileType", "fileUrl", "displayOrder")
+        );
+        assertEmbeddableAttributes(
+                "ReceptionPlace",
+                Set.of("name", "method", "address", "contact", "url")
+        );
+    }
+
+    private void assertEntityAttributes(String simpleClassName, Set<String> expectedAttributes) {
+        Class<?> entityClass = loadClass(simpleClassName);
+        ManagedType<?> managedType = assertDoesNotThrow(
+                () -> entityManagerFactory.getMetamodel().entity(entityClass)
+        );
+
+        assertEquals(expectedAttributes, attributeNames(managedType));
+    }
+
+    private void assertEmbeddableAttributes(String simpleClassName, Set<String> expectedAttributes) {
+        Class<?> embeddableClass = loadClass(simpleClassName);
+        ManagedType<?> managedType = assertDoesNotThrow(
+                () -> entityManagerFactory.getMetamodel().embeddable(embeddableClass)
+        );
+
+        assertEquals(expectedAttributes, attributeNames(managedType));
+    }
+
+    private Class<?> loadClass(String simpleClassName) {
+        return assertDoesNotThrow(() -> Class.forName(DOMAIN_PACKAGE + simpleClassName));
+    }
+
+    private Set<String> attributeNames(ManagedType<?> managedType) {
+        return managedType.getAttributes()
+                .stream()
+                .map(Attribute::getName)
+                .collect(Collectors.toSet());
+    }
+}

--- a/backend/src/test/java/com/toadzip/backend/notice/domain/NoticeValidationTest.java
+++ b/backend/src/test/java/com/toadzip/backend/notice/domain/NoticeValidationTest.java
@@ -1,0 +1,169 @@
+package com.toadzip.backend.notice.domain;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.time.LocalDate;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class NoticeValidationTest {
+
+    @Test
+    void 접수처명과_접수방식은_비어_있을_수_없다() {
+        assertAll(
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> ReceptionPlace.create(" ", "인터넷", null, "1600-1004", "https://apply.lh.or.kr")
+                ),
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> ReceptionPlace.create("LH 청약센터", " ", null, "1600-1004",
+                                "https://apply.lh.or.kr")
+                )
+        );
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {"", " "})
+    void 접수처_연락처는_비어_있을_수_없다(String contact) {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> ReceptionPlace.create(
+                        "LH 청약센터",
+                        "인터넷",
+                        null,
+                        contact,
+                        "https://apply.lh.or.kr"
+                )
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1, 2, 3, 4, 5, 6})
+    void 공고의_필수_문자열은_비어_있을_수_없다(int blankFieldIndex) {
+        String[] fields = validStringFields();
+        fields[blankFieldIndex] = " ";
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> createNotice(
+                        fields,
+                        LocalDate.of(2026, 8, 1),
+                        LocalDate.of(2026, 8, 10),
+                        LocalDate.of(2026, 8, 14),
+                        LocalDate.of(2026, 9, 1),
+                        100L,
+                        createReceptionPlace()
+                )
+        );
+    }
+
+    @Test
+    void 게시일과_접수일과_발표일과_접수처는_필수다() {
+        String[] fields = validStringFields();
+        LocalDate postedDate = LocalDate.of(2026, 8, 1);
+        LocalDate applicationStartDate = LocalDate.of(2026, 8, 10);
+        LocalDate applicationEndDate = LocalDate.of(2026, 8, 14);
+        LocalDate winnerAnnouncementDate = LocalDate.of(2026, 9, 1);
+        ReceptionPlace receptionPlace = createReceptionPlace();
+
+        assertAll(
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> createNotice(fields, null, applicationStartDate, applicationEndDate,
+                                winnerAnnouncementDate, 100L, receptionPlace)
+                ),
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> createNotice(fields, postedDate, null, applicationEndDate,
+                                winnerAnnouncementDate, 100L, receptionPlace)
+                ),
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> createNotice(fields, postedDate, applicationStartDate, null,
+                                winnerAnnouncementDate, 100L, receptionPlace)
+                ),
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> createNotice(fields, postedDate, applicationStartDate, applicationEndDate,
+                                null, 100L, receptionPlace)
+                ),
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> createNotice(fields, postedDate, applicationStartDate, applicationEndDate,
+                                winnerAnnouncementDate, 100L, null)
+                )
+        );
+    }
+
+    @Test
+    void 조회수는_음수일_수_없다() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> createNotice(
+                        validStringFields(),
+                        LocalDate.of(2026, 8, 1),
+                        LocalDate.of(2026, 8, 10),
+                        LocalDate.of(2026, 8, 14),
+                        LocalDate.of(2026, 9, 1),
+                        -1L,
+                        createReceptionPlace()
+                )
+        );
+    }
+
+    private Notice createNotice(
+            String[] fields,
+            LocalDate postedDate,
+            LocalDate applicationStartDate,
+            LocalDate applicationEndDate,
+            LocalDate winnerAnnouncementDate,
+            long viewCount,
+            ReceptionPlace receptionPlace
+    ) {
+        return Notice.create(
+                fields[0],
+                null,
+                null,
+                fields[1],
+                fields[2],
+                fields[3],
+                fields[4],
+                fields[5],
+                postedDate,
+                applicationStartDate,
+                applicationEndDate,
+                winnerAnnouncementDate,
+                fields[6],
+                null,
+                viewCount,
+                receptionPlace
+        );
+    }
+
+    private String[] validStringFields() {
+        return new String[]{
+                "source-notice-id",
+                "행복주택 모집공고",
+                "원공고",
+                "행복주택",
+                "신규모집",
+                "LH",
+                "https://example.com/notices/1"
+        };
+    }
+
+    private ReceptionPlace createReceptionPlace() {
+        return ReceptionPlace.create(
+                "LH 청약센터",
+                "인터넷",
+                null,
+                "1600-1004",
+                "https://apply.lh.or.kr"
+        );
+    }
+}

--- a/backend/src/test/java/com/toadzip/backend/notice/domain/NoticeValidationTest.java
+++ b/backend/src/test/java/com/toadzip/backend/notice/domain/NoticeValidationTest.java
@@ -101,6 +101,22 @@ class NoticeValidationTest {
     }
 
     @Test
+    void 접수_종료일은_접수_시작일보다_빠를_수_없다() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> createNotice(
+                        validStringFields(),
+                        LocalDate.of(2026, 8, 1),
+                        LocalDate.of(2026, 8, 14),
+                        LocalDate.of(2026, 8, 10),
+                        LocalDate.of(2026, 9, 1),
+                        100L,
+                        createReceptionPlace()
+                )
+        );
+    }
+
+    @Test
     void 조회수는_음수일_수_없다() {
         assertThrows(
                 IllegalArgumentException.class,

--- a/backend/src/test/java/com/toadzip/backend/notice/domain/SupplyValidationTest.java
+++ b/backend/src/test/java/com/toadzip/backend/notice/domain/SupplyValidationTest.java
@@ -1,0 +1,246 @@
+package com.toadzip.backend.notice.domain;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class SupplyValidationTest {
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1, 2, 3})
+    void 공급행의_원천_문자열은_비어_있을_수_없다(int blankFieldIndex) {
+        String[] fields = validSupplyRowStringFields();
+        fields[blankFieldIndex] = " ";
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> createSupplyRow(
+                        createNotice(),
+                        fields,
+                        1,
+                        YearMonth.of(2027, 3),
+                        SupplyCategory.NEW_SUPPLY,
+                        20
+                )
+        );
+    }
+
+    @Test
+    void 공급행의_공고와_입주예정연월과_공급구분은_필수다() {
+        Notice notice = createNotice();
+        String[] fields = validSupplyRowStringFields();
+        YearMonth expectedMoveInMonth = YearMonth.of(2027, 3);
+
+        assertAll(
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> createSupplyRow(null, fields, 1, expectedMoveInMonth, SupplyCategory.NEW_SUPPLY, 20)
+                ),
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> createSupplyRow(notice, fields, 1, null, SupplyCategory.NEW_SUPPLY, 20)
+                ),
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> createSupplyRow(notice, fields, 1, expectedMoveInMonth, null, 20)
+                )
+        );
+    }
+
+    @Test
+    void 공급행의_표시순서와_전체_공급세대수는_음수일_수_없다() {
+        Notice notice = createNotice();
+        String[] fields = validSupplyRowStringFields();
+        YearMonth expectedMoveInMonth = YearMonth.of(2027, 3);
+
+        assertAll(
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> createSupplyRow(notice, fields, -1, expectedMoveInMonth,
+                                SupplyCategory.NEW_SUPPLY, 20)
+                ),
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> createSupplyRow(notice, fields, 1, expectedMoveInMonth,
+                                SupplyCategory.NEW_SUPPLY, -1)
+                )
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1, 2})
+    void 공급대상의_문자열은_비어_있을_수_없다(int blankFieldIndex) {
+        String[] fields = validSupplyTargetStringFields();
+        fields[blankFieldIndex] = " ";
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> createSupplyTarget(
+                        createSupplyRow(),
+                        fields,
+                        10,
+                        20,
+                        new BigDecimal("50000000"),
+                        new BigDecimal("250000"),
+                        new BigDecimal("70000000"),
+                        1
+                )
+        );
+    }
+
+    @Test
+    void 공급대상의_공급행과_임대보증금과_월임대료는_필수다() {
+        SupplyRow supplyRow = createSupplyRow();
+        String[] fields = validSupplyTargetStringFields();
+        BigDecimal amount = new BigDecimal("1000000");
+
+        assertAll(
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> createSupplyTarget(null, fields, 10, 20, amount, amount, amount, 1)
+                ),
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> createSupplyTarget(supplyRow, fields, 10, 20, null, amount, amount, 1)
+                ),
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> createSupplyTarget(supplyRow, fields, 10, 20, amount, null, amount, 1)
+                )
+        );
+    }
+
+    @Test
+    void 공급대상의_수량과_금액과_표시순서는_음수일_수_없다() {
+        SupplyRow supplyRow = createSupplyRow();
+        String[] fields = validSupplyTargetStringFields();
+        BigDecimal amount = new BigDecimal("1000000");
+        BigDecimal negative = BigDecimal.ONE.negate();
+
+        assertAll(
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> createSupplyTarget(supplyRow, fields, -1, 20, amount, amount, amount, 1)
+                ),
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> createSupplyTarget(supplyRow, fields, 10, -1, amount, amount, amount, 1)
+                ),
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> createSupplyTarget(supplyRow, fields, 10, 20, negative, amount, amount, 1)
+                ),
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> createSupplyTarget(supplyRow, fields, 10, 20, amount, negative, amount, 1)
+                ),
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> createSupplyTarget(supplyRow, fields, 10, 20, amount, amount, negative, 1)
+                ),
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> createSupplyTarget(supplyRow, fields, 10, 20, amount, amount, amount, -1)
+                )
+        );
+    }
+
+    private SupplyRow createSupplyRow() {
+        return createSupplyRow(
+                createNotice(),
+                validSupplyRowStringFields(),
+                1,
+                YearMonth.of(2027, 3),
+                SupplyCategory.NEW_SUPPLY,
+                20
+        );
+    }
+
+    private SupplyRow createSupplyRow(
+            Notice notice,
+            String[] fields,
+            int displayOrder,
+            YearMonth expectedMoveInMonth,
+            SupplyCategory supplyCategory,
+            int totalSupplyHouseholdCount
+    ) {
+        return SupplyRow.create(
+                notice,
+                null,
+                null,
+                fields[0],
+                displayOrder,
+                fields[1],
+                fields[2],
+                fields[3],
+                expectedMoveInMonth,
+                supplyCategory,
+                "단지 식별자 불일치",
+                totalSupplyHouseholdCount
+        );
+    }
+
+    private SupplyTarget createSupplyTarget(
+            SupplyRow supplyRow,
+            String[] fields,
+            int supplyHouseholdCount,
+            int reserveCount,
+            BigDecimal rentalDeposit,
+            BigDecimal monthlyRent,
+            BigDecimal convertedDeposit,
+            int displayOrder
+    ) {
+        return SupplyTarget.create(
+                supplyRow,
+                fields[0],
+                fields[1],
+                supplyHouseholdCount,
+                reserveCount,
+                rentalDeposit,
+                monthlyRent,
+                convertedDeposit,
+                fields[2],
+                displayOrder
+        );
+    }
+
+    private Notice createNotice() {
+        return Notice.create(
+                "source-notice-id",
+                null,
+                null,
+                "행복주택 모집공고",
+                "원공고",
+                "행복주택",
+                "신규모집",
+                "LH",
+                LocalDate.of(2026, 8, 1),
+                LocalDate.of(2026, 8, 10),
+                LocalDate.of(2026, 8, 14),
+                LocalDate.of(2026, 9, 1),
+                "https://example.com/notices/1",
+                null,
+                0L,
+                ReceptionPlace.create("LH 청약센터", "인터넷", null, "1600-1004", "https://apply.lh.or.kr")
+        );
+    }
+
+    private String[] validSupplyRowStringFields() {
+        return new String[]{
+                "source-supply-row-id",
+                "원천 단지명",
+                "36A",
+                "1114010100100010000"
+        };
+    }
+
+    private String[] validSupplyTargetStringFields() {
+        return new String[]{"청년", "1순위", "소득 기준 충족"};
+    }
+}

--- a/backend/src/test/java/com/toadzip/backend/user/domain/UserEligibilityInfoTest.java
+++ b/backend/src/test/java/com/toadzip/backend/user/domain/UserEligibilityInfoTest.java
@@ -13,10 +13,10 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.Test;
 
-class UserInfoTest {
+class UserEligibilityInfoTest {
 
     @Test
-    void 공공주택_자격_판단에_필요한_유저정보를_생성한다() {
+    void 공공주택_자격_판단에_필요한_유저_자격_정보를_생성한다() {
         User user = User.create("login-id", LocalDateTime.of(2026, 8, 19, 12, 0));
         LocalDate birthDate = LocalDate.of(1995, 5, 10);
         LocalDate marriageDate = LocalDate.of(2024, 3, 1);
@@ -29,7 +29,7 @@ class UserInfoTest {
         BigDecimal totalAssets = new BigDecimal("150000000");
         BigDecimal vehicleValue = new BigDecimal("20000000");
         Method createMethod = assertDoesNotThrow(
-                () -> UserInfo.class.getDeclaredMethod(
+                () -> UserEligibilityInfo.class.getDeclaredMethod(
                         "create",
                         User.class,
                         LocalDate.class,
@@ -60,8 +60,8 @@ class UserInfoTest {
                 )
         );
 
-        UserInfo userInfo = assertDoesNotThrow(
-                () -> (UserInfo) createMethod.invoke(
+        UserEligibilityInfo userEligibilityInfo = assertDoesNotThrow(
+                () -> (UserEligibilityInfo) createMethod.invoke(
                         null,
                         user,
                         birthDate,
@@ -92,32 +92,32 @@ class UserInfoTest {
                 )
         );
 
-        assertEquals(user, userInfo.getUser());
-        assertEquals(birthDate, userInfo.getBirthDate());
-        assertEquals("서울특별시", userInfo.getCurrentResidenceRegion());
-        assertTrue(userInfo.isHeadOfHousehold());
-        assertEquals(3, userInfo.getHouseholdMemberCount());
-        assertFalse(userInfo.isSingleParentFamily());
-        assertTrue(userInfo.isNonHomeowner());
-        assertEquals("기혼", userInfo.getMaritalStatus());
-        assertEquals(marriageDate, userInfo.getMarriageDate());
-        assertEquals(spouseIncome, userInfo.getSpouseMonthlyIncome());
-        assertEquals(1, userInfo.getChildCount());
-        assertFalse(userInfo.isStudent());
-        assertTrue(userInfo.isEmployed());
-        assertEquals(personalIncome, userInfo.getPersonalAverageMonthlyIncome());
-        assertEquals(householdIncome, userInfo.getHouseholdAverageMonthlyIncome());
-        assertEquals(parentsIncome, userInfo.getParentsAverageMonthlyIncome());
-        assertEquals(totalAssets, userInfo.getTotalAssets());
-        assertEquals(vehicleValue, userInfo.getVehicleValue());
-        assertTrue(userInfo.isHousingSubscriptionAccount());
-        assertEquals(subscriptionJoinDate, userInfo.getHousingSubscriptionAccountJoinDate());
-        assertEquals(36, userInfo.getHousingSubscriptionPaymentCount());
-        assertFalse(userInfo.isHousingBenefitRecipient());
-        assertFalse(userInfo.isBasicLivingRecipient());
-        assertFalse(userInfo.isDisabled());
-        assertFalse(userInfo.isVeteran());
-        assertEquals(newbornBirthDate, userInfo.getNewbornBirthDate());
+        assertEquals(user, userEligibilityInfo.getUser());
+        assertEquals(birthDate, userEligibilityInfo.getBirthDate());
+        assertEquals("서울특별시", userEligibilityInfo.getCurrentResidenceRegion());
+        assertTrue(userEligibilityInfo.isHeadOfHousehold());
+        assertEquals(3, userEligibilityInfo.getHouseholdMemberCount());
+        assertFalse(userEligibilityInfo.isSingleParentFamily());
+        assertTrue(userEligibilityInfo.isNonHomeowner());
+        assertEquals("기혼", userEligibilityInfo.getMaritalStatus());
+        assertEquals(marriageDate, userEligibilityInfo.getMarriageDate());
+        assertEquals(spouseIncome, userEligibilityInfo.getSpouseMonthlyIncome());
+        assertEquals(1, userEligibilityInfo.getChildCount());
+        assertFalse(userEligibilityInfo.isStudent());
+        assertTrue(userEligibilityInfo.isEmployed());
+        assertEquals(personalIncome, userEligibilityInfo.getPersonalAverageMonthlyIncome());
+        assertEquals(householdIncome, userEligibilityInfo.getHouseholdAverageMonthlyIncome());
+        assertEquals(parentsIncome, userEligibilityInfo.getParentsAverageMonthlyIncome());
+        assertEquals(totalAssets, userEligibilityInfo.getTotalAssets());
+        assertEquals(vehicleValue, userEligibilityInfo.getVehicleValue());
+        assertTrue(userEligibilityInfo.isHousingSubscriptionAccount());
+        assertEquals(subscriptionJoinDate, userEligibilityInfo.getHousingSubscriptionAccountJoinDate());
+        assertEquals(36, userEligibilityInfo.getHousingSubscriptionPaymentCount());
+        assertFalse(userEligibilityInfo.isHousingBenefitRecipient());
+        assertFalse(userEligibilityInfo.isBasicLivingRecipient());
+        assertFalse(userEligibilityInfo.isDisabled());
+        assertFalse(userEligibilityInfo.isVeteran());
+        assertEquals(newbornBirthDate, userEligibilityInfo.getNewbornBirthDate());
     }
 
     @Test
@@ -129,22 +129,22 @@ class UserInfoTest {
         assertAll(
                 () -> assertThrows(
                         IllegalArgumentException.class,
-                        () -> createUserInfo(null, birthDate, "서울특별시", 3, "기혼", amount, 1,
+                        () -> createUserEligibilityInfo(null, birthDate, "서울특별시", 3, "기혼", amount, 1,
                                 amount, amount, amount, amount, amount, 36)
                 ),
                 () -> assertThrows(
                         IllegalArgumentException.class,
-                        () -> createUserInfo(user, null, "서울특별시", 3, "기혼", amount, 1,
+                        () -> createUserEligibilityInfo(user, null, "서울특별시", 3, "기혼", amount, 1,
                                 amount, amount, amount, amount, amount, 36)
                 ),
                 () -> assertThrows(
                         IllegalArgumentException.class,
-                        () -> createUserInfo(user, birthDate, " ", 3, "기혼", amount, 1,
+                        () -> createUserEligibilityInfo(user, birthDate, " ", 3, "기혼", amount, 1,
                                 amount, amount, amount, amount, amount, 36)
                 ),
                 () -> assertThrows(
                         IllegalArgumentException.class,
-                        () -> createUserInfo(user, birthDate, "서울특별시", 3, " ", amount, 1,
+                        () -> createUserEligibilityInfo(user, birthDate, "서울특별시", 3, " ", amount, 1,
                                 amount, amount, amount, amount, amount, 36)
                 )
         );
@@ -159,17 +159,17 @@ class UserInfoTest {
         assertAll(
                 () -> assertThrows(
                         IllegalArgumentException.class,
-                        () -> createUserInfo(user, birthDate, "서울특별시", -1, "기혼", amount, 1,
+                        () -> createUserEligibilityInfo(user, birthDate, "서울특별시", -1, "기혼", amount, 1,
                                 amount, amount, amount, amount, amount, 36)
                 ),
                 () -> assertThrows(
                         IllegalArgumentException.class,
-                        () -> createUserInfo(user, birthDate, "서울특별시", 3, "기혼", amount, -1,
+                        () -> createUserEligibilityInfo(user, birthDate, "서울특별시", 3, "기혼", amount, -1,
                                 amount, amount, amount, amount, amount, 36)
                 ),
                 () -> assertThrows(
                         IllegalArgumentException.class,
-                        () -> createUserInfo(user, birthDate, "서울특별시", 3, "기혼", amount, 1,
+                        () -> createUserEligibilityInfo(user, birthDate, "서울특별시", 3, "기혼", amount, 1,
                                 amount, amount, amount, amount, amount, -1)
                 )
         );
@@ -185,32 +185,32 @@ class UserInfoTest {
         assertAll(
                 () -> assertThrows(
                         IllegalArgumentException.class,
-                        () -> createUserInfo(user, birthDate, "서울특별시", 3, "기혼", negativeAmount, 1,
+                        () -> createUserEligibilityInfo(user, birthDate, "서울특별시", 3, "기혼", negativeAmount, 1,
                                 amount, amount, amount, amount, amount, 36)
                 ),
                 () -> assertThrows(
                         IllegalArgumentException.class,
-                        () -> createUserInfo(user, birthDate, "서울특별시", 3, "기혼", amount, 1,
+                        () -> createUserEligibilityInfo(user, birthDate, "서울특별시", 3, "기혼", amount, 1,
                                 negativeAmount, amount, amount, amount, amount, 36)
                 ),
                 () -> assertThrows(
                         IllegalArgumentException.class,
-                        () -> createUserInfo(user, birthDate, "서울특별시", 3, "기혼", amount, 1,
+                        () -> createUserEligibilityInfo(user, birthDate, "서울특별시", 3, "기혼", amount, 1,
                                 amount, negativeAmount, amount, amount, amount, 36)
                 ),
                 () -> assertThrows(
                         IllegalArgumentException.class,
-                        () -> createUserInfo(user, birthDate, "서울특별시", 3, "기혼", amount, 1,
+                        () -> createUserEligibilityInfo(user, birthDate, "서울특별시", 3, "기혼", amount, 1,
                                 amount, amount, negativeAmount, amount, amount, 36)
                 ),
                 () -> assertThrows(
                         IllegalArgumentException.class,
-                        () -> createUserInfo(user, birthDate, "서울특별시", 3, "기혼", amount, 1,
+                        () -> createUserEligibilityInfo(user, birthDate, "서울특별시", 3, "기혼", amount, 1,
                                 amount, amount, amount, negativeAmount, amount, 36)
                 ),
                 () -> assertThrows(
                         IllegalArgumentException.class,
-                        () -> createUserInfo(user, birthDate, "서울특별시", 3, "기혼", amount, 1,
+                        () -> createUserEligibilityInfo(user, birthDate, "서울특별시", 3, "기혼", amount, 1,
                                 amount, amount, amount, amount, negativeAmount, 36)
                 )
         );
@@ -225,27 +225,27 @@ class UserInfoTest {
         assertAll(
                 () -> assertThrows(
                         IllegalArgumentException.class,
-                        () -> createUserInfo(user, birthDate, "서울특별시", 3, "기혼", amount, 1,
+                        () -> createUserEligibilityInfo(user, birthDate, "서울특별시", 3, "기혼", amount, 1,
                                 null, amount, amount, amount, amount, 36)
                 ),
                 () -> assertThrows(
                         IllegalArgumentException.class,
-                        () -> createUserInfo(user, birthDate, "서울특별시", 3, "기혼", amount, 1,
+                        () -> createUserEligibilityInfo(user, birthDate, "서울특별시", 3, "기혼", amount, 1,
                                 amount, null, amount, amount, amount, 36)
                 ),
                 () -> assertThrows(
                         IllegalArgumentException.class,
-                        () -> createUserInfo(user, birthDate, "서울특별시", 3, "기혼", amount, 1,
+                        () -> createUserEligibilityInfo(user, birthDate, "서울특별시", 3, "기혼", amount, 1,
                                 amount, amount, null, amount, amount, 36)
                 ),
                 () -> assertThrows(
                         IllegalArgumentException.class,
-                        () -> createUserInfo(user, birthDate, "서울특별시", 3, "기혼", amount, 1,
+                        () -> createUserEligibilityInfo(user, birthDate, "서울특별시", 3, "기혼", amount, 1,
                                 amount, amount, amount, null, amount, 36)
                 ),
                 () -> assertThrows(
                         IllegalArgumentException.class,
-                        () -> createUserInfo(user, birthDate, "서울특별시", 3, "기혼", amount, 1,
+                        () -> createUserEligibilityInfo(user, birthDate, "서울특별시", 3, "기혼", amount, 1,
                                 amount, amount, amount, amount, null, 36)
                 )
         );
@@ -255,7 +255,7 @@ class UserInfoTest {
         return User.create("login-id", LocalDateTime.of(2026, 8, 19, 12, 0));
     }
 
-    private UserInfo createUserInfo(
+    private UserEligibilityInfo createUserEligibilityInfo(
             User user,
             LocalDate birthDate,
             String currentResidenceRegion,
@@ -270,7 +270,7 @@ class UserInfoTest {
             BigDecimal vehicleValue,
             Integer housingSubscriptionPaymentCount
     ) {
-        return UserInfo.create(
+        return UserEligibilityInfo.create(
                 user,
                 birthDate,
                 currentResidenceRegion,

--- a/backend/src/test/java/com/toadzip/backend/user/domain/UserInfoTest.java
+++ b/backend/src/test/java/com/toadzip/backend/user/domain/UserInfoTest.java
@@ -1,0 +1,302 @@
+package com.toadzip.backend.user.domain;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Method;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+
+class UserInfoTest {
+
+    @Test
+    void 공공주택_자격_판단에_필요한_유저정보를_생성한다() {
+        User user = User.create("login-id", LocalDateTime.of(2026, 8, 19, 12, 0));
+        LocalDate birthDate = LocalDate.of(1995, 5, 10);
+        LocalDate marriageDate = LocalDate.of(2024, 3, 1);
+        LocalDate subscriptionJoinDate = LocalDate.of(2020, 1, 15);
+        LocalDate newbornBirthDate = LocalDate.of(2026, 2, 1);
+        BigDecimal spouseIncome = new BigDecimal("2500000");
+        BigDecimal personalIncome = new BigDecimal("3000000");
+        BigDecimal householdIncome = new BigDecimal("5500000");
+        BigDecimal parentsIncome = new BigDecimal("6000000");
+        BigDecimal totalAssets = new BigDecimal("150000000");
+        BigDecimal vehicleValue = new BigDecimal("20000000");
+        Method createMethod = assertDoesNotThrow(
+                () -> UserInfo.class.getDeclaredMethod(
+                        "create",
+                        User.class,
+                        LocalDate.class,
+                        String.class,
+                        boolean.class,
+                        int.class,
+                        boolean.class,
+                        boolean.class,
+                        String.class,
+                        LocalDate.class,
+                        BigDecimal.class,
+                        int.class,
+                        boolean.class,
+                        boolean.class,
+                        BigDecimal.class,
+                        BigDecimal.class,
+                        BigDecimal.class,
+                        BigDecimal.class,
+                        BigDecimal.class,
+                        boolean.class,
+                        LocalDate.class,
+                        Integer.class,
+                        boolean.class,
+                        boolean.class,
+                        boolean.class,
+                        boolean.class,
+                        LocalDate.class
+                )
+        );
+
+        UserInfo userInfo = assertDoesNotThrow(
+                () -> (UserInfo) createMethod.invoke(
+                        null,
+                        user,
+                        birthDate,
+                        "서울특별시",
+                        true,
+                        3,
+                        false,
+                        true,
+                        "기혼",
+                        marriageDate,
+                        spouseIncome,
+                        1,
+                        false,
+                        true,
+                        personalIncome,
+                        householdIncome,
+                        parentsIncome,
+                        totalAssets,
+                        vehicleValue,
+                        true,
+                        subscriptionJoinDate,
+                        36,
+                        false,
+                        false,
+                        false,
+                        false,
+                        newbornBirthDate
+                )
+        );
+
+        assertEquals(user, userInfo.getUser());
+        assertEquals(birthDate, userInfo.getBirthDate());
+        assertEquals("서울특별시", userInfo.getCurrentResidenceRegion());
+        assertTrue(userInfo.isHeadOfHousehold());
+        assertEquals(3, userInfo.getHouseholdMemberCount());
+        assertFalse(userInfo.isSingleParentFamily());
+        assertTrue(userInfo.isNonHomeowner());
+        assertEquals("기혼", userInfo.getMaritalStatus());
+        assertEquals(marriageDate, userInfo.getMarriageDate());
+        assertEquals(spouseIncome, userInfo.getSpouseMonthlyIncome());
+        assertEquals(1, userInfo.getChildCount());
+        assertFalse(userInfo.isStudent());
+        assertTrue(userInfo.isEmployed());
+        assertEquals(personalIncome, userInfo.getPersonalAverageMonthlyIncome());
+        assertEquals(householdIncome, userInfo.getHouseholdAverageMonthlyIncome());
+        assertEquals(parentsIncome, userInfo.getParentsAverageMonthlyIncome());
+        assertEquals(totalAssets, userInfo.getTotalAssets());
+        assertEquals(vehicleValue, userInfo.getVehicleValue());
+        assertTrue(userInfo.isHousingSubscriptionAccount());
+        assertEquals(subscriptionJoinDate, userInfo.getHousingSubscriptionAccountJoinDate());
+        assertEquals(36, userInfo.getHousingSubscriptionPaymentCount());
+        assertFalse(userInfo.isHousingBenefitRecipient());
+        assertFalse(userInfo.isBasicLivingRecipient());
+        assertFalse(userInfo.isDisabled());
+        assertFalse(userInfo.isVeteran());
+        assertEquals(newbornBirthDate, userInfo.getNewbornBirthDate());
+    }
+
+    @Test
+    void 유저와_기본_자격정보는_필수다() {
+        User user = createUser();
+        LocalDate birthDate = LocalDate.of(1995, 5, 10);
+        BigDecimal amount = new BigDecimal("1000000");
+
+        assertAll(
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> createUserInfo(null, birthDate, "서울특별시", 3, "기혼", amount, 1,
+                                amount, amount, amount, amount, amount, 36)
+                ),
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> createUserInfo(user, null, "서울특별시", 3, "기혼", amount, 1,
+                                amount, amount, amount, amount, amount, 36)
+                ),
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> createUserInfo(user, birthDate, " ", 3, "기혼", amount, 1,
+                                amount, amount, amount, amount, amount, 36)
+                ),
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> createUserInfo(user, birthDate, "서울특별시", 3, " ", amount, 1,
+                                amount, amount, amount, amount, amount, 36)
+                )
+        );
+    }
+
+    @Test
+    void 가구원과_자녀와_청약통장_납입_횟수는_음수일_수_없다() {
+        User user = createUser();
+        LocalDate birthDate = LocalDate.of(1995, 5, 10);
+        BigDecimal amount = new BigDecimal("1000000");
+
+        assertAll(
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> createUserInfo(user, birthDate, "서울특별시", -1, "기혼", amount, 1,
+                                amount, amount, amount, amount, amount, 36)
+                ),
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> createUserInfo(user, birthDate, "서울특별시", 3, "기혼", amount, -1,
+                                amount, amount, amount, amount, amount, 36)
+                ),
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> createUserInfo(user, birthDate, "서울특별시", 3, "기혼", amount, 1,
+                                amount, amount, amount, amount, amount, -1)
+                )
+        );
+    }
+
+    @Test
+    void 소득과_자산은_음수일_수_없다() {
+        User user = createUser();
+        LocalDate birthDate = LocalDate.of(1995, 5, 10);
+        BigDecimal amount = new BigDecimal("1000000");
+        BigDecimal negativeAmount = BigDecimal.ONE.negate();
+
+        assertAll(
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> createUserInfo(user, birthDate, "서울특별시", 3, "기혼", negativeAmount, 1,
+                                amount, amount, amount, amount, amount, 36)
+                ),
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> createUserInfo(user, birthDate, "서울특별시", 3, "기혼", amount, 1,
+                                negativeAmount, amount, amount, amount, amount, 36)
+                ),
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> createUserInfo(user, birthDate, "서울특별시", 3, "기혼", amount, 1,
+                                amount, negativeAmount, amount, amount, amount, 36)
+                ),
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> createUserInfo(user, birthDate, "서울특별시", 3, "기혼", amount, 1,
+                                amount, amount, negativeAmount, amount, amount, 36)
+                ),
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> createUserInfo(user, birthDate, "서울특별시", 3, "기혼", amount, 1,
+                                amount, amount, amount, negativeAmount, amount, 36)
+                ),
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> createUserInfo(user, birthDate, "서울특별시", 3, "기혼", amount, 1,
+                                amount, amount, amount, amount, negativeAmount, 36)
+                )
+        );
+    }
+
+    @Test
+    void 본인과_가구와_부모_소득과_자산은_필수다() {
+        User user = createUser();
+        LocalDate birthDate = LocalDate.of(1995, 5, 10);
+        BigDecimal amount = new BigDecimal("1000000");
+
+        assertAll(
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> createUserInfo(user, birthDate, "서울특별시", 3, "기혼", amount, 1,
+                                null, amount, amount, amount, amount, 36)
+                ),
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> createUserInfo(user, birthDate, "서울특별시", 3, "기혼", amount, 1,
+                                amount, null, amount, amount, amount, 36)
+                ),
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> createUserInfo(user, birthDate, "서울특별시", 3, "기혼", amount, 1,
+                                amount, amount, null, amount, amount, 36)
+                ),
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> createUserInfo(user, birthDate, "서울특별시", 3, "기혼", amount, 1,
+                                amount, amount, amount, null, amount, 36)
+                ),
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> createUserInfo(user, birthDate, "서울특별시", 3, "기혼", amount, 1,
+                                amount, amount, amount, amount, null, 36)
+                )
+        );
+    }
+
+    private User createUser() {
+        return User.create("login-id", LocalDateTime.of(2026, 8, 19, 12, 0));
+    }
+
+    private UserInfo createUserInfo(
+            User user,
+            LocalDate birthDate,
+            String currentResidenceRegion,
+            int householdMemberCount,
+            String maritalStatus,
+            BigDecimal spouseMonthlyIncome,
+            int childCount,
+            BigDecimal personalAverageMonthlyIncome,
+            BigDecimal householdAverageMonthlyIncome,
+            BigDecimal parentsAverageMonthlyIncome,
+            BigDecimal totalAssets,
+            BigDecimal vehicleValue,
+            Integer housingSubscriptionPaymentCount
+    ) {
+        return UserInfo.create(
+                user,
+                birthDate,
+                currentResidenceRegion,
+                true,
+                householdMemberCount,
+                false,
+                true,
+                maritalStatus,
+                LocalDate.of(2024, 3, 1),
+                spouseMonthlyIncome,
+                childCount,
+                false,
+                true,
+                personalAverageMonthlyIncome,
+                householdAverageMonthlyIncome,
+                parentsAverageMonthlyIncome,
+                totalAssets,
+                vehicleValue,
+                true,
+                LocalDate.of(2020, 1, 15),
+                housingSubscriptionPaymentCount,
+                false,
+                false,
+                false,
+                false,
+                LocalDate.of(2026, 2, 1)
+        );
+    }
+}

--- a/backend/src/test/java/com/toadzip/backend/user/domain/UserJpaMappingTest.java
+++ b/backend/src/test/java/com/toadzip/backend/user/domain/UserJpaMappingTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.Table;
 import jakarta.persistence.metamodel.Attribute;
 import jakarta.persistence.metamodel.EntityType;
 import java.util.Set;
@@ -27,7 +28,7 @@ class UserJpaMappingTest {
                 Set.of("id", "loginIdentifier", "createdAt")
         );
         assertEntityAttributes(
-                "UserInfo",
+                "UserEligibilityInfo",
                 Set.of(
                         "userId",
                         "user",
@@ -58,10 +59,18 @@ class UserJpaMappingTest {
                         "newbornBirthDate"
                 )
         );
+        assertTableName("UserEligibilityInfo", "user_eligibility_infos");
         assertEntityAttributes(
                 "UserPlace",
                 Set.of("id", "user", "name", "address", "latitude", "longitude", "createdAt")
         );
+    }
+
+    private void assertTableName(String simpleClassName, String expectedTableName) {
+        Class<?> entityClass = assertDoesNotThrow(() -> Class.forName(DOMAIN_PACKAGE + simpleClassName));
+        Table table = entityClass.getAnnotation(Table.class);
+
+        assertEquals(expectedTableName, table.name());
     }
 
     private void assertEntityAttributes(String simpleClassName, Set<String> expectedAttributes) {

--- a/backend/src/test/java/com/toadzip/backend/user/domain/UserJpaMappingTest.java
+++ b/backend/src/test/java/com/toadzip/backend/user/domain/UserJpaMappingTest.java
@@ -1,0 +1,77 @@
+package com.toadzip.backend.user.domain;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.metamodel.Attribute;
+import jakarta.persistence.metamodel.EntityType;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class UserJpaMappingTest {
+
+    private static final String DOMAIN_PACKAGE = "com.toadzip.backend.user.domain.";
+
+    @Autowired
+    private EntityManagerFactory entityManagerFactory;
+
+    @Test
+    void 유저_도메인을_JPA_엔티티로_등록한다() {
+        assertEntityAttributes(
+                "User",
+                Set.of("id", "loginIdentifier", "createdAt")
+        );
+        assertEntityAttributes(
+                "UserInfo",
+                Set.of(
+                        "userId",
+                        "user",
+                        "birthDate",
+                        "currentResidenceRegion",
+                        "headOfHousehold",
+                        "householdMemberCount",
+                        "singleParentFamily",
+                        "nonHomeowner",
+                        "maritalStatus",
+                        "marriageDate",
+                        "spouseMonthlyIncome",
+                        "childCount",
+                        "student",
+                        "employed",
+                        "personalAverageMonthlyIncome",
+                        "householdAverageMonthlyIncome",
+                        "parentsAverageMonthlyIncome",
+                        "totalAssets",
+                        "vehicleValue",
+                        "housingSubscriptionAccount",
+                        "housingSubscriptionAccountJoinDate",
+                        "housingSubscriptionPaymentCount",
+                        "housingBenefitRecipient",
+                        "basicLivingRecipient",
+                        "disabled",
+                        "veteran",
+                        "newbornBirthDate"
+                )
+        );
+        assertEntityAttributes(
+                "UserPlace",
+                Set.of("id", "user", "name", "address", "latitude", "longitude", "createdAt")
+        );
+    }
+
+    private void assertEntityAttributes(String simpleClassName, Set<String> expectedAttributes) {
+        Class<?> entityClass = assertDoesNotThrow(() -> Class.forName(DOMAIN_PACKAGE + simpleClassName));
+        EntityType<?> entityType = assertDoesNotThrow(() -> entityManagerFactory.getMetamodel().entity(entityClass));
+        Set<String> actualAttributes = entityType.getAttributes()
+                .stream()
+                .map(Attribute::getName)
+                .collect(Collectors.toSet());
+
+        assertEquals(expectedAttributes, actualAttributes);
+    }
+}

--- a/backend/src/test/java/com/toadzip/backend/user/domain/UserPlaceTest.java
+++ b/backend/src/test/java/com/toadzip/backend/user/domain/UserPlaceTest.java
@@ -1,0 +1,146 @@
+package com.toadzip.backend.user.domain;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.lang.reflect.Method;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class UserPlaceTest {
+
+    @Test
+    void 유저가_저장한_장소를_생성한다() {
+        User user = User.create("login-id", LocalDateTime.of(2026, 8, 19, 12, 0));
+        BigDecimal latitude = new BigDecimal("37.5665");
+        BigDecimal longitude = new BigDecimal("126.9780");
+        LocalDateTime createdAt = LocalDateTime.of(2026, 8, 19, 12, 30);
+        Method createMethod = assertDoesNotThrow(
+                () -> UserPlace.class.getDeclaredMethod(
+                        "create",
+                        User.class,
+                        String.class,
+                        String.class,
+                        BigDecimal.class,
+                        BigDecimal.class,
+                        LocalDateTime.class
+                )
+        );
+
+        UserPlace place = assertDoesNotThrow(
+                () -> (UserPlace) createMethod.invoke(
+                        null,
+                        user,
+                        "회사",
+                        "서울특별시 중구 세종대로 110",
+                        latitude,
+                        longitude,
+                        createdAt
+                )
+        );
+
+        assertEquals(user, place.getUser());
+        assertEquals("회사", place.getName());
+        assertEquals("서울특별시 중구 세종대로 110", place.getAddress());
+        assertEquals(latitude, place.getLatitude());
+        assertEquals(longitude, place.getLongitude());
+        assertEquals(createdAt, place.getCreatedAt());
+    }
+
+    @Test
+    void 장소의_소유_유저는_필수다() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> UserPlace.create(
+                        null,
+                        "회사",
+                        "서울특별시 중구 세종대로 110",
+                        new BigDecimal("37.5665"),
+                        new BigDecimal("126.9780"),
+                        LocalDateTime.of(2026, 8, 19, 12, 30)
+                )
+        );
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {"", " "})
+    void 장소명은_비어_있을_수_없다(String name) {
+        User user = User.create("login-id", LocalDateTime.of(2026, 8, 19, 12, 0));
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> UserPlace.create(
+                        user,
+                        name,
+                        "서울특별시 중구 세종대로 110",
+                        new BigDecimal("37.5665"),
+                        new BigDecimal("126.9780"),
+                        LocalDateTime.of(2026, 8, 19, 12, 30)
+                )
+        );
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {"", " "})
+    void 주소는_비어_있을_수_없다(String address) {
+        User user = User.create("login-id", LocalDateTime.of(2026, 8, 19, 12, 0));
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> UserPlace.create(
+                        user,
+                        "회사",
+                        address,
+                        new BigDecimal("37.5665"),
+                        new BigDecimal("126.9780"),
+                        LocalDateTime.of(2026, 8, 19, 12, 30)
+                )
+        );
+    }
+
+    @Test
+    void 위도와_경도와_등록일시는_필수다() {
+        User user = User.create("login-id", LocalDateTime.of(2026, 8, 19, 12, 0));
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> UserPlace.create(
+                        user,
+                        "회사",
+                        "서울특별시 중구 세종대로 110",
+                        null,
+                        new BigDecimal("126.9780"),
+                        LocalDateTime.of(2026, 8, 19, 12, 30)
+                )
+        );
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> UserPlace.create(
+                        user,
+                        "회사",
+                        "서울특별시 중구 세종대로 110",
+                        new BigDecimal("37.5665"),
+                        null,
+                        LocalDateTime.of(2026, 8, 19, 12, 30)
+                )
+        );
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> UserPlace.create(
+                        user,
+                        "회사",
+                        "서울특별시 중구 세종대로 110",
+                        new BigDecimal("37.5665"),
+                        new BigDecimal("126.9780"),
+                        null
+                )
+        );
+    }
+}

--- a/backend/src/test/java/com/toadzip/backend/user/domain/UserPlaceTest.java
+++ b/backend/src/test/java/com/toadzip/backend/user/domain/UserPlaceTest.java
@@ -1,5 +1,6 @@
 package com.toadzip.backend.user.domain;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -141,6 +142,49 @@ class UserPlaceTest {
                         new BigDecimal("126.9780"),
                         null
                 )
+        );
+    }
+
+    @Test
+    void 위도는_영하_90도에서_90도_사이여야_한다() {
+        assertAll(
+                () -> assertDoesNotThrow(() -> createUserPlace(new BigDecimal("-90"), BigDecimal.ZERO)),
+                () -> assertDoesNotThrow(() -> createUserPlace(new BigDecimal("90"), BigDecimal.ZERO)),
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> createUserPlace(new BigDecimal("-90.0001"), BigDecimal.ZERO)
+                ),
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> createUserPlace(new BigDecimal("90.0001"), BigDecimal.ZERO)
+                )
+        );
+    }
+
+    @Test
+    void 경도는_영하_180도에서_180도_사이여야_한다() {
+        assertAll(
+                () -> assertDoesNotThrow(() -> createUserPlace(BigDecimal.ZERO, new BigDecimal("-180"))),
+                () -> assertDoesNotThrow(() -> createUserPlace(BigDecimal.ZERO, new BigDecimal("180"))),
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> createUserPlace(BigDecimal.ZERO, new BigDecimal("-180.0001"))
+                ),
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> createUserPlace(BigDecimal.ZERO, new BigDecimal("180.0001"))
+                )
+        );
+    }
+
+    private UserPlace createUserPlace(BigDecimal latitude, BigDecimal longitude) {
+        return UserPlace.create(
+                User.create("login-id", LocalDateTime.of(2026, 8, 19, 12, 0)),
+                "회사",
+                "서울특별시 중구 세종대로 110",
+                latitude,
+                longitude,
+                LocalDateTime.of(2026, 8, 19, 12, 30)
         );
     }
 }

--- a/backend/src/test/java/com/toadzip/backend/user/domain/UserTest.java
+++ b/backend/src/test/java/com/toadzip/backend/user/domain/UserTest.java
@@ -1,0 +1,42 @@
+package com.toadzip.backend.user.domain;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.lang.reflect.Method;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class UserTest {
+
+    @Test
+    void 로그인_식별정보와_생성일시로_유저를_생성한다() {
+        LocalDateTime createdAt = LocalDateTime.of(2026, 8, 19, 12, 0);
+        Method createMethod = assertDoesNotThrow(
+                () -> User.class.getDeclaredMethod("create", String.class, LocalDateTime.class)
+        );
+
+        User user = assertDoesNotThrow(() -> (User) createMethod.invoke(null, "login-id", createdAt));
+
+        assertEquals("login-id", user.getLoginIdentifier());
+        assertEquals(createdAt, user.getCreatedAt());
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {"", " "})
+    void 로그인_식별정보는_비어_있을_수_없다(String loginIdentifier) {
+        LocalDateTime createdAt = LocalDateTime.of(2026, 8, 19, 12, 0);
+
+        assertThrows(IllegalArgumentException.class, () -> User.create(loginIdentifier, createdAt));
+    }
+
+    @Test
+    void 생성일시는_필수다() {
+        assertThrows(IllegalArgumentException.class, () -> User.create("login-id", null));
+    }
+}


### PR DESCRIPTION
## 관련 이슈

Closes #6

## 작업 목적

- 첨부 ERD와 도메인별 속성 명세를 코드로 옮겨 공공주택 서비스의 도메인 및 JPA 엔티티 모델을 구성합니다.
- 명세에 없는 계층이나 기능을 추가하지 않고 도메인 모델과 영속성 매핑에 필요한 최소 범위만 구현합니다.

## 작업 내역

- 유저, 관심정보, 단지·주택형, 공고·공급 관련 JPA 엔티티 13개를 구현했습니다.
- 주소와 접수처 값 객체, 공급구분 Enum, YearMonth JPA Converter를 구현했습니다.
- ERD의 일대일·다대일·자기참조 관계와 nullable 매칭 관계를 매핑했습니다.
- 필수값, 공백 문자열, 음수 수량·금액에 대한 최소 도메인 검증을 추가했습니다.
- 생성, 검증, JPA 메타모델 및 H2 영속성 통합 테스트를 추가했습니다.
- 하네스 관련 28개 파일은 PR 범위에서 제외했습니다.

## 리뷰 포인트

- ERD의 연관관계 cardinality와 nullable 여부가 의도와 일치하는지 확인 부탁드립니다.
- 입주 예정 연월은 `YearMonth`를 유지하고 `YYYY-MM` 문자열 컬럼으로 저장하도록 변환했습니다.
- Repository, Service, Controller, DTO, DB Migration 및 외부 연동은 포함하지 않았습니다.

## 검증 결과

- 테스트 방법: `cd backend && ./gradlew clean test`
- 테스트 결과: 18개 테스트 스위트, 총 97개 테스트 통과 (실패 0, 오류 0, 스킵 0)
