### PR TITLE
docs: 예외 처리 하네스 추가 (#37)

### DIFF
--- a/backend/docs/README.md
+++ b/backend/docs/README.md
@@ -20,7 +20,8 @@
 | 구조 변경 | [architecture.md](architecture.md), [layer-boundaries.md](layer-boundaries.md) | 계층 책임과 허용 의존성 |
 | Java·Spring | [CODE_CONVENTION.md](../CODE_CONVENTION.md) | 코드 스타일과 객체 규칙 |
 | Git 작업 | [CONTRIBUTING.md](../../CONTRIBUTING.md) | 이슈, 브랜치, 커밋, PR |
-| HTTP API | [api-conventions.md](api-conventions.md) | 요청, 응답, 오류 계약 |
+| HTTP API | [api-conventions.md](api-conventions.md) | 요청, 응답, 호환성 |
+| 예외 처리 | [exception-handling.md](exception-handling.md) | 예외 소유권, Advice, 오류 계약 |
 | DB 변경 | [persistence.md](persistence.md) | 모델, 쿼리, 트랜잭션 |
 | 테스트 | [testing.md](testing.md) | 테스트 범위와 대역 기준 |
 | 보안 변경 | [security.md](security.md) | 인증, 인가, 개인정보, 비밀 |

--- a/backend/docs/api-conventions.md
+++ b/backend/docs/api-conventions.md
@@ -27,22 +27,12 @@ HTTP → Request DTO 검증 → Controller → Service → Domain / Repository �
 
 ## 오류 응답
 
-```json
-{
-  "code": "ANNOUNCEMENT_NOT_FOUND",
-  "message": "모집 공고를 찾을 수 없습니다.",
-  "traceId": "공개 가능한 추적 식별자"
-}
-```
-
-- `code`는 클라이언트 계약이고 `message`는 사용자 이해를 돕는다.
-- 내부 예외명, SQL, 스택 트레이스와 비밀을 응답에 포함하지 않는다.
-- 같은 실패는 모든 endpoint에서 같은 상태와 code로 매핑한다.
-- 필드 검증 실패는 어떤 입력이 왜 거부됐는지 안전하게 표현한다.
+오류 응답 구조, 검증 실패, 예외 소유권과 Advice 우선순위는
+[exception-handling.md](exception-handling.md)를 원본으로 따른다.
 
 ## 변경과 호환성
 
 - 기존 필드의 의미·타입 변경과 필수화는 공개 계약 변경이다.
 - 추가 필드는 클라이언트가 모르는 필드를 허용하는지 확인한다.
 - breaking change는 승인과 마이그레이션 경로 없이 배포하지 않는다.
-- 요청·응답·오류 계약은 Controller 테스트로 고정한다.
+- 요청·응답 계약은 Controller 테스트로 고정한다.

--- a/backend/docs/exception-handling.md
+++ b/backend/docs/exception-handling.md
@@ -1,0 +1,69 @@
+# Exception Handling
+
+## 패키지와 책임
+
+```text
+global/exception/
+├── ErrorResponse
+└── GlobalExceptionAdvice
+<feature>/
+├── controller/<Feature>ExceptionAdvice
+└── exception/
+    ├── <Feature>NotFoundException
+    └── Invalid<Feature>Exception
+```
+
+- `global.exception`: 기능과 무관한 공통 오류와 응답 모델
+- `<feature>.exception`: Spring과 HTTP에 의존하지 않는 기능 예외
+- `<feature>.controller`: 기능 예외를 HTTP 응답으로 변환하는 Advice
+- 기능별 예외와 비즈니스 규칙을 `global.exception`에 모으지 않는다.
+
+## 오류 응답
+
+```json
+{
+  "code": "ANNOUNCEMENT_NOT_FOUND",
+  "message": "모집 공고를 찾을 수 없습니다.",
+  "traceId": "공개 가능한 추적 식별자"
+}
+```
+
+```json
+{
+  "code": "VALIDATION_FAILED",
+  "message": "요청값이 올바르지 않습니다.",
+  "traceId": "abc123",
+  "errors": [
+    {"field": "applicationStartDate", "reason": "필수 값입니다."},
+    {"field": "supplyRows[0].count", "reason": "100 이하여야 합니다."}
+  ]
+}
+```
+
+- `code`는 고정된 클라이언트 계약이고 같은 실패는 endpoint와 관계없이 같은 상태와 `code`로 응답한다.
+- `message`와 `reason`에는 공개 가능한 문구만 쓰고 내부 예외명, SQL, 스택 트레이스와 비밀을 포함하지 않으며 `traceId`에도 공개 가능한 식별자만 사용한다.
+- `errors`에는 가능한 모든 검증 실패를 담고 `field`는 요청 JSON의 필드명 또는 경로를 사용한다.
+
+## Advice 책임과 상태
+
+| 오류 의미 | HTTP 상태 |
+|---|---|
+| 잘못된 요청 또는 도메인 값 | 400 |
+| 리소스를 찾을 수 없음 | 404 |
+| 지원하지 않는 HTTP 메서드 | 405 |
+| 현재 상태와 요청이 충돌함 | 409 |
+| 지원하지 않는 미디어 타입 | 415 |
+| 예상하지 못한 서버 오류 | 500 |
+
+- `GlobalExceptionAdvice`는 DTO 검증, JSON 파싱, 지원하지 않는 메서드·미디어 타입과 미처리 예외를 담당한다.
+- 기능별 Advice는 소속 기능의 구체적인 예외만 처리하고 `RuntimeException`, `Exception`을 처리하지 않는다.
+- 기능별 Advice는 공통 Advice보다 우선하며 공통 Advice는 `Ordered.LOWEST_PRECEDENCE`로 둔다.
+- Advice는 시작 Controller가 아니라 예외 타입으로 선택하며 특정 Controller 패키지로 적용 범위를 제한하지 않는다.
+- 예: `HousingController → AnnouncementService → AnnouncementNotFoundException → AnnouncementExceptionAdvice`
+
+## 예외 선택
+
+- `IllegalArgumentException`을 전역에서 모두 400으로 처리하지 않는다. 프로그래밍 오류와 내부 전제조건 위반을 사용자 입력 오류로 위장할 수 있다.
+- 예상 가능한 도메인 실패는 의미가 드러나는 기능별 예외로 정의한다.
+- 클라이언트가 실패 원인을 구분해야 하면 별도 예외 타입과 고정된 오류 `code`를 제공한다.
+- 오류 상태, `code`와 검증 필드 계약은 Controller 테스트로 고정한다.

--- a/scripts/validate-harness.sh
+++ b/scripts/validate-harness.sh
@@ -20,6 +20,7 @@ backend/docs/architecture.md
 backend/docs/layer-boundaries.md
 backend/docs/development-cycle.md
 backend/docs/api-conventions.md
+backend/docs/exception-handling.md
 backend/docs/persistence.md
 backend/docs/testing.md
 backend/docs/security.md

--- a/tests/harness/validate-harness-test.sh
+++ b/tests/harness/validate-harness-test.sh
@@ -32,6 +32,7 @@ make_valid_fixture() {
     '[CONTRIBUTING.md](../../CONTRIBUTING.md)' \
     > "$root/backend/docs/README.md"
   for name in architecture layer-boundaries development-cycle api-conventions \
+    exception-handling \
     persistence testing security observability \
     agent-collaboration quality-gates
   do
@@ -126,6 +127,12 @@ make_valid_fixture "$fixture/missing-contributing"
 rm "$fixture/missing-contributing/CONTRIBUTING.md"
 if "$validator" "$fixture/missing-contributing" >/dev/null 2>&1; then
   fail "missing original contribution guide must fail"
+fi
+
+make_valid_fixture "$fixture/missing-exception-handling"
+rm "$fixture/missing-exception-handling/backend/docs/exception-handling.md"
+if "$validator" "$fixture/missing-exception-handling" >/dev/null 2>&1; then
+  fail "missing exception handling convention must fail"
 fi
 
 make_valid_fixture "$fixture/duplicate-code-convention"


### PR DESCRIPTION
## 관련 이슈

Closes #37

## 작업 목적

- 예외 처리에 대한 팀 컨벤션을 백엔드 하네스의 단일 원본으로 추가한다.

## 작업 내역

- `backend/docs/exception-handling.md`에 예외 소유권, 오류 응답, Advice 책임과 우선순위, 예외 선택 규칙을 정리했다.
- 하네스 지도와 API 컨벤션을 새 원본 문서에 연결하고 중복 오류 규칙을 제거했다.
- 새 문서를 하네스 필수 파일로 등록하고 누락 시 실패하는 회귀 테스트를 추가했다.

## 리뷰 포인트

- 기능 예외는 `<feature>/exception`, Advice는 `<feature>/controller`에 두는 경계가 적절한지 확인해 주세요.
- 지원하지 않는 HTTP 메서드와 미디어 타입을 각각 405, 415로 매핑하고, `IllegalArgumentException`을 전역 400으로 처리하지 않도록 명시했다.

## 검증 결과

- 테스트 방법: `sh scripts/validate-harness.sh`
- 테스트 결과: 통과
- 테스트 방법: `sh tests/harness/validate-harness-test.sh`
- 테스트 결과: 통과
- 테스트 방법: `sh tests/harness/contains-hangul-test.sh`, `sh tests/harness/validate-commit-message-test.sh`, `sh tests/harness/validate-pr-test.sh`
- 테스트 결과: 모두 통과
- 추가 검증: 셸 문법 검사와 `git diff --check` 통과
- 미검증: Docker 데몬이 실행 중이지 않아 PostgreSQL 기반 `./gradlew --rerun-tasks check`는 실행하지 못했다. Java 코드는 변경하지 않았다.