### PR TITLE
chore(api): Swagger 및 OpenAPI 문서 환경 도입 (#41)

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -21,6 +21,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.1.0'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'org.postgresql:postgresql'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/backend/src/main/java/com/toadzip/backend/global/config/OpenApiConfig.java
+++ b/backend/src/main/java/com/toadzip/backend/global/config/OpenApiConfig.java
@@ -1,0 +1,19 @@
+package com.toadzip.backend.global.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI toadzipOpenApi() {
+        Info apiInfo = new Info()
+                .title("두꺼비집 API")
+                .version("0.0.1");
+
+        return new OpenAPI().info(apiInfo);
+    }
+}

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -2,3 +2,9 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
+
+springdoc:
+  api-docs:
+    enabled: true
+  swagger-ui:
+    enabled: true

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 spring.application.name=backend
-
+springdoc.api-docs.enabled=false
+springdoc.swagger-ui.enabled=false

--- a/backend/src/test/java/com/toadzip/backend/global/config/OpenApiDocumentationDisabledIntegrationTest.java
+++ b/backend/src/test/java/com/toadzip/backend/global/config/OpenApiDocumentationDisabledIntegrationTest.java
@@ -1,0 +1,34 @@
+package com.toadzip.backend.global.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.net.http.HttpResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        properties = "spring.main.web-application-type=servlet"
+)
+@ActiveProfiles("test")
+class OpenApiDocumentationDisabledIntegrationTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Test
+    void 기본_설정은_OpenAPI_문서를_노출하지_않는다() throws Exception {
+        HttpResponse<String> response = TestHttpClient.get(port, "/v3/api-docs");
+
+        assertEquals(404, response.statusCode());
+    }
+
+    @Test
+    void 기본_설정은_Swagger_UI를_노출하지_않는다() throws Exception {
+        HttpResponse<String> response = TestHttpClient.get(port, "/swagger-ui/index.html");
+
+        assertEquals(404, response.statusCode());
+    }
+}

--- a/backend/src/test/java/com/toadzip/backend/global/config/OpenApiDocumentationIntegrationTest.java
+++ b/backend/src/test/java/com/toadzip/backend/global/config/OpenApiDocumentationIntegrationTest.java
@@ -1,0 +1,49 @@
+package com.toadzip.backend.global.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.jayway.jsonpath.JsonPath;
+import java.net.http.HttpResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        properties = "spring.main.web-application-type=servlet"
+)
+@ActiveProfiles({"local", "test"})
+class OpenApiDocumentationIntegrationTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Test
+    void 로컬_프로필은_헬스_체크_API가_포함된_OpenAPI_문서를_제공한다() throws Exception {
+        HttpResponse<String> response = TestHttpClient.get(port, "/v3/api-docs");
+
+        assertEquals(200, response.statusCode());
+        assertTrue(response.headers().firstValue("content-type").orElseThrow().startsWith("application/json"));
+        assertNotNull(JsonPath.read(response.body(), "$.paths['/api/health'].get"));
+    }
+
+    @Test
+    void 로컬_프로필은_Swagger_UI를_제공한다() throws Exception {
+        HttpResponse<String> response = TestHttpClient.get(port, "/swagger-ui/index.html");
+
+        assertEquals(200, response.statusCode());
+        assertTrue(response.headers().firstValue("content-type").orElseThrow().startsWith("text/html"));
+    }
+
+    @Test
+    void OpenAPI_문서는_서비스_기본_정보를_제공한다() throws Exception {
+        HttpResponse<String> response = TestHttpClient.get(port, "/v3/api-docs");
+
+        assertEquals(200, response.statusCode());
+        assertEquals("두꺼비집 API", JsonPath.read(response.body(), "$.info.title"));
+        assertEquals("0.0.1", JsonPath.read(response.body(), "$.info.version"));
+    }
+}

--- a/backend/src/test/java/com/toadzip/backend/global/config/TestHttpClient.java
+++ b/backend/src/test/java/com/toadzip/backend/global/config/TestHttpClient.java
@@ -1,0 +1,24 @@
+package com.toadzip.backend.global.config;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+final class TestHttpClient {
+
+    private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
+
+    private TestHttpClient() {
+    }
+
+    static HttpResponse<String> get(int port, String path) throws IOException, InterruptedException {
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create("http://127.0.0.1:" + port + path))
+                .GET()
+                .build();
+
+        return HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+    }
+}

--- a/docs/LOCAL_SETUP.md
+++ b/docs/LOCAL_SETUP.md
@@ -6,6 +6,15 @@
 docker compose -f compose.yaml -f compose.local.yaml up -d --build
 ```
 
+## API 문서
+
+로컬 프로필에서만 Swagger UI와 OpenAPI 명세를 제공한다.
+
+- Swagger UI: `http://localhost:8080/swagger-ui/index.html`
+- OpenAPI JSON: `http://localhost:8080/v3/api-docs`
+
+`.env`에서 `BACKEND_PORT`를 변경했다면 URL의 `8080`을 같은 포트로 바꾼다.
+
 ## DB GUI 연결
 
 ```text


### PR DESCRIPTION
## 관련 이슈

Closes #41

## 작업 목적

- 로컬 환경에서 두꺼비집 백엔드 API 명세를 Swagger UI와 OpenAPI JSON으로 확인할 수 있도록 한다.

## 작업 내역

- Springdoc OpenAPI Web MVC UI 의존성 추가
- Swagger UI와 OpenAPI JSON을 local 프로필에서만 활성화하고 기본 프로필에서는 비활성화
- 서비스 제목과 버전 메타데이터 설정
- 실제 HTTP 서버를 통한 문서 노출·비노출 통합 테스트 추가
- 로컬 API 문서 접근 주소 안내 추가

## 리뷰 포인트

- Springdoc은 두꺼비집의 inbound Controller API만 문서화하며 외부 공공데이터 outbound 호출은 자동으로 포함하지 않는다.
- Swagger UI와 OpenAPI JSON은 기본 설정에서 꺼지고 local 프로필에서만 켜진다.
- Springdoc 3.1.0은 Spring Boot 4.1.0 호환 버전이다.

## 검증 결과

- 테스트 방법: Java 25, TEST_POSTGRES_PORT=55433 환경에서 ./gradlew --no-daemon --rerun-tasks check
- 테스트 결과: 121개 전체 테스트 통과
- 테스트 방법: 저장소 하네스 검증 스크립트 전체 실행
- 테스트 결과: harness, commit message, PR 검증 통과
- 직접 확인: /v3/api-docs 200 application/json, /swagger-ui/index.html 200 text/html
- 기본 프로필 확인: 두 문서 경로 모두 404 통합 테스트 통과

## 참고 자료

- Springdoc 호환성 표: https://springdoc.org/faq.html