### PR TITLE
chore: Docker Compose에서 db host를 환경변수로 관리 (#55)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,9 @@
 # PostgreSQL
 POSTGRES_DB=toadzip
 POSTGRES_USER=toadzip
-POSTGRES_PASSWORD=change-me
+POSTGRES_PASSWORD=
+
+DB_HOST=
 
 # Ports exposed on the host machine
 BACKEND_PORT=8080

--- a/compose.yaml
+++ b/compose.yaml
@@ -23,7 +23,7 @@ services:
       dockerfile: Dockerfile
     image: toadzip-backend:latest
     environment:
-      SPRING_DATASOURCE_URL: "jdbc:postgresql://db:5432/${POSTGRES_DB:-toadzip}"
+      SPRING_DATASOURCE_URL: "jdbc:postgresql://${DB_HOST}:5432/${POSTGRES_DB:-toadzip}"
       SPRING_DATASOURCE_USERNAME: "${POSTGRES_USER:-toadzip}"
       SPRING_DATASOURCE_PASSWORD: "${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}"
       DATA_GO_KR_SERVICE_KEY: "${DATA_GO_KR_SERVICE_KEY:-}"


### PR DESCRIPTION
## 관련 이슈

Closes #55 

## 작업 목적

- DB host는 서버마다 다르다. 따라서 파일이 분리된다. 파일 분리를 막기 위해서 해당 값을 환경변수화 한다.

## 작업 내역

- compose.yaml 파일의 SPRING_DATASOURCE_URL - db host 를 환경변수화 한다.
- 운영 서버에 환경변수 설정
- 개발 서버에 환경변수 설정


## 리뷰 포인트

- 파일 검토

## 검증 결과

<!--
실행한 테스트 명령이나 직접 확인한 시나리오와 결과를 작성해 주세요.

예시:
- 테스트 방법: ./gradlew test
- 테스트 결과: 전체 테스트 통과

검증하지 못한 항목이 있다면 그 사유를 작성해 주세요.
-->

- 테스트 방법: 개발/운영 서버 컨테이너 재실행
- 테스트 결과:
    - 개발서버
        <img width="534" height="91" alt="image" src="https://github.com/user-attachments/assets/a2dfabf7-de0a-4a87-996a-9db42e022bce" />

    - 운영서버
        <img width="402" height="64" alt="image" src="https://github.com/user-attachments/assets/05b495de-3221-4269-9c09-4248c0b542ff" />
