### PR TITLE
docs(architecture): 기능 간 계층 의존 규칙 명시 (#33)

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -21,7 +21,8 @@
 - 의존성은 Controller → Service → Repository·Domain 방향으로만 흐른다.
 - 계층별 책임과 Entity 응답 금지는 [CODE_CONVENTION.md](CODE_CONVENTION.md)를 원본으로 따른다.
 - Domain은 HTTP, DTO, Controller, Service와 Repository에 의존하지 않는다.
-- 기능 간 협력은 Service에서 수행하고 순환 의존을 만들지 않는다.
+- 기능 간 협력도 기능 소속과 관계없이 Controller → Service → Repository 방향을 유지하고
+  객체 간 순환 의존을 만들지 않는다.
 - `global`에는 공통 기술 설정만 두고 기능별 비즈니스 규칙을 넣지 않는다.
 
 ## 작업 계약

--- a/backend/docs/architecture.md
+++ b/backend/docs/architecture.md
@@ -29,6 +29,19 @@ Controller ↔ DTO
 
 세부 허용 의존성은 [layer-boundaries.md](layer-boundaries.md)에서 확인한다.
 
+## 기능 간 협력
+
+`Housing`과 `Announcement`가 서로의 정보를 사용하는 경우 다음 의존을 함께 구성할 수 있다.
+
+```text
+Housing: HousingController → AnnouncementService, HousingService → AnnouncementRepository
+Announcement: AnnouncementController → HousingService, AnnouncementService → HousingRepository
+```
+
+기능 간 협력은 양방향일 수 있지만 각 객체의 의존은
+Controller → Service → Repository 방향을 따른다. 두 객체가 서로를 참조하거나 의존 경로를
+따라 원래 객체로 돌아오는 순환 참조는 금지한다.
+
 ## 패키지 기준
 
 - `controller`, `service`, `repository`의 책임은 [CODE_CONVENTION.md](../CODE_CONVENTION.md)를 따른다.
@@ -40,7 +53,6 @@ Controller ↔ DTO
 ## 구조 선택 기준
 
 - 비즈니스 규칙은 Controller나 Repository가 아니라 Domain에 둔다.
-- 기능 간 협력은 Service에서 수행하고 다른 기능의 Repository를 직접 호출하지 않는다.
 - 인터페이스는 대체 구현이나 테스트 경계가 실제로 필요할 때만 만든다.
 - 공통 코드는 둘 이상의 기능에서 안정적으로 공유될 때만 `global`로 옮긴다.
 - 비동기 이벤트는 동기 결합을 끊을 필요가 증명된 뒤 도입한다.

--- a/backend/docs/layer-boundaries.md
+++ b/backend/docs/layer-boundaries.md
@@ -19,7 +19,7 @@ feature layers ─────────────────────�
 | Domain | Controller, Service, Repository, DTO, Web·JSON 기술 |
 | DTO | 비즈니스 규칙, Repository |
 | Global | 기능별 Domain과 비즈니스 규칙 |
-| 모든 패키지 | 순환 의존, 범용 `util` 패키지 |
+| 모든 패키지 | 범용 `util` 패키지 |
 
 Domain에는 JPA 매핑을 허용한다. Entity 응답 금지와 계층별 책임은
 [CODE_CONVENTION.md](../CODE_CONVENTION.md)를 원본으로 따른다.

--- a/backend/docs/layer-boundaries.md
+++ b/backend/docs/layer-boundaries.md
@@ -14,7 +14,7 @@ feature layers ─────────────────────�
 | 출발점 | 금지 대상 |
 |---|---|
 | Controller | Repository 직접 호출 |
-| Service | Controller, 다른 기능 Repository |
+| Service | Controller |
 | Repository | Controller, Service |
 | Domain | Controller, Service, Repository, DTO, Web·JSON 기술 |
 | DTO | 비즈니스 규칙, Repository |
@@ -26,9 +26,15 @@ Domain에는 JPA 매핑을 허용한다. Entity 응답 금지와 계층별 책�
 
 ## 기능 간 협력
 
-- 기능 간 호출은 Service에서 수행한다.
-- 다른 기능의 Controller, Repository와 내부 구현을 직접 호출하지 않는다.
-- 기능 간 순환 호출을 만들지 않는다.
+- Controller는 소속 기능과 관계없이 Service를 호출할 수 있다.
+- Service는 소속 기능과 관계없이 Repository를 호출할 수 있다.
+- `HousingController → AnnouncementService`, `HousingService → AnnouncementRepository`를 허용한다.
+- `AnnouncementController → HousingService`, `AnnouncementService → HousingRepository`도
+  함께 구성할 수 있다.
+- 기능 간 협력은 양방향일 수 있지만 각 객체의 의존은 Controller → Service → Repository
+  방향을 유지한다.
+- `HousingController ↔ AnnouncementService`처럼 객체가 서로를 참조하거나 의존 경로가
+  순환해서는 안 된다.
 - 공유 트랜잭션은 호출 Service가 범위와 실패 처리를 소유한다.
 - 결합을 끊어야 할 실제 필요가 생기기 전에는 이벤트를 추가하지 않는다.
 
@@ -43,6 +49,7 @@ Domain에는 JPA 매핑을 허용한다. Entity 응답 금지와 계층별 책�
 
 - Controller가 Repository를 직접 참조하지 않는지 확인한다.
 - Service와 Repository가 Controller에 의존하지 않는지 확인한다.
+- Repository가 Service에 의존하지 않는지 확인한다.
 - Domain이 상위 계층과 Web·JSON 기술에 의존하지 않는지 확인한다.
-- 기능 간 Repository 직접 호출과 순환 의존이 없는지 확인한다.
+- 기능 간 의존도 계층 방향을 유지하고 객체 간 순환 의존이 없는지 확인한다.
 - 자동 구조 검사가 없다면 실행하지 못한 검사와 수동 검토 결과를 보고한다.


### PR DESCRIPTION
## 관련 이슈

Closes #33

## 작업 목적

- 기능 패키지 간 협력에서 계층별로 허용되는 객체 의존 방향을 명확히 한다.

## 작업 내역

- 다른 기능의 `Service`와 `Repository`를 참조할 수 있는 계층 규칙 명시
- `HousingController → AnnouncementService`, `HousingService → AnnouncementRepository` 예시 추가
- 기능 간 양방향 협력과 객체 간 순환 의존의 차이 및 금지 규칙 명시
- `architecture.md`, `layer-boundaries.md`, `backend/AGENTS.md` 규칙 정합성 수정

## 리뷰 포인트

- 기능 간 협력은 양방향일 수 있지만 실제 객체 의존은 `Controller → Service → Repository` 방향을 유지한다.
- `Announcement` 용어는 PR #32의 네이밍 변경을 기준으로 하므로 #32를 먼저 병합해야 한다.

## 검증 결과

- 테스트 방법: 저장소 하네스 테스트와 `sh scripts/validate-harness.sh` 실행
- 테스트 결과: 전체 하네스 검사 통과
- 추가 검증: `git diff --check`, 문서 70줄 제한, PR 제목·브랜치 규칙 통과

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified guidelines for collaboration between features while preserving the Controller → Service → Repository layer direction.
  * Documented allowed cross-feature interactions and prohibited circular dependencies.
  * Added clearer layer-boundary rules, including restrictions on Service and Repository dependencies.
  * Expanded architecture validation guidance for checking dependency direction and preventing circular references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->