### PR TITLE
feat(frontend): 공통 레이아웃 및 지도 화면 구성 (#54)

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,3 +1,5 @@
+# 관리자 API 요청에 사용하는 브라우저 공개 기본 URL입니다.
+# 로컬 기본값은 아래 주소이며, 운영 빌드에서는 실제 API 주소가 반드시 필요합니다.
 VITE_API_BASE_URL=http://localhost:8080
 
 # NAVER Maps JavaScript SDK의 브라우저 공개 Client ID입니다.

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,1 +1,5 @@
 VITE_API_BASE_URL=http://localhost:8080
+
+# NAVER Maps JavaScript SDK의 브라우저 공개 Client ID입니다.
+# 값이 없으면 애플리케이션은 지도 설정이 준비되지 않았다는 안내를 표시합니다.
+VITE_NAVER_MAPS_CLIENT_ID=

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -30,19 +30,47 @@ npm ci
 
 ## 개발 서버 실행
 
-`frontend/.env.example`을 참고해 `frontend/.env`를 생성한다.
+`frontend/.env.example`을 참고해 Git이 추적하지 않는 `frontend/.env.local`을
+생성한다.
 
 ```shell
-Copy-Item .env.example .env
+cp .env.example .env.local
 ```
 
-로컬 기본값은 `http://localhost:8080`이다.
+NAVER Cloud Platform에서 로컬 Web 서비스 URL로 `http://localhost`를
+등록하고 브라우저용 Client ID를 입력한다.
+
+```dotenv
+VITE_API_BASE_URL=http://localhost:8080
+VITE_NAVER_MAPS_CLIENT_ID=발급받은_Client_ID
+```
+
+`VITE_*` 환경 변수는 빌드 결과와 브라우저에 공개된다. Client Secret이나 서버
+비밀값을 입력하지 않는다. 로컬에서 API 주소를 생략하면
+`http://localhost:8080`을 사용하고, 운영 빌드에서는 API 주소가 없으면 빌드가
+실패한다. Client ID가 없으면 빌드는 정상적으로 완료되지만 실행 화면에는 지도
+사용 불가 안내가 표시된다.
 
 ```shell
 npm run dev
 ```
 
 명령어가 출력하는 로컬 주소를 브라우저에서 열어 애플리케이션을 확인한다.
+
+## 환경별 지도 설정
+
+모든 환경은 `VITE_NAVER_MAPS_CLIENT_ID`라는 같은 변수명을 사용하고 환경별 빌드
+시점에 값을 주입한다.
+
+| 환경 | Client ID와 Web 서비스 URL |
+| --- | --- |
+| 로컬 | 비운영 Client ID, `http://localhost` |
+| 개발 | 비운영 Client ID, 실제 개발 프론트엔드 주소 |
+| 운영 | 별도 운영 Client ID, 실제 운영 프론트엔드 주소 |
+
+Vite는 환경 변수 값을 정적 빌드 결과에 포함하므로 개발과 운영은 각각 올바른
+값으로 빌드한다. 서버 실행 중 환경 변수만 바꾸거나 런타임 설정 파일을 별도로
+사용하지 않는다.
 
 ## 코드 검사
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,7 @@
         "@testing-library/dom": "10.4.1",
         "@testing-library/jest-dom": "7.0.1",
         "@testing-library/react": "16.3.2",
+        "@types/navermaps": "3.9.2",
         "@types/node": "24.13.3",
         "@types/react": "19.2.18",
         "@types/react-dom": "19.2.4",
@@ -1025,6 +1026,23 @@
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/navermaps": {
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@types/navermaps/-/navermaps-3.9.2.tgz",
+      "integrity": "sha512-pPO38MFRRY+2wka0VdG3U9RlwLEVBwJVYy50KtQzwxNdJVVfas8Qlv4USx3wxvly7GNX9Cew2qfjdKEmLoQPKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "24.13.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,6 +24,7 @@
     "@testing-library/dom": "10.4.1",
     "@testing-library/jest-dom": "7.0.1",
     "@testing-library/react": "16.3.2",
+    "@types/navermaps": "3.9.2",
     "@types/node": "24.13.3",
     "@types/react": "19.2.18",
     "@types/react-dom": "19.2.4",

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -27,7 +27,7 @@ describe('App', () => {
     expect(screen.getByRole('banner', { name: '서비스 헤더' })).toBeVisible()
     expect(screen.getByRole('link', { name: '두꺼비집 홈' })).toBeVisible()
     expect(
-      screen.getByRole('region', { name: '공공임대 지도' }),
+      screen.getByRole('region', { name: '공공임대주택 지도' }),
     ).toBeVisible()
     expect(screen.getByRole('alert')).toHaveTextContent(
       '지도 설정이 준비되지 않았습니다.',

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,8 +1,16 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { StrictMode } from 'react'
 import { MemoryRouter } from 'react-router'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import App from './App.tsx'
+
+beforeEach(() => {
+  vi.stubEnv('VITE_NAVER_MAPS_CLIENT_ID', '')
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
 
 describe('App', () => {
   afterEach(() => {
@@ -16,8 +24,14 @@ describe('App', () => {
       </MemoryRouter>,
     )
 
-    expect(screen.getByRole('heading', { name: '두꺼비집' })).toBeInTheDocument()
-    expect(screen.getByText('프론트엔드 개발 환경이 준비되었습니다.')).toBeVisible()
+    expect(screen.getByRole('banner', { name: '서비스 헤더' })).toBeVisible()
+    expect(screen.getByRole('link', { name: '두꺼비집 홈' })).toBeVisible()
+    expect(
+      screen.getByRole('region', { name: '공공임대 지도' }),
+    ).toBeVisible()
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      '지도 설정이 준비되지 않았습니다.',
+    )
   })
 
   it('존재하지 않는 경로에서 안내 화면을 표시한다', () => {
@@ -30,6 +44,10 @@ describe('App', () => {
     expect(
       screen.getByRole('heading', { name: '페이지를 찾을 수 없습니다.' }),
     ).toBeVisible()
+    expect(screen.getByRole('link', { name: '지도로 돌아가기' })).toHaveAttribute(
+      'href',
+      '/',
+    )
   })
 
   it('만료된 세션의 로그아웃 응답이 401이어도 로그인 상태를 지우고 다시 로그인한다', async () => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,24 +1,48 @@
-import { Route, Routes } from 'react-router'
+import { Link, Route, Routes } from 'react-router'
 import { AdminAuthProvider } from './admin/auth/AdminAuthProvider'
 import { AdminHome } from './admin/auth/AdminHome'
 import { AdminLayout } from './admin/auth/AdminLayout'
 import { LoginPage } from './admin/auth/LoginPage'
 import { RequireAdmin } from './admin/auth/RequireAdmin'
+import NaverMap from './maps/naver/NaverMap.tsx'
 
 function Home() {
   return (
-    <main>
-      <h1>두꺼비집</h1>
-      <p>프론트엔드 개발 환경이 준비되었습니다.</p>
-    </main>
+    <div className="app-shell">
+      <header className="service-header" aria-label="서비스 헤더">
+        <Link className="brand-link" to="/" aria-label="두꺼비집 홈">
+          <span className="brand-mark" aria-hidden="true">
+            <svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2.2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              focusable="false"
+            >
+              <path d="m4 10 8-6 8 6" />
+              <path d="M6.5 9.5V20h11V9.5" />
+              <path d="M10 20v-6h4v6" />
+            </svg>
+          </span>
+          <span className="brand-name">두꺼비집</span>
+          <span className="brand-tagline">공공임대 지도</span>
+        </Link>
+      </header>
+      <main className="map-main">
+        <NaverMap />
+      </main>
+    </div>
   )
 }
 
 function NotFound() {
   return (
-    <main>
+    <main className="not-found-main">
       <h1>페이지를 찾을 수 없습니다.</h1>
       <p>입력한 주소를 다시 확인해 주세요.</p>
+      <Link to="/">지도로 돌아가기</Link>
     </main>
   )
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -27,7 +27,7 @@ function Home() {
             </svg>
           </span>
           <span className="brand-name">두꺼비집</span>
-          <span className="brand-tagline">공공임대 지도</span>
+          <span className="brand-tagline">공공임대주택 지도</span>
         </Link>
       </header>
       <main className="map-main">

--- a/frontend/src/admin/auth/RequireAdmin.tsx
+++ b/frontend/src/admin/auth/RequireAdmin.tsx
@@ -5,10 +5,10 @@ export function RequireAdmin() {
   const { session, isLoading, error } = useAdminAuth()
 
   if (isLoading) {
-    return <main>관리자 인증 상태를 확인하고 있습니다.</main>
+    return <main className="admin-auth-state">관리자 인증 상태를 확인하고 있습니다.</main>
   }
   if (error) {
-    return <main>{error}</main>
+    return <main className="admin-auth-state">{error}</main>
   }
   if (!session) {
     return <Navigate to="/admin/login" replace />

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,38 +1,271 @@
 :root {
   font-family:
     Inter, Pretendard, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  color: #1f2937;
-  background: #f8fafc;
+  color: #17202a;
+  background: #eef4f3;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
+  --brand: #087f74;
+  --brand-dark: #06685f;
+  --border: #d7e1df;
+  --focus: #1d4ed8;
+  --muted: #52615f;
+  --surface: #ffffff;
 }
 
 * {
   box-sizing: border-box;
 }
 
-body {
+html,
+body,
+#root {
   min-width: 320px;
-  min-height: 100vh;
+  min-height: 100%;
   margin: 0;
 }
 
-main {
+button,
+a {
+  font: inherit;
+}
+
+.app-shell {
+  display: flex;
+  min-height: 100vh;
+  min-height: 100dvh;
+  flex-direction: column;
+  background: #eef4f3;
+}
+
+.service-header {
+  position: relative;
+  z-index: 10;
+  display: flex;
+  height: 56px;
+  flex: 0 0 56px;
+  align-items: center;
+  padding: 0 16px;
+  border-bottom: 1px solid var(--border);
+  background: rgb(255 255 255 / 98%);
+}
+
+.brand-link {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 8px;
+  color: inherit;
+  text-decoration: none;
+}
+
+.brand-link:focus-visible,
+.map-retry-button:focus-visible,
+.not-found-main a:focus-visible {
+  outline: 3px solid var(--focus);
+  outline-offset: 3px;
+}
+
+.brand-mark {
+  display: grid;
+  width: 34px;
+  height: 34px;
+  margin-right: 9px;
+  border-radius: 9px;
+  background: var(--brand);
+  color: #ffffff;
+  place-items: center;
+}
+
+.brand-mark svg {
+  width: 21px;
+  height: 21px;
+}
+
+.brand-name {
+  font-size: 18px;
+  font-weight: 750;
+  letter-spacing: -0.025em;
+}
+
+.brand-tagline {
+  margin-left: 8px;
+  padding-left: 8px;
+  border-left: 1px solid var(--border);
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.map-main {
+  display: flex;
+  min-width: 0;
+  min-height: 0;
+  flex: 1;
+}
+
+.map-region {
+  position: relative;
+  min-width: 0;
+  min-height: 0;
+  flex: 1;
+  overflow: hidden;
+  background: #dfeae8;
+}
+
+.map-surface {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.map-surface[aria-hidden='true'] {
+  pointer-events: none;
+}
+
+.map-state-layer {
+  position: absolute;
+  z-index: 2;
+  inset: 0;
+  display: grid;
+  padding: 24px;
+  background:
+    linear-gradient(rgb(238 246 245 / 88%), rgb(238 246 245 / 88%)),
+    radial-gradient(circle at 30% 30%, #d4e5e2, #edf4f3 70%);
+  place-items: center;
+}
+
+.map-state-card {
+  display: flex;
+  width: min(100%, 420px);
+  align-items: center;
+  padding: 28px;
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  background: var(--surface);
+  box-shadow: 0 16px 40px rgb(20 57 52 / 10%);
+  color: var(--muted);
+  text-align: center;
+  flex-direction: column;
+}
+
+.map-state-card strong {
+  margin-top: 14px;
+  color: #17202a;
+  font-size: 18px;
+  line-height: 1.45;
+}
+
+.map-state-card > span:last-of-type {
+  margin-top: 7px;
+  line-height: 1.6;
+}
+
+.map-loading-indicator {
+  width: 30px;
+  height: 30px;
+  border: 3px solid #c9dcda;
+  border-top-color: var(--brand);
+  border-radius: 50%;
+  animation: map-loading-spin 0.8s linear infinite;
+}
+
+.map-error-mark {
+  display: grid;
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  background: #fff0ed;
+  color: #b42318;
+  font-size: 20px;
+  font-weight: 800;
+  place-items: center;
+}
+
+.map-retry-button {
+  min-height: 44px;
+  margin-top: 20px;
+  padding: 0 20px;
+  border: 0;
+  border-radius: 9px;
+  background: var(--brand);
+  color: #ffffff;
+  cursor: pointer;
+  font-weight: 700;
+}
+
+.map-retry-button:hover {
+  background: var(--brand-dark);
+}
+
+.not-found-main {
   display: grid;
   min-height: 100vh;
+  min-height: 100dvh;
   padding: 24px;
+  background: #f8fafc;
   text-align: center;
   place-content: center;
 }
 
-h1,
-p {
+.not-found-main h1,
+.not-found-main p {
   margin: 0;
 }
 
-p {
+.not-found-main p {
   margin-top: 12px;
-  color: #475569;
+  color: var(--muted);
+}
+
+.not-found-main a {
+  justify-self: center;
+  margin-top: 24px;
+  border-radius: 6px;
+  color: var(--brand-dark);
+  font-weight: 700;
+  text-underline-offset: 4px;
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@keyframes map-loading-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (max-width: 420px) {
+  .service-header {
+    padding: 0 12px;
+  }
+
+  .brand-tagline {
+    font-size: 12px;
+  }
+
+  .map-state-layer {
+    padding: 16px;
+  }
+
+  .map-state-card {
+    padding: 24px 20px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .map-loading-indicator {
+    animation: none;
+  }
 }
 
 button,

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -279,7 +279,18 @@ button {
 
 .admin-login-page {
   display: grid;
+  min-height: 100vh;
+  min-height: 100dvh;
   padding: 24px;
+  place-content: center;
+}
+
+.admin-auth-state {
+  display: grid;
+  min-height: 100vh;
+  min-height: 100dvh;
+  padding: 24px;
+  text-align: center;
   place-content: center;
 }
 
@@ -327,6 +338,7 @@ button {
 
 .admin-layout {
   min-height: 100vh;
+  min-height: 100dvh;
 }
 
 .admin-header {
@@ -353,6 +365,16 @@ button {
   min-height: auto;
   padding: 32px 24px;
   text-align: left;
+}
+
+.admin-content h1,
+.admin-content p {
+  margin: 0;
+}
+
+.admin-content p {
+  margin-top: 12px;
+  color: #475569;
 }
 
 .admin-layout-error {

--- a/frontend/src/maps/naver/NaverMap.test.tsx
+++ b/frontend/src/maps/naver/NaverMap.test.tsx
@@ -123,7 +123,7 @@ describe('NaverMap', () => {
       '지도를 불러오고 있습니다.',
     )
     expect(
-      screen.getByRole('region', { name: '공공임대 지도' }),
+      screen.getByRole('region', { name: '공공임대주택 지도' }),
     ).toHaveAttribute('aria-busy', 'true')
   })
 
@@ -163,7 +163,7 @@ describe('NaverMap', () => {
     )
     expect(screen.queryByRole('status')).not.toBeInTheDocument()
     expect(
-      screen.getByRole('region', { name: '공공임대 지도' }),
+      screen.getByRole('region', { name: '공공임대주택 지도' }),
     ).toHaveAttribute('aria-busy', 'false')
     expect(observe).toHaveBeenCalledOnce()
 

--- a/frontend/src/maps/naver/NaverMap.test.tsx
+++ b/frontend/src/maps/naver/NaverMap.test.tsx
@@ -1,0 +1,315 @@
+import { StrictMode } from 'react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import NaverMap from './NaverMap.tsx'
+import {
+  loadNaverMapsSdk,
+  NaverMapsSdkError,
+  subscribeToNaverMapsAuthenticationFailure,
+} from './loadNaverMapsSdk.ts'
+
+vi.mock('./loadNaverMapsSdk.ts', async () => {
+  const actual = await vi.importActual<
+    typeof import('./loadNaverMapsSdk.ts')
+  >('./loadNaverMapsSdk.ts')
+
+  return {
+    ...actual,
+    loadNaverMapsSdk: vi.fn(),
+    subscribeToNaverMapsAuthenticationFailure: vi.fn(),
+  }
+})
+
+interface FakeSdk {
+  autoResizeMap: ReturnType<typeof vi.fn>
+  destroyMap: ReturnType<typeof vi.fn>
+  latLngConstructor: ReturnType<typeof vi.fn>
+  mapConstructor: ReturnType<typeof vi.fn>
+  maps: typeof naver.maps
+}
+
+function createFakeSdk(): FakeSdk {
+  const destroyMap = vi.fn()
+  const autoResizeMap = vi.fn()
+  const mapInstance = {
+    autoResize: autoResizeMap,
+    destroy: destroyMap,
+  }
+  const mapConstructor = vi.fn(function FakeMapConstructor(
+    _element: string | HTMLElement,
+    _options?: naver.maps.MapOptions,
+  ) {
+    return mapInstance
+  })
+  const latLngConstructor = vi.fn(function FakeLatLngConstructor(
+    latitude: number,
+    longitude: number,
+  ) {
+    return { latitude, longitude }
+  })
+
+  return {
+    autoResizeMap,
+    destroyMap,
+    latLngConstructor,
+    mapConstructor,
+    maps: {
+      LatLng: latLngConstructor,
+      Map: mapConstructor,
+    } as unknown as typeof naver.maps,
+  }
+}
+
+function createDeferred<T>() {
+  let resolvePromise: (value: T) => void = () => {
+    throw new Error('Promise resolve 함수가 준비되지 않았습니다.')
+  }
+
+  const promise = new Promise<T>((resolve) => {
+    resolvePromise = resolve
+  })
+
+  return { promise, resolve: resolvePromise }
+}
+
+const loadNaverMapsSdkMock = vi.mocked(loadNaverMapsSdk)
+const subscribeToAuthenticationFailureMock = vi.mocked(
+  subscribeToNaverMapsAuthenticationFailure,
+)
+let authenticationFailureListener:
+  | ((error: NaverMapsSdkError) => void)
+  | null = null
+const unsubscribeAuthenticationFailure = vi.fn()
+
+beforeEach(() => {
+  loadNaverMapsSdkMock.mockReset()
+  subscribeToAuthenticationFailureMock.mockReset()
+  unsubscribeAuthenticationFailure.mockReset()
+  authenticationFailureListener = null
+  subscribeToAuthenticationFailureMock.mockImplementation((listener) => {
+    authenticationFailureListener = listener
+    return unsubscribeAuthenticationFailure
+  })
+  vi.stubEnv('VITE_NAVER_MAPS_CLIENT_ID', 'sample-client-id')
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  vi.unstubAllGlobals()
+})
+
+describe('NaverMap', () => {
+  it('Client ID가 없으면 SDK를 요청하지 않고 설정 안내를 표시한다', async () => {
+    vi.stubEnv('VITE_NAVER_MAPS_CLIENT_ID', '   ')
+
+    render(<NaverMap />)
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      '지도 설정이 준비되지 않았습니다.',
+    )
+    expect(loadNaverMapsSdkMock).not.toHaveBeenCalled()
+    expect(
+      screen.queryByRole('button', { name: '다시 시도' }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('SDK가 준비되는 동안 로딩 상태를 표시한다', () => {
+    const deferred = createDeferred<typeof naver.maps>()
+    loadNaverMapsSdkMock.mockReturnValue(deferred.promise)
+
+    render(<NaverMap />)
+
+    expect(screen.getByRole('status')).toHaveTextContent(
+      '지도를 불러오고 있습니다.',
+    )
+    expect(
+      screen.getByRole('region', { name: '공공임대 지도' }),
+    ).toHaveAttribute('aria-busy', 'true')
+  })
+
+  it('GL 지도 옵션으로 초기화하고 unmount에서 지도 인스턴스를 해제한다', async () => {
+    const fakeSdk = createFakeSdk()
+    const observe = vi.fn()
+    const disconnect = vi.fn()
+    let resizeCallback: ResizeObserverCallback = () => undefined
+
+    class FakeResizeObserver {
+      constructor(callback: ResizeObserverCallback) {
+        resizeCallback = callback
+      }
+
+      observe = observe
+      disconnect = disconnect
+    }
+
+    vi.stubGlobal('ResizeObserver', FakeResizeObserver)
+    loadNaverMapsSdkMock.mockResolvedValue(fakeSdk.maps)
+
+    const { unmount } = render(<NaverMap />)
+
+    await waitFor(() => expect(fakeSdk.mapConstructor).toHaveBeenCalledOnce())
+
+    expect(fakeSdk.latLngConstructor).toHaveBeenCalledWith(
+      37.5666103,
+      126.9783882,
+    )
+    expect(fakeSdk.mapConstructor.mock.calls[0]?.[1]).toEqual(
+      expect.objectContaining({
+        gl: true,
+        keyboardShortcuts: true,
+        zoom: 14,
+        zoomControl: true,
+      }),
+    )
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+    expect(
+      screen.getByRole('region', { name: '공공임대 지도' }),
+    ).toHaveAttribute('aria-busy', 'false')
+    expect(observe).toHaveBeenCalledOnce()
+
+    resizeCallback([], {} as ResizeObserver)
+
+    expect(fakeSdk.autoResizeMap).toHaveBeenCalledOnce()
+
+    unmount()
+
+    expect(disconnect).toHaveBeenCalledOnce()
+    expect(fakeSdk.destroyMap).toHaveBeenCalledOnce()
+  })
+
+  it('인증 실패에는 재시도 없이 설정 확인을 안내한다', async () => {
+    loadNaverMapsSdkMock.mockRejectedValue(
+      new NaverMapsSdkError(
+        'authentication',
+        'NAVER Maps SDK 인증에 실패했습니다.',
+      ),
+    )
+
+    render(<NaverMap />)
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      '지도 인증에 실패했습니다.',
+    )
+    expect(
+      screen.queryByRole('button', { name: '다시 시도' }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('지도 생성 뒤 인증이 실패하면 지도를 해제하고 오류를 표시한다', async () => {
+    const fakeSdk = createFakeSdk()
+    fakeSdk.destroyMap.mockImplementationOnce(() => {
+      throw new Error('NAVER SDK가 이미 지도를 해제했습니다.')
+    })
+    loadNaverMapsSdkMock.mockResolvedValue(fakeSdk.maps)
+
+    render(<NaverMap />)
+    await waitFor(() => expect(fakeSdk.mapConstructor).toHaveBeenCalledOnce())
+
+    act(() => {
+      authenticationFailureListener?.(
+        new NaverMapsSdkError(
+          'authentication',
+          'NAVER Maps SDK 인증에 실패했습니다.',
+        ),
+      )
+    })
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      '지도 인증에 실패했습니다.',
+    )
+    expect(fakeSdk.destroyMap).toHaveBeenCalledOnce()
+  })
+
+  it('네트워크 실패 후 다시 시도하면 지도를 표시한다', async () => {
+    const fakeSdk = createFakeSdk()
+    loadNaverMapsSdkMock
+      .mockRejectedValueOnce(
+        new NaverMapsSdkError(
+          'network',
+          'NAVER Maps SDK를 내려받지 못했습니다.',
+        ),
+      )
+      .mockResolvedValueOnce(fakeSdk.maps)
+
+    render(<NaverMap />)
+
+    const retryButton = await screen.findByRole('button', {
+      name: '다시 시도',
+    })
+    fireEvent.click(retryButton)
+
+    expect(screen.getByRole('status')).toHaveTextContent(
+      '지도를 불러오고 있습니다.',
+    )
+    await waitFor(() => expect(fakeSdk.mapConstructor).toHaveBeenCalledOnce())
+    expect(loadNaverMapsSdkMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('지도 생성 실패 후 SDK를 재사용해 다시 초기화한다', async () => {
+    const fakeSdk = createFakeSdk()
+    fakeSdk.mapConstructor.mockImplementationOnce(() => {
+      throw new Error('지도 생성 실패')
+    })
+    loadNaverMapsSdkMock.mockResolvedValue(fakeSdk.maps)
+
+    render(<NaverMap />)
+
+    const alert = await screen.findByRole('alert')
+    expect(alert).toHaveTextContent('지도를 표시하지 못했습니다.')
+
+    fireEvent.click(screen.getByRole('button', { name: '다시 시도' }))
+
+    await waitFor(() =>
+      expect(fakeSdk.mapConstructor).toHaveBeenCalledTimes(2),
+    )
+    expect(loadNaverMapsSdkMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('반응형 관찰자 생성 실패 시 만들어진 지도를 즉시 해제한다', async () => {
+    const fakeSdk = createFakeSdk()
+
+    class FailingResizeObserver {
+      constructor() {
+        throw new Error('ResizeObserver 생성 실패')
+      }
+    }
+
+    vi.stubGlobal('ResizeObserver', FailingResizeObserver)
+    loadNaverMapsSdkMock.mockResolvedValue(fakeSdk.maps)
+
+    render(<NaverMap />)
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      '지도를 표시하지 못했습니다.',
+    )
+    expect(fakeSdk.destroyMap).toHaveBeenCalledOnce()
+  })
+
+  it('준비되기 전에 unmount되면 늦은 응답으로 지도를 만들지 않는다', async () => {
+    const fakeSdk = createFakeSdk()
+    const deferred = createDeferred<typeof naver.maps>()
+    loadNaverMapsSdkMock.mockReturnValue(deferred.promise)
+    const { unmount } = render(<NaverMap />)
+
+    unmount()
+    await act(async () => deferred.resolve(fakeSdk.maps))
+
+    expect(fakeSdk.mapConstructor).not.toHaveBeenCalled()
+  })
+
+  it('StrictMode 재실행에서도 생성한 지도를 한 번 해제한다', async () => {
+    const fakeSdk = createFakeSdk()
+    loadNaverMapsSdkMock.mockResolvedValue(fakeSdk.maps)
+
+    const { unmount } = render(
+      <StrictMode>
+        <NaverMap />
+      </StrictMode>,
+    )
+
+    await waitFor(() => expect(fakeSdk.mapConstructor).toHaveBeenCalledOnce())
+    unmount()
+
+    expect(fakeSdk.destroyMap).toHaveBeenCalledOnce()
+  })
+})

--- a/frontend/src/maps/naver/NaverMap.tsx
+++ b/frontend/src/maps/naver/NaverMap.tsx
@@ -1,0 +1,223 @@
+import { useEffect, useRef, useState } from 'react'
+import {
+  loadNaverMapsSdk,
+  NaverMapsSdkError,
+  subscribeToNaverMapsAuthenticationFailure,
+  type NaverMapsSdkErrorCode,
+} from './loadNaverMapsSdk.ts'
+
+type MapFailureReason = NaverMapsSdkErrorCode | 'configuration' | 'initialization'
+
+type MapStatus =
+  | { kind: 'loading' }
+  | { kind: 'ready' }
+  | { kind: 'unavailable'; reason: MapFailureReason }
+
+interface FailureContent {
+  description: string
+  retryable: boolean
+  title: string
+}
+
+const INITIAL_CENTER = {
+  latitude: 37.5666103,
+  longitude: 126.9783882,
+}
+
+const FAILURE_CONTENT: Record<MapFailureReason, FailureContent> = {
+  configuration: {
+    title: '지도 설정이 준비되지 않았습니다.',
+    description: '현재 환경의 NAVER Maps Client ID를 확인해 주세요.',
+    retryable: false,
+  },
+  authentication: {
+    title: '지도 인증에 실패했습니다.',
+    description:
+      'Client ID와 현재 주소의 Web 서비스 URL 설정을 확인한 후 새로고침해 주세요.',
+    retryable: false,
+  },
+  network: {
+    title: '지도를 불러오지 못했습니다.',
+    description: '네트워크 연결을 확인한 뒤 다시 시도해 주세요.',
+    retryable: true,
+  },
+  'invalid-sdk': {
+    title: '지도 SDK를 초기화하지 못했습니다.',
+    description: '잠시 후 다시 시도해 주세요.',
+    retryable: true,
+  },
+  initialization: {
+    title: '지도를 표시하지 못했습니다.',
+    description: '잠시 후 다시 시도해 주세요.',
+    retryable: true,
+  },
+}
+
+function toFailureReason(error: unknown): MapFailureReason {
+  if (error instanceof NaverMapsSdkError) {
+    return error.code
+  }
+
+  return 'invalid-sdk'
+}
+
+function destroyMapSafely(mapInstance: naver.maps.Map | null) {
+  try {
+    mapInstance?.destroy()
+  } catch {
+    // 인증 실패 시 NAVER SDK가 지도 객체를 먼저 무효화할 수 있습니다.
+  }
+}
+
+function MapLoading() {
+  return (
+    <div className="map-state-layer">
+      <div className="map-state-card" role="status" aria-live="polite">
+        <span className="map-loading-indicator" aria-hidden="true" />
+        <strong>지도를 불러오고 있습니다.</strong>
+        <span>잠시만 기다려 주세요.</span>
+      </div>
+    </div>
+  )
+}
+
+interface MapUnavailableProps {
+  onRetry: () => void
+  reason: MapFailureReason
+}
+
+function MapUnavailable({ onRetry, reason }: MapUnavailableProps) {
+  const content = FAILURE_CONTENT[reason]
+
+  return (
+    <div className="map-state-layer">
+      <div className="map-state-card map-state-card--error" role="alert">
+        <span className="map-error-mark" aria-hidden="true">
+          !
+        </span>
+        <strong>{content.title}</strong>
+        <span>{content.description}</span>
+        {content.retryable && (
+          <button className="map-retry-button" type="button" onClick={onRetry}>
+            다시 시도
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default function NaverMap() {
+  const mapContainerRef = useRef<HTMLDivElement>(null)
+  const [attempt, setAttempt] = useState(0)
+  const [status, setStatus] = useState<MapStatus>({ kind: 'loading' })
+
+  useEffect(() => {
+    const clientId = import.meta.env.VITE_NAVER_MAPS_CLIENT_ID?.trim() ?? ''
+
+    if (!clientId) {
+      setStatus({ kind: 'unavailable', reason: 'configuration' })
+      return
+    }
+
+    let cancelled = false
+    let mapInstance: naver.maps.Map | null = null
+    let resizeObserver: ResizeObserver | null = null
+    setStatus({ kind: 'loading' })
+
+    const handleAuthenticationFailure = () => {
+      if (cancelled) {
+        return
+      }
+
+      resizeObserver?.disconnect()
+      resizeObserver = null
+      const failedMap = mapInstance
+      mapInstance = null
+      setStatus({ kind: 'unavailable', reason: 'authentication' })
+      destroyMapSafely(failedMap)
+    }
+    const unsubscribeAuthenticationFailure =
+      subscribeToNaverMapsAuthenticationFailure(handleAuthenticationFailure)
+
+    loadNaverMapsSdk(clientId)
+      .then((maps) => {
+        if (cancelled || !mapContainerRef.current) {
+          return
+        }
+
+        try {
+          mapInstance = new maps.Map(mapContainerRef.current, {
+            center: new maps.LatLng(
+              INITIAL_CENTER.latitude,
+              INITIAL_CENTER.longitude,
+            ),
+            gl: true,
+            keyboardShortcuts: true,
+            zoom: 14,
+            zoomControl: true,
+          })
+
+          if (typeof ResizeObserver === 'function') {
+            resizeObserver = new ResizeObserver(() => mapInstance?.autoResize())
+            resizeObserver.observe(mapContainerRef.current)
+          }
+
+          setStatus({ kind: 'ready' })
+        } catch {
+          resizeObserver?.disconnect()
+          resizeObserver = null
+          const failedMap = mapInstance
+          mapInstance = null
+          setStatus({ kind: 'unavailable', reason: 'initialization' })
+          destroyMapSafely(failedMap)
+        }
+      })
+      .catch((error: unknown) => {
+        if (!cancelled) {
+          setStatus({ kind: 'unavailable', reason: toFailureReason(error) })
+        }
+      })
+
+    return () => {
+      cancelled = true
+      unsubscribeAuthenticationFailure()
+      resizeObserver?.disconnect()
+      destroyMapSafely(mapInstance)
+    }
+  }, [attempt])
+
+  const retry = () => {
+    setStatus({ kind: 'loading' })
+    setAttempt((currentAttempt) => currentAttempt + 1)
+  }
+
+  const isLoading = status.kind === 'loading'
+  const isReady = status.kind === 'ready'
+
+  return (
+    <section
+      className="map-region"
+      aria-labelledby="map-title"
+      aria-describedby="map-description"
+      aria-busy={isLoading}
+    >
+      <h1 className="visually-hidden" id="map-title">
+        공공임대 지도
+      </h1>
+      <p className="visually-hidden" id="map-description">
+        서울시청을 중심으로 지도를 표시합니다. 실제 주택 데이터는 아직 표시하지
+        않습니다.
+      </p>
+      <div
+        className="map-surface"
+        ref={mapContainerRef}
+        aria-hidden={!isReady}
+      />
+      {isLoading && <MapLoading />}
+      {status.kind === 'unavailable' && (
+        <MapUnavailable reason={status.reason} onRetry={retry} />
+      )}
+    </section>
+  )
+}

--- a/frontend/src/maps/naver/NaverMap.tsx
+++ b/frontend/src/maps/naver/NaverMap.tsx
@@ -203,7 +203,7 @@ export default function NaverMap() {
       aria-busy={isLoading}
     >
       <h1 className="visually-hidden" id="map-title">
-        공공임대 지도
+        공공임대주택 지도
       </h1>
       <p className="visually-hidden" id="map-description">
         서울시청을 중심으로 지도를 표시합니다. 실제 주택 데이터는 아직 표시하지

--- a/frontend/src/maps/naver/loadNaverMapsSdk.test.ts
+++ b/frontend/src/maps/naver/loadNaverMapsSdk.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const SCRIPT_SELECTOR = 'script[data-toadzip-naver-maps-sdk]'
+
+function createFakeMaps(): typeof naver.maps {
+  class FakeMap {}
+  class FakeLatLng {}
+
+  return {
+    Map: FakeMap,
+    LatLng: FakeLatLng,
+  } as unknown as typeof naver.maps
+}
+
+function installFakeMaps(): typeof naver.maps {
+  const maps = createFakeMaps()
+  Reflect.set(window, 'naver', { maps })
+  return maps
+}
+
+function getSdkScript(): HTMLScriptElement {
+  const script = document.querySelector<HTMLScriptElement>(SCRIPT_SELECTOR)
+
+  if (!script) {
+    throw new Error('NAVER Maps SDK 스크립트를 찾을 수 없습니다.')
+  }
+
+  return script
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  document.querySelectorAll(SCRIPT_SELECTOR).forEach((script) => script.remove())
+  Reflect.deleteProperty(window, 'naver')
+  delete window.__toadzipNaverMapsReady
+  delete window.navermap_authFailure
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  document.querySelectorAll(SCRIPT_SELECTOR).forEach((script) => script.remove())
+  Reflect.deleteProperty(window, 'naver')
+  delete window.__toadzipNaverMapsReady
+  delete window.navermap_authFailure
+})
+
+describe('loadNaverMapsSdk', () => {
+  it('동시 요청에서 GL SDK 스크립트를 한 번만 추가한다', async () => {
+    const { loadNaverMapsSdk } = await import('./loadNaverMapsSdk.ts')
+
+    const firstLoad = loadNaverMapsSdk('sample client id')
+    const secondLoad = loadNaverMapsSdk('sample client id')
+    const script = getSdkScript()
+    const scriptUrl = new URL(script.src)
+
+    expect(firstLoad).toBe(secondLoad)
+    expect(document.querySelectorAll(SCRIPT_SELECTOR)).toHaveLength(1)
+    expect(scriptUrl.origin).toBe('https://oapi.map.naver.com')
+    expect(scriptUrl.pathname).toBe('/openapi/v3/maps.js')
+    expect(scriptUrl.searchParams.get('ncpKeyId')).toBe('sample client id')
+    expect(scriptUrl.searchParams.get('submodules')).toBe('gl')
+    expect(scriptUrl.searchParams.get('callback')).toBe(
+      '__toadzipNaverMapsReady',
+    )
+
+    const maps = installFakeMaps()
+    window.__toadzipNaverMapsReady?.()
+
+    await expect(firstLoad).resolves.toBe(maps)
+    await expect(secondLoad).resolves.toBe(maps)
+  })
+
+  it('이미 준비된 SDK가 있으면 스크립트를 추가하지 않는다', async () => {
+    const maps = installFakeMaps()
+    const { loadNaverMapsSdk } = await import('./loadNaverMapsSdk.ts')
+
+    await expect(loadNaverMapsSdk('sample-client-id')).resolves.toBe(maps)
+    expect(document.querySelector(SCRIPT_SELECTOR)).not.toBeInTheDocument()
+  })
+
+  it('인증 실패를 비재시도 오류로 유지한다', async () => {
+    const { loadNaverMapsSdk, subscribeToNaverMapsAuthenticationFailure } =
+      await import('./loadNaverMapsSdk.ts')
+    const authenticationFailureListener = vi.fn()
+    subscribeToNaverMapsAuthenticationFailure(authenticationFailureListener)
+    const firstLoad = loadNaverMapsSdk('invalid-client-id')
+    installFakeMaps()
+    window.__toadzipNaverMapsReady?.()
+    delete window.navermap_authFailure
+    await Promise.resolve()
+
+    await expect(firstLoad).resolves.toBeDefined()
+    const authenticationFailureCallback: unknown = Reflect.get(
+      window,
+      'navermap_authFailure',
+    )
+    expect(authenticationFailureCallback).toBeTypeOf('function')
+
+    if (typeof authenticationFailureCallback !== 'function') {
+      throw new Error('NAVER Maps 인증 실패 callback을 찾을 수 없습니다.')
+    }
+
+    authenticationFailureCallback()
+
+    expect(authenticationFailureListener).toHaveBeenCalledWith(
+      expect.objectContaining({ code: 'authentication' }),
+    )
+    await expect(loadNaverMapsSdk('invalid-client-id')).rejects.toMatchObject({
+      code: 'authentication',
+    })
+    expect(document.querySelectorAll(SCRIPT_SELECTOR)).toHaveLength(1)
+  })
+
+  it('script load 이벤트만으로는 GL SDK 준비가 완료되지 않는다', async () => {
+    const { loadNaverMapsSdk } = await import('./loadNaverMapsSdk.ts')
+    const sdkLoad = loadNaverMapsSdk('sample-client-id')
+    const script = getSdkScript()
+    const loadSettled = vi.fn()
+    sdkLoad.then(loadSettled, loadSettled)
+    installFakeMaps()
+
+    script.dispatchEvent(new Event('load'))
+    await Promise.resolve()
+
+    expect(loadSettled).not.toHaveBeenCalled()
+
+    window.__toadzipNaverMapsReady?.()
+
+    await expect(sdkLoad).resolves.toBeDefined()
+  })
+
+  it('네트워크 실패 스크립트를 제거하고 다음 호출에서 다시 시도한다', async () => {
+    const { loadNaverMapsSdk } = await import('./loadNaverMapsSdk.ts')
+    const firstLoad = loadNaverMapsSdk('sample-client-id')
+    const failedScript = getSdkScript()
+
+    failedScript.dispatchEvent(new Event('error'))
+
+    await expect(firstLoad).rejects.toMatchObject({ code: 'network' })
+    expect(failedScript.isConnected).toBe(false)
+
+    const retryLoad = loadNaverMapsSdk('sample-client-id')
+    const retryScript = getSdkScript()
+
+    expect(retryScript).not.toBe(failedScript)
+
+    const maps = installFakeMaps()
+    window.__toadzipNaverMapsReady?.()
+
+    await expect(retryLoad).resolves.toBe(maps)
+  })
+
+  it('준비 callback 이후 SDK가 없으면 재시도 가능한 오류로 처리한다', async () => {
+    const { loadNaverMapsSdk } = await import('./loadNaverMapsSdk.ts')
+    const sdkLoad = loadNaverMapsSdk('sample-client-id')
+    const failedScript = getSdkScript()
+
+    window.__toadzipNaverMapsReady?.()
+
+    await expect(sdkLoad).rejects.toMatchObject({ code: 'invalid-sdk' })
+    expect(failedScript.isConnected).toBe(false)
+    expect(document.querySelector(SCRIPT_SELECTOR)).not.toBeInTheDocument()
+  })
+
+  it('준비 callback이 오지 않으면 대기를 끝내고 재시도를 허용한다', async () => {
+    vi.useFakeTimers()
+    const { loadNaverMapsSdk } = await import('./loadNaverMapsSdk.ts')
+    const sdkLoad = loadNaverMapsSdk('sample-client-id')
+    const failedScript = getSdkScript()
+    const rejection = expect(sdkLoad).rejects.toMatchObject({ code: 'network' })
+
+    await vi.advanceTimersByTimeAsync(15_000)
+
+    await rejection
+    expect(failedScript.isConnected).toBe(false)
+
+    const retryLoad = loadNaverMapsSdk('sample-client-id')
+
+    expect(getSdkScript()).not.toBe(failedScript)
+
+    const maps = installFakeMaps()
+    window.__toadzipNaverMapsReady?.()
+
+    await expect(retryLoad).resolves.toBe(maps)
+  })
+})

--- a/frontend/src/maps/naver/loadNaverMapsSdk.ts
+++ b/frontend/src/maps/naver/loadNaverMapsSdk.ts
@@ -1,0 +1,259 @@
+const NAVER_MAPS_CALLBACK_NAME = '__toadzipNaverMapsReady'
+const NAVER_MAPS_LOAD_TIMEOUT_MS = 15_000
+const NAVER_MAPS_SCRIPT_ATTRIBUTE = 'data-toadzip-naver-maps-sdk'
+const NAVER_MAPS_SCRIPT_URL = 'https://oapi.map.naver.com/openapi/v3/maps.js'
+const retiredReadyCallback = () => undefined
+
+export type NaverMapsSdkErrorCode =
+  | 'network'
+  | 'authentication'
+  | 'invalid-sdk'
+
+export class NaverMapsSdkError extends Error {
+  readonly code: NaverMapsSdkErrorCode
+
+  constructor(code: NaverMapsSdkErrorCode, message: string) {
+    super(message)
+    this.name = 'NaverMapsSdkError'
+    this.code = code
+  }
+}
+
+let sdkPromise: Promise<typeof naver.maps> | null = null
+let authenticationError: NaverMapsSdkError | null = null
+let previousAuthenticationCallback: (() => void) | undefined
+let pendingAuthenticationFailure:
+  | ((error: NaverMapsSdkError) => void)
+  | null = null
+const authenticationFailureListeners = new Set<
+  (error: NaverMapsSdkError) => void
+>()
+
+function handleAuthenticationFailure() {
+  const error = new NaverMapsSdkError(
+    'authentication',
+    'NAVER Maps SDK 인증에 실패했습니다.',
+  )
+  authenticationError = error
+  authenticationFailureListeners.forEach((listener) => listener(error))
+  pendingAuthenticationFailure?.(error)
+  previousAuthenticationCallback?.()
+}
+
+function ensureAuthenticationCallback() {
+  const currentCallback = window.navermap_authFailure
+
+  if (currentCallback === handleAuthenticationFailure) {
+    return
+  }
+
+  if (currentCallback) {
+    previousAuthenticationCallback = currentCallback
+  }
+
+  window.navermap_authFailure = handleAuthenticationFailure
+}
+
+export function subscribeToNaverMapsAuthenticationFailure(
+  listener: (error: NaverMapsSdkError) => void,
+): () => void {
+  authenticationFailureListeners.add(listener)
+
+  if (authenticationError) {
+    listener(authenticationError)
+  }
+
+  return () => authenticationFailureListeners.delete(listener)
+}
+
+function getReadyNaverMaps(): typeof naver.maps | null {
+  const naverCandidate: unknown = Reflect.get(window, 'naver')
+
+  if (typeof naverCandidate !== 'object' || naverCandidate === null) {
+    return null
+  }
+
+  const mapsCandidate: unknown = Reflect.get(naverCandidate, 'maps')
+
+  if (typeof mapsCandidate !== 'object' || mapsCandidate === null) {
+    return null
+  }
+
+  const mapConstructor: unknown = Reflect.get(mapsCandidate, 'Map')
+  const latLngConstructor: unknown = Reflect.get(mapsCandidate, 'LatLng')
+
+  if (
+    typeof mapConstructor !== 'function' ||
+    typeof latLngConstructor !== 'function'
+  ) {
+    return null
+  }
+
+  return mapsCandidate as typeof naver.maps
+}
+
+function createScript(clientId: string): HTMLScriptElement {
+  const url = new URL(NAVER_MAPS_SCRIPT_URL)
+  url.searchParams.set('ncpKeyId', clientId)
+  url.searchParams.set('submodules', 'gl')
+  url.searchParams.set('callback', NAVER_MAPS_CALLBACK_NAME)
+
+  const script = document.createElement('script')
+  script.src = url.toString()
+  script.async = true
+  script.setAttribute(NAVER_MAPS_SCRIPT_ATTRIBUTE, '')
+  return script
+}
+
+function findExistingScript(): HTMLScriptElement | null {
+  return document.querySelector<HTMLScriptElement>(
+    `script[${NAVER_MAPS_SCRIPT_ATTRIBUTE}]`,
+  )
+}
+
+function loadScript(clientId: string): Promise<typeof naver.maps> {
+  const existingScript = findExistingScript()
+  const script = existingScript ?? createScript(clientId)
+  const shouldAppendScript = existingScript === null
+
+  return new Promise((resolve, reject) => {
+    let settled = false
+    let timeoutId: number | null = null
+    const currentReadyCallback = window.__toadzipNaverMapsReady
+    const previousReadyCallback =
+      currentReadyCallback === retiredReadyCallback
+        ? undefined
+        : currentReadyCallback
+
+    const restoreReadyCallback = () => {
+      if (window.__toadzipNaverMapsReady === handleReady) {
+        if (previousReadyCallback) {
+          window.__toadzipNaverMapsReady = previousReadyCallback
+        } else {
+          window.__toadzipNaverMapsReady = retiredReadyCallback
+        }
+      }
+    }
+
+    const clearLoadTimeout = () => {
+      if (timeoutId !== null) {
+        window.clearTimeout(timeoutId)
+        timeoutId = null
+      }
+    }
+
+    const removeScriptListeners = () => {
+      script.removeEventListener('error', handleNetworkFailure)
+    }
+
+    const handlePendingAuthenticationFailure = (error: NaverMapsSdkError) => {
+      fail(error, false)
+    }
+
+    const clearPendingAuthenticationFailure = () => {
+      if (pendingAuthenticationFailure === handlePendingAuthenticationFailure) {
+        pendingAuthenticationFailure = null
+      }
+    }
+
+    const fail = (error: NaverMapsSdkError, retryable: boolean) => {
+      if (settled) {
+        return
+      }
+
+      settled = true
+      clearLoadTimeout()
+      restoreReadyCallback()
+      clearPendingAuthenticationFailure()
+      removeScriptListeners()
+      sdkPromise = null
+
+      if (retryable) {
+        script.remove()
+      }
+
+      reject(error)
+    }
+
+    function handleReady() {
+      if (settled) {
+        return
+      }
+
+      const maps = getReadyNaverMaps()
+
+      if (!maps) {
+        fail(
+          new NaverMapsSdkError(
+            'invalid-sdk',
+            'NAVER Maps SDK 전역 객체를 확인할 수 없습니다.',
+          ),
+          true,
+        )
+        return
+      }
+
+      settled = true
+      clearLoadTimeout()
+      restoreReadyCallback()
+      clearPendingAuthenticationFailure()
+      removeScriptListeners()
+      queueMicrotask(() => {
+        if (!authenticationError) {
+          ensureAuthenticationCallback()
+        }
+      })
+      resolve(maps)
+    }
+
+    const handleNetworkFailure = () => {
+      fail(
+        new NaverMapsSdkError(
+          'network',
+          'NAVER Maps SDK를 내려받지 못했습니다.',
+        ),
+        true,
+      )
+    }
+
+    window.__toadzipNaverMapsReady = handleReady
+    pendingAuthenticationFailure = handlePendingAuthenticationFailure
+    ensureAuthenticationCallback()
+    script.addEventListener('error', handleNetworkFailure, { once: true })
+    timeoutId = window.setTimeout(() => {
+      fail(
+        new NaverMapsSdkError(
+          'network',
+          'NAVER Maps SDK 준비 시간이 초과되었습니다.',
+        ),
+        true,
+      )
+    }, NAVER_MAPS_LOAD_TIMEOUT_MS)
+
+    if (shouldAppendScript) {
+      document.head.append(script)
+    }
+  })
+}
+
+export function loadNaverMapsSdk(
+  clientId: string,
+): Promise<typeof naver.maps> {
+  if (authenticationError) {
+    return Promise.reject(authenticationError)
+  }
+
+  const readyMaps = getReadyNaverMaps()
+
+  if (readyMaps) {
+    ensureAuthenticationCallback()
+    return Promise.resolve(readyMaps)
+  }
+
+  if (sdkPromise) {
+    return sdkPromise
+  }
+
+  sdkPromise = loadScript(clientId.trim())
+  return sdkPromise
+}

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,12 @@
+interface ImportMetaEnv {
+  readonly VITE_NAVER_MAPS_CLIENT_ID?: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}
+
+interface Window {
+  __toadzipNaverMapsReady?: () => void
+  navermap_authFailure?: () => void
+}

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -4,7 +4,7 @@
     "target": "es2023",
     "lib": ["ES2023", "DOM"],
     "module": "esnext",
-    "types": ["vite/client"],
+    "types": ["vite/client", "navermaps"],
     "allowArbitraryExtensions": true,
     "skipLibCheck": true,
     "moduleResolution": "bundler",


### PR DESCRIPTION
## 관련 이슈

Closes #54

## 작업 목적

- 백엔드 API가 준비되지 않은 상태에서도 프론트엔드 진입 화면과 외부 지도 연동이 독립적으로 동작하는지 검증한다.

## 작업 내역

- 헤더와 화면을 채우는 지도 중심의 기본 진입 화면을 구성했다.
- NAVER Maps JavaScript SDK를 GL 방식으로 연동하고 서울시청을 중심으로 지도를 표시했다.
- 지도 로딩 중, 설정 누락, 인증 실패, 네트워크 오류 및 지도 초기화 실패 상태를 구분해 안내하도록 구현했다.
- 재시도 가능한 오류에 다시 시도 기능을 제공하고, 화면 해제 시 생성한 지도 인스턴스를 정리하도록 구성했다.
- 로컬에서는 `frontend/.env.example`을 참고해 Git이 추적하지 않는 `frontend/.env.local`을 생성하고 `VITE_NAVER_MAPS_CLIENT_ID`를 입력하도록 문서화했다.
- 개발과 운영에서는 동일한 환경변수 이름으로 환경별 Client ID를 빌드 시점에 주입하도록 환경 계약을 정리했다.
- 실제 Client ID와 Client Secret은 저장소에 포함하지 않으며, Client Secret은 프론트엔드에서 사용하지 않는다.
- 기존 관리자 화면과 404 화면이 유지되도록 통합했다.
- 백엔드 API 연동, 실제 주택 데이터 표시와 AWS 배포는 이번 작업에 포함하지 않았다.

## 리뷰 포인트

- React StrictMode에서도 NAVER 지도 SDK가 중복으로 로딩되거나 지도가 중복 초기화되지 않는지 확인해 주세요.
- Client ID 누락과 인증 실패에는 재시도를 제공하지 않고, 네트워크·SDK·지도 생성 실패에만 재시도를 제공하는지 확인해 주세요.
- 지도 화면을 벗어날 때 지도 인스턴스가 정상적으로 정리되는지 확인해 주세요.
- `frontend/.env.local`이 Git에 포함되지 않고 `.env.example`에는 실제 값 없이 환경변수 계약만 기록되어 있는지 확인해 주세요.
- `/` 지도 화면 추가 이후에도 기존 `/admin/*`와 404 라우트가 정상적으로 유지되는지 확인해 주세요.

## 검증 결과

- 테스트 방법: `VITE_API_BASE_URL=http://localhost:8080 npm run check`
- 테스트 결과: lint, 테스트 21개, TypeScript 검사 및 프로덕션 빌드 전체 통과
- 테스트 방법: `./scripts/validate-harness.sh`
- 테스트 결과: 하네스 검사 통과
- 직접 확인: `frontend/.env.local`에 실제 Client ID를 설정한 뒤 로컬 환경에서 지도 렌더링 확인
- 직접 확인: 모바일·태블릿·데스크톱 크기에서 공통 레이아웃 유지 확인
- 직접 확인: 기존 관리자 화면과 404 화면 유지 확인
- 미검증: 개발·운영 AWS 환경에서의 실제 지도 동작과 배포 파이프라인은 후속 배포 작업에서 확인