### PR TITLE
docs(setup): 사전준비, 컨테이너 개별 실행 방식 추가 (#11)

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -5,15 +5,34 @@
 - Git
 - Docker
 - Docker Compose
+- Docker Buildx
 
 ## 실행
 
 프로젝트 루트의 `.env.example`을 참고해 `.env`를 생성한다.
 
+### 전체 실행
+
 프로젝트 루트에서 백엔드와 PostgreSQL을 빌드하고 실행한다.
 
 ```shell
 docker compose up -d --build
+```
+
+### PostgreSQL 실행
+
+PostgreSQL만 실행한다.
+
+```shell
+docker compose up -d db
+```
+
+### 백엔드 실행
+
+백엔드를 빌드하고 실행한다.
+
+```shell
+docker compose up -d --build backend
 ```
 
 ## 종료


### PR DESCRIPTION
## 관련 이슈

Closes #11 

## 작업 목적

- 배포에 필요한 Docker Buildx가 사전 준비 항목에서 누락되어 있어 이를 추가한다.
- DB와 백엔드를 각각 실행할 수 있도록 배포 명령어를 세분화한다.

## 작업 내역

- 배포 사전 준비 항목에 Docker Buildx를 추가
- 백엔드 컨테이너, PostgreSQL 컨테이너만 실행하는 명령어를 문서화한다.

## 리뷰 포인트

- 문서 가독성