### PR TITLE
chore(infra): 프론트 Docker 및 Nginx 실행 구성 (#64)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+*
+!frontend/
+!frontend/**
+!infra/
+!infra/nginx/
+!infra/nginx/**
+
+frontend/.env
+frontend/.env.*
+!frontend/.env.example
+frontend/node_modules/
+frontend/dist/
+frontend/coverage/

--- a/.github/workflows/harness-check.yml
+++ b/.github/workflows/harness-check.yml
@@ -81,6 +81,4 @@ jobs:
       - name: Install frontend dependencies
         run: npm ci
       - name: Check frontend
-        env:
-          VITE_API_BASE_URL: https://api.toadzip.com
         run: npm run check

--- a/compose.frontend.yaml
+++ b/compose.frontend.yaml
@@ -1,0 +1,19 @@
+services:
+  frontend:
+    build:
+      context: .
+      dockerfile: infra/nginx/Dockerfile
+      args:
+        VITE_NAVER_MAPS_CLIENT_ID: "${VITE_NAVER_MAPS_CLIENT_ID:-}"
+    image: toadzip-frontend:local
+    ports:
+      - "${FRONTEND_PORT:-80}:8080"
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - wget --quiet --output-document=- http://127.0.0.1:8080/healthz >/dev/null || exit 1
+      interval: 10s
+      timeout: 3s
+      retries: 5
+      start_period: 5s
+    restart: unless-stopped

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -37,8 +37,42 @@ docker compose up -d db
 docker compose up -d --build backend
 ```
 
+### 프론트엔드 컨테이너 실행
+
+프론트엔드는 기존 DB·백엔드 Compose와 독립적으로 실행한다. 지도 설정과 공개
+환경값은 [프론트엔드 README](../frontend/README.md)를 참고한다.
+
+지도 없이도 이미지는 빌드되고 실행된다.
+
+```shell
+docker compose --project-name toadzip-frontend \
+  --file compose.frontend.yaml \
+  up --detach --build --wait
+```
+
+지도를 표시하려면 Git이 추적하지 않는 `frontend/.env.local`에
+`VITE_NAVER_MAPS_CLIENT_ID`를 설정하고 빌드 시 전달한다.
+
+```shell
+docker compose --project-name toadzip-frontend \
+  --file compose.frontend.yaml \
+  --env-file frontend/.env.local \
+  up --detach --build --wait
+```
+
+기본 접속 주소는 `http://localhost`, 상태 확인 주소는
+`http://localhost/healthz`다. 백엔드 연결 전에는 `/api` 요청이 의도적으로
+`503` JSON을 반환한다.
+
 ## 종료
 
 ```shell
 docker compose down
+```
+
+프론트엔드 컨테이너는 같은 프로젝트 이름과 Compose 파일로 종료한다.
+
+```shell
+docker compose --project-name toadzip-frontend \
+  --file compose.frontend.yaml down --remove-orphans
 ```

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,6 +1,7 @@
-# 관리자 API 요청에 사용하는 브라우저 공개 기본 URL입니다.
-# 로컬 기본값은 아래 주소이며, 운영 빌드에서는 실제 API 주소가 반드시 필요합니다.
-VITE_API_BASE_URL=http://localhost:8080
+# 관리자 API 요청에 사용하는 선택적 브라우저 공개 URL입니다.
+# 값이 없으면 로컬 개발은 http://localhost:8080, 프로덕션은 같은 주소의 /api를 사용합니다.
+# 별도 API 주소가 필요할 때만 끝 슬래시 없이 설정합니다.
+VITE_API_BASE_URL=
 
 # NAVER Maps JavaScript SDK의 브라우저 공개 Client ID입니다.
 # 값이 없으면 애플리케이션은 지도 설정이 준비되지 않았다는 안내를 표시합니다.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -41,15 +41,14 @@ NAVER Cloud Platform에서 로컬 Web 서비스 URL로 `http://localhost`를
 등록하고 브라우저용 Client ID를 입력한다.
 
 ```dotenv
-VITE_API_BASE_URL=http://localhost:8080
+VITE_API_BASE_URL=
 VITE_NAVER_MAPS_CLIENT_ID=발급받은_Client_ID
 ```
 
 `VITE_*` 환경 변수는 빌드 결과와 브라우저에 공개된다. Client Secret이나 서버
 비밀값을 입력하지 않는다. 로컬에서 API 주소를 생략하면
-`http://localhost:8080`을 사용하고, 운영 빌드에서는 API 주소가 없으면 빌드가
-실패한다. Client ID가 없으면 빌드는 정상적으로 완료되지만 실행 화면에는 지도
-사용 불가 안내가 표시된다.
+`http://localhost:8080`을 사용한다. Client ID가 없으면 빌드는 정상적으로
+완료되지만 실행 화면에는 지도 사용 불가 안내가 표시된다.
 
 ```shell
 npm run dev
@@ -102,14 +101,16 @@ npm run build
 
 TypeScript 타입 검사 후 프로덕션 파일을 `dist/`에 생성한다.
 
-운영 프런트엔드와 API를 서로 다른 주소에 배포하므로, 운영 빌드 환경에는 공개 API 주소를 반드시 설정한다.
+프로덕션에서 `VITE_API_BASE_URL`을 생략하면 브라우저는 프론트엔드와 같은 주소의
+`/api`로 요청한다. 별도 API 주소가 필요한 환경에서만 프로토콜과 호스트를 끝
+슬래시 없이 설정한다.
 
 ```text
 VITE_API_BASE_URL=https://api.toadzip.com
 ```
 
-값이 없으면 빌드는 실패한다. 운영 백엔드에는 `ADMIN_CORS_ALLOWED_ORIGIN=https://toadzip.com`와
-`SESSION_COOKIE_SECURE=true`를 설정한다.
+API 경로가 이미 `/api`로 시작하므로 `VITE_API_BASE_URL=/api`로 설정하지 않는다.
+별도 주소를 사용하면 백엔드 CORS와 세션 쿠키 정책도 함께 설정해야 한다.
 
 ## 빌드 결과 확인
 
@@ -118,3 +119,43 @@ npm run preview
 ```
 
 이 명령은 빌드 결과를 로컬에서 확인하기 위한 용도이며 운영 서버로 사용하지 않는다.
+
+## Docker와 Nginx로 실행
+
+아래 명령은 프로젝트 루트에서 실행한다. 지도 없이 이미지 빌드가 가능한지 먼저
+확인하려면 다음 명령을 사용한다.
+
+```shell
+docker compose --project-name toadzip-frontend \
+  --file compose.frontend.yaml build
+```
+
+지도를 표시하려면 `frontend/.env.local`에
+`VITE_NAVER_MAPS_CLIENT_ID=발급받은_Client_ID`를 넣고 이미지를 다시 빌드해
+실행한다.
+
+```shell
+docker compose --project-name toadzip-frontend \
+  --file compose.frontend.yaml \
+  --env-file frontend/.env.local \
+  up --detach --build --wait
+```
+
+기본 접속 주소는 `http://localhost`이고 상태 확인 주소는
+`http://localhost/healthz`다. 호스트 포트를 바꾸려면 명령 앞에
+`FRONTEND_PORT=8081`을 지정한다. 이 구성은 프로덕션 API 주소를 별도로 넣지 않고
+같은 주소의 `/api`를 사용한다.
+
+현재는 백엔드가 연결되지 않았으므로 `/api`와 `/api/*`가 `503` JSON을 반환한다.
+백엔드 배포 작업에서 이 경로를 `backend:8080` 프록시로 교체한다. `/`,
+`/admin/login`과 그 밖의 화면 주소는 Nginx가 React 애플리케이션으로 연결한다.
+
+`VITE_NAVER_MAPS_CLIENT_ID`는 브라우저 공개값이며 정적 빌드 결과에 포함된다.
+실행 중인 컨테이너의 환경값만 바꿔서는 화면이 바뀌지 않으므로 환경별 Client ID로
+각각 다시 빌드한다. Client Secret은 `.env.local`, 빌드 인자와 이미지 어디에도
+넣지 않는다.
+
+```shell
+docker compose --project-name toadzip-frontend \
+  --file compose.frontend.yaml down --remove-orphans
+```

--- a/frontend/src/admin/auth/api.test.ts
+++ b/frontend/src/admin/auth/api.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  vi.unstubAllGlobals()
+  vi.resetModules()
+})
+
+describe('관리자 API 주소', () => {
+  it('로컬에서 API 주소가 없으면 로컬 백엔드로 요청한다', async () => {
+    const fetchMock = prepareFetch({ development: true })
+    const { getCurrentAdmin } = await import('./api.ts')
+
+    await getCurrentAdmin()
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://localhost:8080/api/admin/auth/me',
+      expect.objectContaining({ credentials: 'include' }),
+    )
+  })
+
+  it('프로덕션에서 API 주소가 없으면 같은 주소로 요청한다', async () => {
+    const fetchMock = prepareFetch({ development: false })
+    const { getCurrentAdmin } = await import('./api.ts')
+
+    await getCurrentAdmin()
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/admin/auth/me',
+      expect.objectContaining({ credentials: 'include' }),
+    )
+  })
+
+  it('API 주소를 설정하면 해당 주소로 요청한다', async () => {
+    const fetchMock = prepareFetch({
+      apiBaseUrl: 'https://api.example.test',
+      development: false,
+    })
+    const { getCurrentAdmin } = await import('./api.ts')
+
+    await getCurrentAdmin()
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.example.test/api/admin/auth/me',
+      expect.objectContaining({ credentials: 'include' }),
+    )
+  })
+})
+
+function prepareFetch({
+  apiBaseUrl,
+  development,
+}: {
+  apiBaseUrl?: string
+  development: boolean
+}) {
+  vi.stubEnv('DEV', development)
+  vi.stubEnv('VITE_API_BASE_URL', apiBaseUrl)
+  vi.resetModules()
+
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: vi.fn().mockResolvedValue({
+      loginIdentifier: 'admin',
+      role: 'ADMIN',
+    }),
+  } as unknown as Response)
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
+}

--- a/frontend/src/admin/auth/api.ts
+++ b/frontend/src/admin/auth/api.ts
@@ -88,5 +88,5 @@ function resolveApiBaseUrl(): string {
   if (import.meta.env.DEV) {
     return 'http://localhost:8080'
   }
-  throw new Error('VITE_API_BASE_URL must be configured outside development.')
+  return ''
 }

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,4 +1,5 @@
 interface ImportMetaEnv {
+  readonly VITE_API_BASE_URL?: string
   readonly VITE_NAVER_MAPS_CLIENT_ID?: string
 }
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,18 +1,10 @@
 import react from '@vitejs/plugin-react'
-import { loadEnv } from 'vite'
 import { defineConfig } from 'vitest/config'
 
-export default defineConfig(({ mode }) => {
-  const environment = loadEnv(mode, process.cwd(), '')
-  if (mode === 'production' && !environment.VITE_API_BASE_URL) {
-    throw new Error('VITE_API_BASE_URL must be configured for production builds.')
-  }
-
-  return {
-    plugins: [react()],
-    test: {
-      environment: 'jsdom',
-      setupFiles: './src/test/setup.ts',
-    },
-  }
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    setupFiles: './src/test/setup.ts',
+  },
 })

--- a/infra/nginx/Dockerfile
+++ b/infra/nginx/Dockerfile
@@ -1,0 +1,28 @@
+FROM node:24.19.0-alpine AS builder
+
+WORKDIR /workspace/frontend
+
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci
+
+COPY frontend/ ./
+
+ARG VITE_API_BASE_URL=""
+ARG VITE_NAVER_MAPS_CLIENT_ID=""
+RUN VITE_API_BASE_URL="${VITE_API_BASE_URL}" \
+    VITE_NAVER_MAPS_CLIENT_ID="${VITE_NAVER_MAPS_CLIENT_ID}" \
+    npm run build
+
+
+FROM nginx:1.29.5-alpine
+
+COPY infra/nginx/nginx.conf /etc/nginx/nginx.conf
+COPY --from=builder --chown=nginx:nginx /workspace/frontend/dist/ /usr/share/nginx/html/
+
+USER nginx
+
+EXPOSE 8080
+
+STOPSIGNAL SIGQUIT
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/infra/nginx/nginx.conf
+++ b/infra/nginx/nginx.conf
@@ -1,0 +1,63 @@
+worker_processes auto;
+pid /tmp/nginx.pid;
+
+error_log /dev/stderr warn;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+
+    access_log /dev/stdout;
+    sendfile on;
+    server_tokens off;
+
+    client_body_temp_path /tmp/client-body;
+    proxy_temp_path /tmp/proxy;
+    fastcgi_temp_path /tmp/fastcgi;
+    uwsgi_temp_path /tmp/uwsgi;
+    scgi_temp_path /tmp/scgi;
+
+    server {
+        listen 8080;
+        server_name _;
+
+        root /usr/share/nginx/html;
+        index index.html;
+
+        location = /healthz {
+            access_log off;
+            default_type text/plain;
+            add_header Cache-Control "no-store" always;
+            return 200 "ok\n";
+        }
+
+        location = /api {
+            default_type application/json;
+            add_header Cache-Control "no-store" always;
+            return 503 '{"message":"Backend service is not available."}';
+        }
+
+        location ^~ /api/ {
+            default_type application/json;
+            add_header Cache-Control "no-store" always;
+            return 503 '{"message":"Backend service is not available."}';
+        }
+
+        location ^~ /assets/ {
+            try_files $uri =404;
+            add_header Cache-Control "public, max-age=31536000, immutable" always;
+        }
+
+        location = /index.html {
+            add_header Cache-Control "no-store" always;
+        }
+
+        location / {
+            try_files $uri /index.html;
+        }
+    }
+}


### PR DESCRIPTION
## 관련 이슈

Closes #64

## 작업 목적

- 개발 EC2에서 프론트엔드를 재현 가능하게 실행할 수 있도록 Docker 및 Nginx 구성을 마련한다.
- 프로덕션 프론트엔드가 별도 API 주소 설정 없이 같은 주소의 `/api`를 사용하도록 환경 계약을 정리한다.

## 작업 내역

- Node.js 24.19.0 빌드 단계와 Nginx 실행 단계로 구성된 멀티 스테이지 이미지를 추가했다.
- 기존 DB·백엔드 구성과 독립적으로 실행할 수 있는 `compose.frontend.yaml`을 추가했다.
- Nginx에 다음 동작을 구성했다.
  - `/healthz`: 상태 확인용 `200` 응답
  - `/api`, `/api/*`: 백엔드 연결 전임을 나타내는 `503 JSON` 응답
  - `/assets/*`: 실제 파일만 제공하고 누락된 파일은 `404` 응답
  - 그 외 화면 주소: React Router 처리를 위한 SPA fallback
  - `index.html` 비캐시 및 해시 정적 자산 장기 캐시
- `VITE_API_BASE_URL`이 없을 때 로컬 개발은 `http://localhost:8080`, 프로덕션은 동일 출처를 사용하도록 변경했다.
- API 주소를 설정한 경우 기존처럼 별도 주소를 사용하는 테스트를 추가했다.
- CI에서 임시 API 주소를 주입하지 않아도 프로덕션 빌드가 통과하도록 변경했다.
- `.env.local`과 빌드 산출물이 Docker 빌드 컨텍스트에 포함되지 않도록 설정했다.
- NAVER Maps Client ID를 포함한 컨테이너 빌드·실행 및 종료 방법을 문서화했다.

## 리뷰 포인트

- 프로덕션의 기본 API 요청 주소는 프론트엔드와 같은 주소의 `/api`다.
- `VITE_API_BASE_URL`은 별도 API 호스트가 필요한 경우에만 사용한다.
- 현재 `/api`는 의도적으로 `503`을 반환하며, 실제 백엔드 배포 작업에서 `backend:8080` 프록시로 교체해야 한다.
- 호스트 EC2에 별도 Nginx를 설치하지 않고 컨테이너 내부 Nginx를 사용한다.
- `VITE_NAVER_MAPS_CLIENT_ID`는 브라우저 공개값이므로 빌드 결과에 포함되며, 환경별 Client ID로 이미지를 다시 빌드해야 한다.
- Client Secret은 환경값, 빌드 인자 및 이미지에 사용하지 않는다.
- 실제 EC2 설정·배포, 백엔드 연결, 도메인·HTTPS 및 자동 배포는 이번 작업 범위에 포함하지 않았다.

## 검증 결과

- 테스트 방법: Node.js 24.19.0 환경에서 `npm ci && npm run check`
- 테스트 결과: lint, 테스트 24개, TypeScript 검사 및 프로덕션 빌드 통과

- 테스트 방법: `./scripts/validate-harness.sh`
- 테스트 결과: 저장소 하네스 검사 통과

- 테스트 방법: NAVER Maps Client ID 없이 Docker 이미지 빌드
- 테스트 결과: 이미지 빌드 성공

- 테스트 방법: 로컬 `.env.local`의 Client ID를 사용해 Compose 빌드·실행
- 테스트 결과: 지도 렌더링, 드래그, 스크롤 확대 및 새로고침 정상 동작 확인

- 테스트 방법: 컨테이너 내부 `nginx -t` 및 HTTP 경로 확인
- 테스트 결과:
  - `/healthz`: `200`
  - `/api`, `/api/...`: `503 JSON`
  - 존재하지 않는 `/assets/*`: `404`
  - `/`, `/admin/login`, 잘못된 화면 주소의 직접 접근 및 새로고침: React 화면 표시

- 테스트 방법: 최종 이미지 구성 확인
- 테스트 결과: Node.js, 프론트엔드 소스, `node_modules`, `.env.local`이 최종 이미지에 포함되지 않음을 확인

- 물리 트랙패드 제스처와 실제 EC2 환경은 이번 로컬 검증에서 확인하지 않았다.