### PR TITLE
feat(ingest): 마이홈 공고·공급 정보 도메인 매핑 (#18)

### DIFF
--- a/backend/src/main/java/com/toadzip/backend/announcement/domain/Announcement.java
+++ b/backend/src/main/java/com/toadzip/backend/announcement/domain/Announcement.java
@@ -106,13 +106,10 @@ public class Announcement {
 
     @Embedded
     @AttributeOverrides({
-            @AttributeOverride(name = "name", column = @Column(name = "reception_place_name", nullable = false)),
-            @AttributeOverride(name = "method", column = @Column(name = "reception_method", nullable = false)),
+            @AttributeOverride(name = "name", column = @Column(name = "reception_place_name")),
+            @AttributeOverride(name = "method", column = @Column(name = "reception_method")),
             @AttributeOverride(name = "address", column = @Column(name = "reception_address")),
-            @AttributeOverride(
-                    name = "contact",
-                    column = @Column(name = "reception_contact", nullable = false)
-            ),
+            @AttributeOverride(name = "contact", column = @Column(name = "reception_contact")),
             @AttributeOverride(name = "url", column = @Column(name = "reception_url"))
     })
     private ReceptionPlace receptionPlace;
@@ -153,7 +150,6 @@ public class Announcement {
         validateNonNegative(viewCount, "조회수");
         validateNonNegativeIfPresent(actualCompetitionRate, "실제 경쟁률");
         validateNonNegativeIfPresent(predictedCompetitionRate, "예상 경쟁률");
-        validateRequired(receptionPlace, "접수처");
         this.sourceAnnouncementIdentifier = sourceAnnouncementIdentifier;
         this.previousSourceAnnouncementIdentifier = previousSourceAnnouncementIdentifier;
         this.previousAnnouncement = previousAnnouncement;
@@ -271,7 +267,14 @@ public class Announcement {
                 && winnerAnnouncementDate.equals(incoming.winnerAnnouncementDate)
                 && originalUrl.equals(incoming.originalUrl)
                 && Objects.equals(correctionCancellationReason, incoming.correctionCancellationReason)
-                && receptionPlace.hasSameValues(incoming.receptionPlace);
+                && hasSameReceptionPlace(incoming.receptionPlace);
+    }
+
+    private boolean hasSameReceptionPlace(ReceptionPlace incoming) {
+        if (receptionPlace == null) {
+            return incoming == null;
+        }
+        return receptionPlace.hasSameValues(incoming);
     }
 
     private void applySourceValues(Announcement incoming) {

--- a/backend/src/main/java/com/toadzip/backend/announcement/domain/Announcement.java
+++ b/backend/src/main/java/com/toadzip/backend/announcement/domain/Announcement.java
@@ -21,8 +21,10 @@ import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.Objects;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.JdbcType;
@@ -31,7 +33,11 @@ import org.hibernate.annotations.JdbcType;
 @Entity
 @Table(
         name = "announcements",
-        indexes = @Index(name = "idx_announcements_posted_date_id", columnList = "posted_date,id")
+        indexes = @Index(name = "idx_announcements_posted_date_id", columnList = "posted_date,id"),
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_announcement_source_identifier",
+                columnNames = "source_announcement_identifier"
+        )
 )
 @NoArgsConstructor(access = PROTECTED)
 public class Announcement {
@@ -206,6 +212,83 @@ public class Announcement {
                 null,
                 receptionPlace
         );
+    }
+
+    public boolean updateFromSource(
+            String previousSourceAnnouncementIdentifier,
+            Announcement previousAnnouncement,
+            String name,
+            AnnouncementPublicationType status,
+            RentalType supplyType,
+            RecruitmentType recruitmentType,
+            AgencyCode provider,
+            LocalDate postedDate,
+            LocalDate applicationStartDate,
+            LocalDate applicationEndDate,
+            LocalDate winnerAnnouncementDate,
+            String originalUrl,
+            String correctionCancellationReason,
+            ReceptionPlace receptionPlace
+    ) {
+        Announcement incoming = new Announcement(
+                sourceAnnouncementIdentifier,
+                previousSourceAnnouncementIdentifier,
+                previousAnnouncement,
+                name,
+                status,
+                supplyType,
+                recruitmentType,
+                provider,
+                postedDate,
+                applicationStartDate,
+                applicationEndDate,
+                winnerAnnouncementDate,
+                originalUrl,
+                correctionCancellationReason,
+                viewCount,
+                actualCompetitionRate,
+                predictedCompetitionRate,
+                receptionPlace
+        );
+        if (hasSameSourceValues(incoming)) {
+            return false;
+        }
+        applySourceValues(incoming);
+        return true;
+    }
+
+    private boolean hasSameSourceValues(Announcement incoming) {
+        return Objects.equals(previousSourceAnnouncementIdentifier, incoming.previousSourceAnnouncementIdentifier)
+                && Objects.equals(previousAnnouncement, incoming.previousAnnouncement)
+                && name.equals(incoming.name)
+                && status == incoming.status
+                && supplyType == incoming.supplyType
+                && recruitmentType == incoming.recruitmentType
+                && provider == incoming.provider
+                && postedDate.equals(incoming.postedDate)
+                && applicationStartDate.equals(incoming.applicationStartDate)
+                && applicationEndDate.equals(incoming.applicationEndDate)
+                && winnerAnnouncementDate.equals(incoming.winnerAnnouncementDate)
+                && originalUrl.equals(incoming.originalUrl)
+                && Objects.equals(correctionCancellationReason, incoming.correctionCancellationReason)
+                && receptionPlace.hasSameValues(incoming.receptionPlace);
+    }
+
+    private void applySourceValues(Announcement incoming) {
+        previousSourceAnnouncementIdentifier = incoming.previousSourceAnnouncementIdentifier;
+        previousAnnouncement = incoming.previousAnnouncement;
+        name = incoming.name;
+        status = incoming.status;
+        supplyType = incoming.supplyType;
+        recruitmentType = incoming.recruitmentType;
+        provider = incoming.provider;
+        postedDate = incoming.postedDate;
+        applicationStartDate = incoming.applicationStartDate;
+        applicationEndDate = incoming.applicationEndDate;
+        winnerAnnouncementDate = incoming.winnerAnnouncementDate;
+        originalUrl = incoming.originalUrl;
+        correctionCancellationReason = incoming.correctionCancellationReason;
+        receptionPlace = incoming.receptionPlace;
     }
 
     public static Announcement create(

--- a/backend/src/main/java/com/toadzip/backend/announcement/domain/ReceptionPlace.java
+++ b/backend/src/main/java/com/toadzip/backend/announcement/domain/ReceptionPlace.java
@@ -6,6 +6,7 @@ import com.toadzip.backend.global.persistence.LegacyEnumVarcharJdbcType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Embeddable;
+import java.util.Objects;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.JdbcType;
@@ -47,6 +48,15 @@ public class ReceptionPlace {
 
     public static ReceptionPlace create(String name, String method, String address, String contact, String url) {
         return create(name, ReceptionMethod.fromStoredValue(method), address, contact, url);
+    }
+
+    boolean hasSameValues(ReceptionPlace other) {
+        return other != null
+                && name.equals(other.name)
+                && method == other.method
+                && Objects.equals(address, other.address)
+                && contact.equals(other.contact)
+                && Objects.equals(url, other.url);
     }
 
     private void validateNotBlank(String value, String fieldName) {

--- a/backend/src/main/java/com/toadzip/backend/announcement/domain/ReceptionPlace.java
+++ b/backend/src/main/java/com/toadzip/backend/announcement/domain/ReceptionPlace.java
@@ -26,7 +26,6 @@ public class ReceptionPlace {
 
     private String address;
 
-    @Column(nullable = false)
     private String contact;
 
     private String url;
@@ -34,7 +33,6 @@ public class ReceptionPlace {
     private ReceptionPlace(String name, ReceptionMethod method, String address, String contact, String url) {
         validateNotBlank(name, "접수처명");
         validateRequired(method, "접수방식");
-        validateNotBlank(contact, "연락처");
         this.name = name;
         this.method = method;
         this.address = address;
@@ -55,7 +53,7 @@ public class ReceptionPlace {
                 && name.equals(other.name)
                 && method == other.method
                 && Objects.equals(address, other.address)
-                && contact.equals(other.contact)
+                && Objects.equals(contact, other.contact)
                 && Objects.equals(url, other.url);
     }
 

--- a/backend/src/main/java/com/toadzip/backend/announcement/domain/SupplyRow.java
+++ b/backend/src/main/java/com/toadzip/backend/announcement/domain/SupplyRow.java
@@ -16,13 +16,21 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.time.YearMonth;
+import java.util.Objects;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
-@Table(name = "supply_rows")
+@Table(
+        name = "supply_rows",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_supply_row_source_identifier",
+                columnNames = "source_supply_row_identifier"
+        )
+)
 @NoArgsConstructor(access = PROTECTED)
 public class SupplyRow {
 
@@ -133,6 +141,65 @@ public class SupplyRow {
                 matchingFailureReason,
                 totalSupplyHouseholdCount
         );
+    }
+
+    public boolean updateFromSource(
+            HousingComplex housingComplex,
+            HousingType housingType,
+            int displayOrder,
+            String sourceComplexName,
+            String sourceHousingTypeName,
+            String supplyPnu,
+            YearMonth expectedMoveInMonth,
+            SupplyCategory supplyCategory,
+            String matchingFailureReason,
+            Integer totalSupplyHouseholdCount
+    ) {
+        SupplyRow incoming = new SupplyRow(
+                announcement,
+                housingComplex,
+                housingType,
+                sourceSupplyRowIdentifier,
+                displayOrder,
+                sourceComplexName,
+                sourceHousingTypeName,
+                supplyPnu,
+                expectedMoveInMonth,
+                supplyCategory,
+                matchingFailureReason,
+                totalSupplyHouseholdCount
+        );
+        if (hasSameSourceValues(incoming)) {
+            return false;
+        }
+        applySourceValues(incoming);
+        return true;
+    }
+
+    private boolean hasSameSourceValues(SupplyRow incoming) {
+        return Objects.equals(housingComplex, incoming.housingComplex)
+                && Objects.equals(housingType, incoming.housingType)
+                && displayOrder == incoming.displayOrder
+                && sourceComplexName.equals(incoming.sourceComplexName)
+                && sourceHousingTypeName.equals(incoming.sourceHousingTypeName)
+                && supplyPnu.equals(incoming.supplyPnu)
+                && Objects.equals(expectedMoveInMonth, incoming.expectedMoveInMonth)
+                && supplyCategory == incoming.supplyCategory
+                && Objects.equals(matchingFailureReason, incoming.matchingFailureReason)
+                && Objects.equals(totalSupplyHouseholdCount, incoming.totalSupplyHouseholdCount);
+    }
+
+    private void applySourceValues(SupplyRow incoming) {
+        housingComplex = incoming.housingComplex;
+        housingType = incoming.housingType;
+        displayOrder = incoming.displayOrder;
+        sourceComplexName = incoming.sourceComplexName;
+        sourceHousingTypeName = incoming.sourceHousingTypeName;
+        supplyPnu = incoming.supplyPnu;
+        expectedMoveInMonth = incoming.expectedMoveInMonth;
+        supplyCategory = incoming.supplyCategory;
+        matchingFailureReason = incoming.matchingFailureReason;
+        totalSupplyHouseholdCount = incoming.totalSupplyHouseholdCount;
     }
 
     private void validateRequired(Object value, String fieldName) {

--- a/backend/src/main/java/com/toadzip/backend/announcement/repository/AnnouncementRepository.java
+++ b/backend/src/main/java/com/toadzip/backend/announcement/repository/AnnouncementRepository.java
@@ -8,6 +8,8 @@ import org.springframework.data.repository.query.Param;
 
 public interface AnnouncementRepository extends JpaRepository<Announcement, Long> {
 
+    Optional<Announcement> findBySourceAnnouncementIdentifier(String sourceAnnouncementIdentifier);
+
     @Query("""
             SELECT announcement
             FROM Announcement announcement

--- a/backend/src/main/java/com/toadzip/backend/announcement/repository/SupplyRowRepository.java
+++ b/backend/src/main/java/com/toadzip/backend/announcement/repository/SupplyRowRepository.java
@@ -1,14 +1,20 @@
 package com.toadzip.backend.announcement.repository;
 
+import com.toadzip.backend.announcement.domain.Announcement;
 import com.toadzip.backend.announcement.domain.SupplyRow;
 import com.toadzip.backend.housing.domain.HousingType;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface SupplyRowRepository extends JpaRepository<SupplyRow, Long> {
+
+    Optional<SupplyRow> findBySourceSupplyRowIdentifier(String sourceSupplyRowIdentifier);
+
+    List<SupplyRow> findAllByAnnouncement(Announcement announcement);
 
     boolean existsByHousingType(HousingType housingType);
 

--- a/backend/src/main/java/com/toadzip/backend/announcement/repository/SupplyTargetRepository.java
+++ b/backend/src/main/java/com/toadzip/backend/announcement/repository/SupplyTargetRepository.java
@@ -1,13 +1,19 @@
 package com.toadzip.backend.announcement.repository;
 
+import com.toadzip.backend.announcement.domain.SupplyRow;
 import com.toadzip.backend.announcement.domain.SupplyTarget;
 import java.util.Collection;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface SupplyTargetRepository extends JpaRepository<SupplyTarget, Long> {
+
+    @Modifying
+    @Query("DELETE FROM SupplyTarget target WHERE target.supplyRow IN :supplyRows")
+    int deleteAllBySupplyRowIn(@Param("supplyRows") Collection<SupplyRow> supplyRows);
 
     @Query("""
             SELECT target

--- a/backend/src/main/java/com/toadzip/backend/announcement/service/AnnouncementResponseMapper.java
+++ b/backend/src/main/java/com/toadzip/backend/announcement/service/AnnouncementResponseMapper.java
@@ -94,7 +94,7 @@ final class AnnouncementResponseMapper {
                 aggregate.supplyComplexCount(),
                 aggregate.supplyHouseholdCount(),
                 announcement.getOriginalUrl(),
-                List.of(receptionPlaceResponse(announcement.getReceptionPlace())),
+                receptionPlaceResponses(announcement.getReceptionPlace()),
                 schedules.stream().map(this::scheduleResponse).toList(),
                 attachments.stream().map(this::attachmentResponse).toList(),
                 supplyComposition.supplyRows(),
@@ -167,6 +167,13 @@ final class AnnouncementResponseMapper {
                 receptionPlace.getContact(),
                 receptionPlace.getUrl()
         );
+    }
+
+    private List<ReceptionPlaceResponse> receptionPlaceResponses(ReceptionPlace receptionPlace) {
+        if (receptionPlace == null) {
+            return List.of();
+        }
+        return List.of(receptionPlaceResponse(receptionPlace));
     }
 
     private AnnouncementScheduleResponse scheduleResponse(AnnouncementSchedule schedule) {

--- a/backend/src/main/java/com/toadzip/backend/housing/repository/HousingComplexRepository.java
+++ b/backend/src/main/java/com/toadzip/backend/housing/repository/HousingComplexRepository.java
@@ -1,10 +1,24 @@
 package com.toadzip.backend.housing.repository;
 
 import com.toadzip.backend.housing.domain.HousingComplex;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface HousingComplexRepository extends JpaRepository<HousingComplex, Long> {
 
     Optional<HousingComplex> findBySourceComplexIdentifier(String sourceComplexIdentifier);
+
+    @Query("""
+            SELECT complex
+            FROM HousingComplex complex
+            WHERE complex.address.pnu = :pnu
+              AND complex.supplyType = :supplyType
+            """)
+    List<HousingComplex> findAllByPnuAndSupplyType(
+            @Param("pnu") String pnu,
+            @Param("supplyType") String supplyType
+    );
 }

--- a/backend/src/main/java/com/toadzip/backend/ingest/controller/MyHomeAnnouncementMappingController.java
+++ b/backend/src/main/java/com/toadzip/backend/ingest/controller/MyHomeAnnouncementMappingController.java
@@ -1,0 +1,32 @@
+package com.toadzip.backend.ingest.controller;
+
+import com.toadzip.backend.ingest.dto.MyHomeAnnouncementMappingFailureResponse;
+import com.toadzip.backend.ingest.dto.MyHomeAnnouncementMappingReport;
+import com.toadzip.backend.ingest.service.MyHomeAnnouncementMappingService;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/admin/ingest/myhome/announcement-mappings")
+public class MyHomeAnnouncementMappingController {
+
+    private final MyHomeAnnouncementMappingService mappingService;
+
+    public MyHomeAnnouncementMappingController(MyHomeAnnouncementMappingService mappingService) {
+        this.mappingService = mappingService;
+    }
+
+    @PostMapping
+    public ResponseEntity<MyHomeAnnouncementMappingReport> mapAll() {
+        return ResponseEntity.ok(mappingService.mapAll());
+    }
+
+    @GetMapping("/failures")
+    public ResponseEntity<List<MyHomeAnnouncementMappingFailureResponse>> findFailures() {
+        return ResponseEntity.ok(mappingService.findFailures());
+    }
+}

--- a/backend/src/main/java/com/toadzip/backend/ingest/domain/MyHomeAnnouncementMappingFailure.java
+++ b/backend/src/main/java/com/toadzip/backend/ingest/domain/MyHomeAnnouncementMappingFailure.java
@@ -1,0 +1,93 @@
+package com.toadzip.backend.ingest.domain;
+
+import static lombok.AccessLevel.PROTECTED;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "myhome_announcement_mapping_failures")
+@NoArgsConstructor(access = PROTECTED)
+public class MyHomeAnnouncementMappingFailure {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 500)
+    private String sourceKey;
+
+    private String sourceAnnouncementIdentifier;
+
+    private Integer sourceHouseSerialNumber;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 50)
+    private MyHomeAnnouncementMappingFailureReason reason;
+
+    @Column(nullable = false, length = 1000)
+    private String detail;
+
+    @Column(nullable = false)
+    private Instant occurredAt;
+
+    private MyHomeAnnouncementMappingFailure(
+            String sourceKey,
+            String sourceAnnouncementIdentifier,
+            Integer sourceHouseSerialNumber,
+            MyHomeAnnouncementMappingFailureReason reason,
+            String detail,
+            Instant occurredAt
+    ) {
+        validateNotBlank(sourceKey, "원천 키");
+        validateRequired(reason, "실패 사유");
+        validateNotBlank(detail, "실패 상세");
+        validateRequired(occurredAt, "실패 시각");
+        this.sourceKey = sourceKey;
+        this.sourceAnnouncementIdentifier = sourceAnnouncementIdentifier;
+        this.sourceHouseSerialNumber = sourceHouseSerialNumber;
+        this.reason = reason;
+        this.detail = detail;
+        this.occurredAt = occurredAt;
+    }
+
+    public static MyHomeAnnouncementMappingFailure create(
+            String sourceKey,
+            String sourceAnnouncementIdentifier,
+            Integer sourceHouseSerialNumber,
+            MyHomeAnnouncementMappingFailureReason reason,
+            String detail,
+            Instant occurredAt
+    ) {
+        return new MyHomeAnnouncementMappingFailure(
+                sourceKey,
+                sourceAnnouncementIdentifier,
+                sourceHouseSerialNumber,
+                reason,
+                detail,
+                occurredAt
+        );
+    }
+
+    private void validateNotBlank(String value, String fieldName) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(fieldName + "은 필수입니다.");
+        }
+    }
+
+    private void validateRequired(Object value, String fieldName) {
+        if (value == null) {
+            throw new IllegalArgumentException(fieldName + "은 필수입니다.");
+        }
+    }
+}

--- a/backend/src/main/java/com/toadzip/backend/ingest/domain/MyHomeAnnouncementMappingFailureReason.java
+++ b/backend/src/main/java/com/toadzip/backend/ingest/domain/MyHomeAnnouncementMappingFailureReason.java
@@ -1,0 +1,13 @@
+package com.toadzip.backend.ingest.domain;
+
+public enum MyHomeAnnouncementMappingFailureReason {
+    MISSING_REQUIRED_VALUE,
+    INVALID_VALUE,
+    CONFLICTING_SOURCE_VALUE,
+    PREVIOUS_ANNOUNCEMENT_NOT_FOUND,
+    CYCLIC_ANNOUNCEMENT_REVISION,
+    COMPLEX_NOT_FOUND,
+    AMBIGUOUS_COMPLEX,
+    HOUSING_TYPE_NOT_FOUND,
+    AMBIGUOUS_HOUSING_TYPE
+}

--- a/backend/src/main/java/com/toadzip/backend/ingest/dto/MyHomeAnnouncementMappingFailureResponse.java
+++ b/backend/src/main/java/com/toadzip/backend/ingest/dto/MyHomeAnnouncementMappingFailureResponse.java
@@ -1,0 +1,26 @@
+package com.toadzip.backend.ingest.dto;
+
+import com.toadzip.backend.ingest.domain.MyHomeAnnouncementMappingFailure;
+import com.toadzip.backend.ingest.domain.MyHomeAnnouncementMappingFailureReason;
+import java.time.Instant;
+
+public record MyHomeAnnouncementMappingFailureResponse(
+        String sourceKey,
+        String sourceAnnouncementIdentifier,
+        Integer sourceHouseSerialNumber,
+        MyHomeAnnouncementMappingFailureReason reason,
+        String detail,
+        Instant occurredAt
+) {
+
+    public static MyHomeAnnouncementMappingFailureResponse from(MyHomeAnnouncementMappingFailure failure) {
+        return new MyHomeAnnouncementMappingFailureResponse(
+                failure.getSourceKey(),
+                failure.getSourceAnnouncementIdentifier(),
+                failure.getSourceHouseSerialNumber(),
+                failure.getReason(),
+                failure.getDetail(),
+                failure.getOccurredAt()
+        );
+    }
+}

--- a/backend/src/main/java/com/toadzip/backend/ingest/dto/MyHomeAnnouncementMappingReport.java
+++ b/backend/src/main/java/com/toadzip/backend/ingest/dto/MyHomeAnnouncementMappingReport.java
@@ -7,6 +7,7 @@ public record MyHomeAnnouncementMappingReport(
         int createdSupplyRowCount,
         int updatedSupplyRowCount,
         int unchangedSupplyRowCount,
+        int deletedSupplyRowCount,
         int failedSourceRowCount
 ) {
 
@@ -17,17 +18,18 @@ public record MyHomeAnnouncementMappingReport(
                 || createdSupplyRowCount < 0
                 || updatedSupplyRowCount < 0
                 || unchangedSupplyRowCount < 0
+                || deletedSupplyRowCount < 0
                 || failedSourceRowCount < 0) {
             throw new IllegalArgumentException("매핑 결과 개수는 음수일 수 없습니다.");
         }
     }
 
     public static MyHomeAnnouncementMappingReport empty() {
-        return new MyHomeAnnouncementMappingReport(0, 0, 0, 0, 0, 0, 0);
+        return new MyHomeAnnouncementMappingReport(0, 0, 0, 0, 0, 0, 0, 0);
     }
 
     public static MyHomeAnnouncementMappingReport failedRows(int count) {
-        return new MyHomeAnnouncementMappingReport(0, 0, 0, 0, 0, 0, count);
+        return new MyHomeAnnouncementMappingReport(0, 0, 0, 0, 0, 0, 0, count);
     }
 
     public MyHomeAnnouncementMappingReport plus(MyHomeAnnouncementMappingReport other) {
@@ -38,6 +40,7 @@ public record MyHomeAnnouncementMappingReport(
                 createdSupplyRowCount + other.createdSupplyRowCount,
                 updatedSupplyRowCount + other.updatedSupplyRowCount,
                 unchangedSupplyRowCount + other.unchangedSupplyRowCount,
+                deletedSupplyRowCount + other.deletedSupplyRowCount,
                 failedSourceRowCount + other.failedSourceRowCount
         );
     }

--- a/backend/src/main/java/com/toadzip/backend/ingest/dto/MyHomeAnnouncementMappingReport.java
+++ b/backend/src/main/java/com/toadzip/backend/ingest/dto/MyHomeAnnouncementMappingReport.java
@@ -1,0 +1,44 @@
+package com.toadzip.backend.ingest.dto;
+
+public record MyHomeAnnouncementMappingReport(
+        int createdAnnouncementCount,
+        int updatedAnnouncementCount,
+        int unchangedAnnouncementCount,
+        int createdSupplyRowCount,
+        int updatedSupplyRowCount,
+        int unchangedSupplyRowCount,
+        int failedSourceRowCount
+) {
+
+    public MyHomeAnnouncementMappingReport {
+        if (createdAnnouncementCount < 0
+                || updatedAnnouncementCount < 0
+                || unchangedAnnouncementCount < 0
+                || createdSupplyRowCount < 0
+                || updatedSupplyRowCount < 0
+                || unchangedSupplyRowCount < 0
+                || failedSourceRowCount < 0) {
+            throw new IllegalArgumentException("매핑 결과 개수는 음수일 수 없습니다.");
+        }
+    }
+
+    public static MyHomeAnnouncementMappingReport empty() {
+        return new MyHomeAnnouncementMappingReport(0, 0, 0, 0, 0, 0, 0);
+    }
+
+    public static MyHomeAnnouncementMappingReport failedRows(int count) {
+        return new MyHomeAnnouncementMappingReport(0, 0, 0, 0, 0, 0, count);
+    }
+
+    public MyHomeAnnouncementMappingReport plus(MyHomeAnnouncementMappingReport other) {
+        return new MyHomeAnnouncementMappingReport(
+                createdAnnouncementCount + other.createdAnnouncementCount,
+                updatedAnnouncementCount + other.updatedAnnouncementCount,
+                unchangedAnnouncementCount + other.unchangedAnnouncementCount,
+                createdSupplyRowCount + other.createdSupplyRowCount,
+                updatedSupplyRowCount + other.updatedSupplyRowCount,
+                unchangedSupplyRowCount + other.unchangedSupplyRowCount,
+                failedSourceRowCount + other.failedSourceRowCount
+        );
+    }
+}

--- a/backend/src/main/java/com/toadzip/backend/ingest/repository/LhAnnouncementCollectionCheckpointRepository.java
+++ b/backend/src/main/java/com/toadzip/backend/ingest/repository/LhAnnouncementCollectionCheckpointRepository.java
@@ -34,6 +34,11 @@ public interface LhAnnouncementCollectionCheckpointRepository
             @Param("panIds") Collection<String> panIds
     );
 
+    List<LhAnnouncementCollectionCheckpoint> findAllBySourceAndSourceAnnouncementKeyOrderByIdAsc(
+            ExternalDataSource source,
+            String sourceAnnouncementKey
+    );
+
     @Modifying
     @Query(value = """
             insert into lh_announcement_collection_checkpoints

--- a/backend/src/main/java/com/toadzip/backend/ingest/repository/LhAnnouncementCollectionCheckpointRepository.java
+++ b/backend/src/main/java/com/toadzip/backend/ingest/repository/LhAnnouncementCollectionCheckpointRepository.java
@@ -3,6 +3,7 @@ package com.toadzip.backend.ingest.repository;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -34,7 +35,7 @@ public interface LhAnnouncementCollectionCheckpointRepository
             @Param("panIds") Collection<String> panIds
     );
 
-    List<LhAnnouncementCollectionCheckpoint> findAllBySourceAndSourceAnnouncementKeyOrderByIdAsc(
+    Optional<LhAnnouncementCollectionCheckpoint> findFirstBySourceAndSourceAnnouncementKeyOrderByIdDesc(
             ExternalDataSource source,
             String sourceAnnouncementKey
     );

--- a/backend/src/main/java/com/toadzip/backend/ingest/repository/LhAnnouncementSupplySourceRepository.java
+++ b/backend/src/main/java/com/toadzip/backend/ingest/repository/LhAnnouncementSupplySourceRepository.java
@@ -12,7 +12,7 @@ public interface LhAnnouncementSupplySourceRepository extends JpaRepository<LhAn
     @Query("select distinct source.panId from LhAnnouncementSupplySource source where source.panId in :panIds")
     List<String> findStoredPanIds(Collection<String> panIds);
 
-    List<LhAnnouncementSupplySource> findAllByPanIdInOrderByPanIdAscSourceOrderAsc(Collection<String> panIds);
+    List<LhAnnouncementSupplySource> findAllByPanIdOrderBySourceOrderAsc(String panId);
 
     void deleteByPanId(String panId);
 }

--- a/backend/src/main/java/com/toadzip/backend/ingest/repository/LhAnnouncementSupplySourceRepository.java
+++ b/backend/src/main/java/com/toadzip/backend/ingest/repository/LhAnnouncementSupplySourceRepository.java
@@ -12,5 +12,7 @@ public interface LhAnnouncementSupplySourceRepository extends JpaRepository<LhAn
     @Query("select distinct source.panId from LhAnnouncementSupplySource source where source.panId in :panIds")
     List<String> findStoredPanIds(Collection<String> panIds);
 
+    List<LhAnnouncementSupplySource> findAllByPanIdInOrderByPanIdAscSourceOrderAsc(Collection<String> panIds);
+
     void deleteByPanId(String panId);
 }

--- a/backend/src/main/java/com/toadzip/backend/ingest/repository/MyHomeAnnouncementMappingExecutionLock.java
+++ b/backend/src/main/java/com/toadzip/backend/ingest/repository/MyHomeAnnouncementMappingExecutionLock.java
@@ -1,0 +1,79 @@
+package com.toadzip.backend.ingest.repository;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Optional;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Supplier;
+import javax.sql.DataSource;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+
+@Slf4j
+@Repository
+public class MyHomeAnnouncementMappingExecutionLock {
+
+    private static final long LOCK_KEY = 8_432_026_082_800_018L;
+
+    private static final String TRY_LOCK_SQL = "SELECT pg_try_advisory_lock(?)";
+
+    private static final String UNLOCK_SQL = "SELECT pg_advisory_unlock(?)";
+
+    private final ReentrantLock localLock = new ReentrantLock();
+
+    private final DataSource dataSource;
+
+    public MyHomeAnnouncementMappingExecutionLock(DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    public <T> Optional<T> tryRun(Supplier<T> operation) {
+        if (!localLock.tryLock()) {
+            return Optional.empty();
+        }
+        try (Connection connection = dataSource.getConnection()) {
+            if (!executeLockQuery(connection, TRY_LOCK_SQL)) {
+                return Optional.empty();
+            }
+            try {
+                return Optional.of(operation.get());
+            }
+            finally {
+                releaseDatabaseLock(connection);
+            }
+        }
+        catch (SQLException exception) {
+            throw new IllegalStateException(
+                    "마이홈 공고 매핑 실행 잠금을 처리하지 못했습니다.",
+                    exception
+            );
+        }
+        finally {
+            localLock.unlock();
+        }
+    }
+
+    private boolean executeLockQuery(Connection connection, String sql) throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setLong(1, LOCK_KEY);
+            try (ResultSet result = statement.executeQuery()) {
+                return result.next() && result.getBoolean(1);
+            }
+        }
+    }
+
+    private void releaseDatabaseLock(Connection connection) {
+        try {
+            executeLockQuery(connection, UNLOCK_SQL);
+        }
+        catch (SQLException exception) {
+            log.error(
+                    "마이홈 공고 매핑 실행 잠금 해제에 실패했습니다. "
+                            + "DB 연결 종료 시 잠금이 해제됩니다.",
+                    exception
+            );
+        }
+    }
+}

--- a/backend/src/main/java/com/toadzip/backend/ingest/repository/MyHomeAnnouncementMappingFailureRepository.java
+++ b/backend/src/main/java/com/toadzip/backend/ingest/repository/MyHomeAnnouncementMappingFailureRepository.java
@@ -1,0 +1,11 @@
+package com.toadzip.backend.ingest.repository;
+
+import com.toadzip.backend.ingest.domain.MyHomeAnnouncementMappingFailure;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MyHomeAnnouncementMappingFailureRepository
+        extends JpaRepository<MyHomeAnnouncementMappingFailure, Long> {
+
+    List<MyHomeAnnouncementMappingFailure> findAllByOrderBySourceKeyAsc();
+}

--- a/backend/src/main/java/com/toadzip/backend/ingest/repository/MyHomeAnnouncementMappingFailureStore.java
+++ b/backend/src/main/java/com/toadzip/backend/ingest/repository/MyHomeAnnouncementMappingFailureStore.java
@@ -1,0 +1,22 @@
+package com.toadzip.backend.ingest.repository;
+
+import com.toadzip.backend.ingest.domain.MyHomeAnnouncementMappingFailure;
+import java.util.List;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+public class MyHomeAnnouncementMappingFailureStore {
+
+    private final MyHomeAnnouncementMappingFailureRepository repository;
+
+    public MyHomeAnnouncementMappingFailureStore(MyHomeAnnouncementMappingFailureRepository repository) {
+        this.repository = repository;
+    }
+
+    @Transactional
+    public void replaceAll(List<MyHomeAnnouncementMappingFailure> failures) {
+        repository.deleteAllInBatch();
+        repository.saveAll(failures);
+    }
+}

--- a/backend/src/main/java/com/toadzip/backend/ingest/service/MyHomeAnnouncementMappingService.java
+++ b/backend/src/main/java/com/toadzip/backend/ingest/service/MyHomeAnnouncementMappingService.java
@@ -40,6 +40,8 @@ public class MyHomeAnnouncementMappingService {
 
     private final MyHomeAnnouncementSourceMapper sourceMapper;
 
+    private final MyHomeAnnouncementSupplyRowResolver supplyRowResolver;
+
     private final MyHomeAnnouncementMappingWriter writer;
 
     private final Clock clock;
@@ -51,6 +53,7 @@ public class MyHomeAnnouncementMappingService {
             MyHomeAnnouncementMappingExecutionLock executionLock,
             AnnouncementRepository announcementRepository,
             MyHomeAnnouncementSourceMapper sourceMapper,
+            MyHomeAnnouncementSupplyRowResolver supplyRowResolver,
             MyHomeAnnouncementMappingWriter writer,
             Clock clock
     ) {
@@ -60,6 +63,7 @@ public class MyHomeAnnouncementMappingService {
         this.executionLock = executionLock;
         this.announcementRepository = announcementRepository;
         this.sourceMapper = sourceMapper;
+        this.supplyRowResolver = supplyRowResolver;
         this.writer = writer;
         this.clock = clock;
     }
@@ -113,7 +117,7 @@ public class MyHomeAnnouncementMappingService {
             );
         }
         try {
-            MyHomeAnnouncementMappingData data = sourceMapper.map(sources);
+            MyHomeAnnouncementMappingData data = supplyRowResolver.resolve(sourceMapper.map(sources));
             PreviousAnnouncementResult previousResult = previousAnnouncementOf(
                     data,
                     groupedSources,

--- a/backend/src/main/java/com/toadzip/backend/ingest/service/MyHomeAnnouncementMappingService.java
+++ b/backend/src/main/java/com/toadzip/backend/ingest/service/MyHomeAnnouncementMappingService.java
@@ -1,0 +1,271 @@
+package com.toadzip.backend.ingest.service;
+
+import com.toadzip.backend.announcement.domain.Announcement;
+import com.toadzip.backend.announcement.repository.AnnouncementRepository;
+import com.toadzip.backend.ingest.domain.MyHomeAnnouncementMappingFailure;
+import com.toadzip.backend.ingest.domain.MyHomeAnnouncementMappingFailureReason;
+import com.toadzip.backend.ingest.domain.MyHomeAnnouncementSource;
+import com.toadzip.backend.ingest.dto.MyHomeAnnouncementMappingFailureResponse;
+import com.toadzip.backend.ingest.dto.MyHomeAnnouncementMappingReport;
+import com.toadzip.backend.ingest.exception.exception.IngestAlreadyRunningException;
+import com.toadzip.backend.ingest.repository.MyHomeAnnouncementMappingExecutionLock;
+import com.toadzip.backend.ingest.repository.MyHomeAnnouncementMappingFailureRepository;
+import com.toadzip.backend.ingest.repository.MyHomeAnnouncementMappingFailureStore;
+import com.toadzip.backend.ingest.repository.MyHomeAnnouncementSourceRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+public class MyHomeAnnouncementMappingService {
+
+    private final MyHomeAnnouncementSourceRepository sourceRepository;
+
+    private final MyHomeAnnouncementMappingFailureRepository failureRepository;
+
+    private final MyHomeAnnouncementMappingFailureStore failureStore;
+
+    private final MyHomeAnnouncementMappingExecutionLock executionLock;
+
+    private final AnnouncementRepository announcementRepository;
+
+    private final MyHomeAnnouncementSourceMapper sourceMapper;
+
+    private final MyHomeAnnouncementMappingWriter writer;
+
+    private final Clock clock;
+
+    public MyHomeAnnouncementMappingService(
+            MyHomeAnnouncementSourceRepository sourceRepository,
+            MyHomeAnnouncementMappingFailureRepository failureRepository,
+            MyHomeAnnouncementMappingFailureStore failureStore,
+            MyHomeAnnouncementMappingExecutionLock executionLock,
+            AnnouncementRepository announcementRepository,
+            MyHomeAnnouncementSourceMapper sourceMapper,
+            MyHomeAnnouncementMappingWriter writer,
+            Clock clock
+    ) {
+        this.sourceRepository = sourceRepository;
+        this.failureRepository = failureRepository;
+        this.failureStore = failureStore;
+        this.executionLock = executionLock;
+        this.announcementRepository = announcementRepository;
+        this.sourceMapper = sourceMapper;
+        this.writer = writer;
+        this.clock = clock;
+    }
+
+    public MyHomeAnnouncementMappingReport mapAll() {
+        return executionLock.tryRun(this::mapAllUnlocked)
+                .orElseThrow(this::alreadyRunning);
+    }
+
+    private MyHomeAnnouncementMappingReport mapAllUnlocked() {
+        Instant occurredAt = clock.instant();
+        List<MyHomeAnnouncementMappingFailure> failures = new ArrayList<>();
+        Map<String, List<MyHomeAnnouncementSource>> groupedSources = groupSources(failures, occurredAt);
+        Set<String> processed = new LinkedHashSet<>();
+        Set<String> processing = new LinkedHashSet<>();
+        MyHomeAnnouncementMappingReport report = MyHomeAnnouncementMappingReport.failedRows(failures.size());
+        for (String identifier : groupedSources.keySet()) {
+            report = report.plus(mapGroup(
+                    identifier,
+                    groupedSources,
+                    processed,
+                    processing,
+                    failures,
+                    occurredAt
+            ));
+        }
+        failureStore.replaceAll(failures);
+        return report;
+    }
+
+    private MyHomeAnnouncementMappingReport mapGroup(
+            String identifier,
+            Map<String, List<MyHomeAnnouncementSource>> groupedSources,
+            Set<String> processed,
+            Set<String> processing,
+            List<MyHomeAnnouncementMappingFailure> failures,
+            Instant occurredAt
+    ) {
+        if (processed.contains(identifier)) {
+            return MyHomeAnnouncementMappingReport.empty();
+        }
+        List<MyHomeAnnouncementSource> sources = groupedSources.get(identifier);
+        if (!processing.add(identifier)) {
+            processed.add(identifier);
+            return reject(
+                    sources,
+                    MyHomeAnnouncementMappingFailureReason.CYCLIC_ANNOUNCEMENT_REVISION,
+                    "이전 공고 참조가 순환합니다.",
+                    failures,
+                    occurredAt
+            );
+        }
+        try {
+            MyHomeAnnouncementMappingData data = sourceMapper.map(sources);
+            PreviousAnnouncementResult previousResult = previousAnnouncementOf(
+                    data,
+                    groupedSources,
+                    processed,
+                    processing,
+                    failures,
+                    occurredAt
+            );
+            if (processed.contains(identifier)) {
+                return previousResult.report();
+            }
+            if (data.previousSourceAnnouncementIdentifier() != null
+                    && previousResult.announcement() == null) {
+                processed.add(identifier);
+                return previousResult.report().plus(reject(
+                        sources,
+                        MyHomeAnnouncementMappingFailureReason.PREVIOUS_ANNOUNCEMENT_NOT_FOUND,
+                        "이전 공고를 찾을 수 없습니다: " + data.previousSourceAnnouncementIdentifier(),
+                        failures,
+                        occurredAt
+                ));
+            }
+            MyHomeAnnouncementWriteResult result = writer.write(data, previousResult.announcement());
+            addSupplyMatchingFailures(failures, result.failures(), occurredAt);
+            processed.add(identifier);
+            return previousResult.report().plus(result.report());
+        }
+        catch (MyHomeAnnouncementMappingRejectedException exception) {
+            processed.add(identifier);
+            return reject(sources, exception.reason(), exception.getMessage(), failures, occurredAt);
+        }
+        finally {
+            processing.remove(identifier);
+        }
+    }
+
+    private PreviousAnnouncementResult previousAnnouncementOf(
+            MyHomeAnnouncementMappingData data,
+            Map<String, List<MyHomeAnnouncementSource>> groupedSources,
+            Set<String> processed,
+            Set<String> processing,
+            List<MyHomeAnnouncementMappingFailure> failures,
+            Instant occurredAt
+    ) {
+        String previousIdentifier = data.previousSourceAnnouncementIdentifier();
+        if (previousIdentifier == null) {
+            return PreviousAnnouncementResult.empty();
+        }
+        MyHomeAnnouncementMappingReport report = MyHomeAnnouncementMappingReport.empty();
+        if (groupedSources.containsKey(previousIdentifier)) {
+            report = mapGroup(
+                    previousIdentifier,
+                    groupedSources,
+                    processed,
+                    processing,
+                    failures,
+                    occurredAt
+            );
+        }
+        Announcement previous = announcementRepository
+                .findBySourceAnnouncementIdentifier(previousIdentifier)
+                .orElse(null);
+        return new PreviousAnnouncementResult(previous, report);
+    }
+
+    private Map<String, List<MyHomeAnnouncementSource>> groupSources(
+            List<MyHomeAnnouncementMappingFailure> failures,
+            Instant occurredAt
+    ) {
+        Map<String, List<MyHomeAnnouncementSource>> grouped = new LinkedHashMap<>();
+        for (MyHomeAnnouncementSource source : sourceRepository.findAll()) {
+            String identifier = normalizedText(source.getPblancId());
+            if (identifier == null) {
+                failures.add(failureOf(
+                        source,
+                        MyHomeAnnouncementMappingFailureReason.MISSING_REQUIRED_VALUE,
+                        "공고 식별자 값이 없습니다.",
+                        occurredAt
+                ));
+                continue;
+            }
+            grouped.computeIfAbsent(identifier, ignored -> new ArrayList<>()).add(source);
+        }
+        return grouped;
+    }
+
+    private MyHomeAnnouncementMappingReport reject(
+            List<MyHomeAnnouncementSource> sources,
+            MyHomeAnnouncementMappingFailureReason reason,
+            String detail,
+            List<MyHomeAnnouncementMappingFailure> failures,
+            Instant occurredAt
+    ) {
+        for (MyHomeAnnouncementSource source : sources) {
+            failures.add(failureOf(source, reason, detail, occurredAt));
+        }
+        return MyHomeAnnouncementMappingReport.failedRows(sources.size());
+    }
+
+    private void addSupplyMatchingFailures(
+            List<MyHomeAnnouncementMappingFailure> failures,
+            List<MyHomeSupplyMatchingFailureData> matchingFailures,
+            Instant occurredAt
+    ) {
+        for (MyHomeSupplyMatchingFailureData failure : matchingFailures) {
+            failures.add(failureOf(failure.source(), failure.reason(), failure.detail(), occurredAt));
+        }
+    }
+
+    private MyHomeAnnouncementMappingFailure failureOf(
+            MyHomeAnnouncementSource source,
+            MyHomeAnnouncementMappingFailureReason reason,
+            String detail,
+            Instant occurredAt
+    ) {
+        return MyHomeAnnouncementMappingFailure.create(
+                source.getSourceKey(),
+                source.getPblancId(),
+                source.getHouseSn(),
+                reason,
+                detail,
+                occurredAt
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public List<MyHomeAnnouncementMappingFailureResponse> findFailures() {
+        return failureRepository.findAllByOrderBySourceKeyAsc()
+                .stream()
+                .map(MyHomeAnnouncementMappingFailureResponse::from)
+                .toList();
+    }
+
+    private String normalizedText(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        return value.strip();
+    }
+
+    private IngestAlreadyRunningException alreadyRunning() {
+        log.warn("마이홈 공고 매핑이 이미 실행 중이므로 중복 실행을 건너뜁니다.");
+        return new IngestAlreadyRunningException("마이홈 공고 매핑이 이미 실행 중입니다.");
+    }
+
+    private record PreviousAnnouncementResult(
+            Announcement announcement,
+            MyHomeAnnouncementMappingReport report
+    ) {
+
+        static PreviousAnnouncementResult empty() {
+            return new PreviousAnnouncementResult(null, MyHomeAnnouncementMappingReport.empty());
+        }
+    }
+}

--- a/backend/src/main/java/com/toadzip/backend/ingest/service/MyHomeAnnouncementMappingWriter.java
+++ b/backend/src/main/java/com/toadzip/backend/ingest/service/MyHomeAnnouncementMappingWriter.java
@@ -11,6 +11,7 @@ import com.toadzip.backend.housing.repository.HousingTypeRepository;
 import com.toadzip.backend.ingest.domain.MyHomeAnnouncementMappingFailureReason;
 import com.toadzip.backend.ingest.domain.MyHomeAnnouncementSource;
 import com.toadzip.backend.ingest.dto.MyHomeAnnouncementMappingReport;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -125,7 +126,7 @@ public class MyHomeAnnouncementMappingWriter {
             if (match.failure() != null) {
                 failures.add(match.failure());
             }
-            SupplyRow stored = storedRows.get(data.source().getSourceKey());
+            SupplyRow stored = storedRows.remove(data.sourceSupplyRowIdentifier());
             if (stored == null) {
                 supplyRowRepository.save(createSupplyRow(announcement, data, match, index + 1));
                 created++;
@@ -162,7 +163,7 @@ public class MyHomeAnnouncementMappingWriter {
                 announcement,
                 match.complex(),
                 match.housingType(),
-                data.source().getSourceKey(),
+                data.sourceSupplyRowIdentifier(),
                 displayOrder,
                 data.sourceComplexName(),
                 data.sourceHousingTypeName(),
@@ -225,11 +226,17 @@ public class MyHomeAnnouncementMappingWriter {
         if (housingTypes.size() > 1) {
             HousingType matched = uniqueHousingTypeByName(housingTypes, data.sourceHousingTypeName());
             if (matched == null) {
+                matched = uniqueHousingTypeByExclusiveArea(housingTypes, data.exclusiveArea());
+            }
+            if (matched == null) {
+                matched = uniqueHousingTypeBySupplyArea(housingTypes, data.supplyArea());
+            }
+            if (matched == null) {
                 return SupplyMatchResult.failure(
                         data,
                         complex,
                         MyHomeAnnouncementMappingFailureReason.AMBIGUOUS_HOUSING_TYPE,
-                        "공고 원본의 주택형명을 보정해도 주택형 하나를 확정할 수 없습니다."
+                        "LH 공급행의 주택형명과 면적으로도 주택형 하나를 확정할 수 없습니다."
                 );
             }
             return SupplyMatchResult.matched(complex, matched);
@@ -247,6 +254,52 @@ public class MyHomeAnnouncementMappingWriter {
             return null;
         }
         return matched.getFirst();
+    }
+
+    private HousingType uniqueHousingTypeByExclusiveArea(
+            List<HousingType> housingTypes,
+            BigDecimal exclusiveArea
+    ) {
+        if (exclusiveArea == null) {
+            return null;
+        }
+        return uniqueHousingTypeByArea(
+                housingTypes,
+                housingType -> housingType.getExclusiveArea(),
+                exclusiveArea
+        );
+    }
+
+    private HousingType uniqueHousingTypeBySupplyArea(
+            List<HousingType> housingTypes,
+            BigDecimal supplyArea
+    ) {
+        if (supplyArea == null) {
+            return null;
+        }
+        return uniqueHousingTypeByArea(
+                housingTypes,
+                HousingType::getSupplyArea,
+                supplyArea
+        );
+    }
+
+    private HousingType uniqueHousingTypeByArea(
+            List<HousingType> housingTypes,
+            Function<HousingType, BigDecimal> areaExtractor,
+            BigDecimal sourceArea
+    ) {
+        List<HousingType> matched = housingTypes.stream()
+                .filter(housingType -> sameArea(areaExtractor.apply(housingType), sourceArea))
+                .toList();
+        if (matched.size() != 1) {
+            return null;
+        }
+        return matched.getFirst();
+    }
+
+    private boolean sameArea(BigDecimal left, BigDecimal right) {
+        return left != null && right != null && left.compareTo(right) == 0;
     }
 
     private MyHomeAnnouncementMappingReport reportOf(

--- a/backend/src/main/java/com/toadzip/backend/ingest/service/MyHomeAnnouncementMappingWriter.java
+++ b/backend/src/main/java/com/toadzip/backend/ingest/service/MyHomeAnnouncementMappingWriter.java
@@ -1,0 +1,301 @@
+package com.toadzip.backend.ingest.service;
+
+import com.toadzip.backend.announcement.domain.Announcement;
+import com.toadzip.backend.announcement.domain.SupplyRow;
+import com.toadzip.backend.announcement.repository.AnnouncementRepository;
+import com.toadzip.backend.announcement.repository.SupplyRowRepository;
+import com.toadzip.backend.housing.domain.HousingComplex;
+import com.toadzip.backend.housing.domain.HousingType;
+import com.toadzip.backend.housing.repository.HousingComplexRepository;
+import com.toadzip.backend.housing.repository.HousingTypeRepository;
+import com.toadzip.backend.ingest.domain.MyHomeAnnouncementMappingFailureReason;
+import com.toadzip.backend.ingest.domain.MyHomeAnnouncementSource;
+import com.toadzip.backend.ingest.dto.MyHomeAnnouncementMappingReport;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class MyHomeAnnouncementMappingWriter {
+
+    private final AnnouncementRepository announcementRepository;
+
+    private final SupplyRowRepository supplyRowRepository;
+
+    private final HousingComplexRepository housingComplexRepository;
+
+    private final HousingTypeRepository housingTypeRepository;
+
+    public MyHomeAnnouncementMappingWriter(
+            AnnouncementRepository announcementRepository,
+            SupplyRowRepository supplyRowRepository,
+            HousingComplexRepository housingComplexRepository,
+            HousingTypeRepository housingTypeRepository
+    ) {
+        this.announcementRepository = announcementRepository;
+        this.supplyRowRepository = supplyRowRepository;
+        this.housingComplexRepository = housingComplexRepository;
+        this.housingTypeRepository = housingTypeRepository;
+    }
+
+    @Transactional
+    public MyHomeAnnouncementWriteResult write(
+            MyHomeAnnouncementMappingData data,
+            Announcement previousAnnouncement
+    ) {
+        AnnouncementWriteResult announcementResult = writeAnnouncement(data, previousAnnouncement);
+        SupplyRowsWriteResult supplyRowsResult = writeSupplyRows(announcementResult.announcement(), data.supplyRows());
+        return new MyHomeAnnouncementWriteResult(
+                reportOf(announcementResult, supplyRowsResult),
+                supplyRowsResult.failures()
+        );
+    }
+
+    private AnnouncementWriteResult writeAnnouncement(
+            MyHomeAnnouncementMappingData data,
+            Announcement previousAnnouncement
+    ) {
+        Announcement stored = announcementRepository
+                .findBySourceAnnouncementIdentifier(data.sourceAnnouncementIdentifier())
+                .orElse(null);
+        if (stored == null) {
+            Announcement created = announcementRepository.save(Announcement.create(
+                    data.sourceAnnouncementIdentifier(),
+                    data.previousSourceAnnouncementIdentifier(),
+                    previousAnnouncement,
+                    data.name(),
+                    data.publicationType(),
+                    data.rentalType(),
+                    data.recruitmentType(),
+                    data.provider(),
+                    data.postedDate(),
+                    data.applicationStartDate(),
+                    data.applicationEndDate(),
+                    data.winnerAnnouncementDate(),
+                    data.originalUrl(),
+                    null,
+                    0L,
+                    data.receptionPlace()
+            ));
+            return new AnnouncementWriteResult(created, true, false);
+        }
+        boolean updated = stored.updateFromSource(
+                data.previousSourceAnnouncementIdentifier(),
+                previousAnnouncement,
+                data.name(),
+                data.publicationType(),
+                data.rentalType(),
+                data.recruitmentType(),
+                data.provider(),
+                data.postedDate(),
+                data.applicationStartDate(),
+                data.applicationEndDate(),
+                data.winnerAnnouncementDate(),
+                data.originalUrl(),
+                null,
+                data.receptionPlace()
+        );
+        return new AnnouncementWriteResult(stored, false, updated);
+    }
+
+    private SupplyRowsWriteResult writeSupplyRows(
+            Announcement announcement,
+            List<MyHomeSupplyRowMappingData> rows
+    ) {
+        Map<String, SupplyRow> storedRows = supplyRowRepository.findAllByAnnouncement(announcement)
+                .stream()
+                .collect(Collectors.toMap(
+                        SupplyRow::getSourceSupplyRowIdentifier,
+                        Function.identity(),
+                        (left, right) -> left,
+                        LinkedHashMap::new
+                ));
+        int created = 0;
+        int updated = 0;
+        int unchanged = 0;
+        List<MyHomeSupplyMatchingFailureData> failures = new ArrayList<>();
+        for (int index = 0; index < rows.size(); index++) {
+            MyHomeSupplyRowMappingData data = rows.get(index);
+            SupplyMatchResult match = match(data);
+            if (match.failure() != null) {
+                failures.add(match.failure());
+            }
+            SupplyRow stored = storedRows.get(data.source().getSourceKey());
+            if (stored == null) {
+                supplyRowRepository.save(createSupplyRow(announcement, data, match, index + 1));
+                created++;
+                continue;
+            }
+            boolean changed = stored.updateFromSource(
+                    match.complex(),
+                    match.housingType(),
+                    index + 1,
+                    data.sourceComplexName(),
+                    data.sourceHousingTypeName(),
+                    data.pnu(),
+                    null,
+                    data.supplyCategory(),
+                    match.failureDetail(),
+                    data.totalSupplyHouseholdCount()
+            );
+            if (changed) {
+                updated++;
+                continue;
+            }
+            unchanged++;
+        }
+        return new SupplyRowsWriteResult(created, updated, unchanged, failures);
+    }
+
+    private SupplyRow createSupplyRow(
+            Announcement announcement,
+            MyHomeSupplyRowMappingData data,
+            SupplyMatchResult match,
+            int displayOrder
+    ) {
+        return SupplyRow.create(
+                announcement,
+                match.complex(),
+                match.housingType(),
+                data.source().getSourceKey(),
+                displayOrder,
+                data.sourceComplexName(),
+                data.sourceHousingTypeName(),
+                data.pnu(),
+                null,
+                data.supplyCategory(),
+                match.failureDetail(),
+                data.totalSupplyHouseholdCount()
+        );
+    }
+
+    private SupplyMatchResult match(MyHomeSupplyRowMappingData data) {
+        List<HousingComplex> complexes = housingComplexRepository.findAllByPnuAndSupplyType(
+                data.pnu(),
+                data.complexSupplyType()
+        );
+        if (complexes.isEmpty()) {
+            return SupplyMatchResult.failure(
+                    data,
+                    MyHomeAnnouncementMappingFailureReason.COMPLEX_NOT_FOUND,
+                    "PNU와 공급유형이 일치하는 단지가 없습니다."
+            );
+        }
+        if (complexes.size() > 1) {
+            return SupplyMatchResult.failure(
+                    data,
+                    MyHomeAnnouncementMappingFailureReason.AMBIGUOUS_COMPLEX,
+                    "PNU와 공급유형이 일치하는 단지가 여러 개입니다."
+            );
+        }
+        HousingComplex complex = complexes.getFirst();
+        List<HousingType> housingTypes = housingTypeRepository.findAllByHousingComplex(complex);
+        if (housingTypes.isEmpty()) {
+            return SupplyMatchResult.failure(
+                    data,
+                    complex,
+                    MyHomeAnnouncementMappingFailureReason.HOUSING_TYPE_NOT_FOUND,
+                    "단지에 연결된 주택형이 없습니다."
+            );
+        }
+        if (housingTypes.size() > 1) {
+            return SupplyMatchResult.failure(
+                    data,
+                    complex,
+                    MyHomeAnnouncementMappingFailureReason.AMBIGUOUS_HOUSING_TYPE,
+                    "공고 원본만으로 주택형 하나를 확정할 수 없습니다."
+            );
+        }
+        return SupplyMatchResult.matched(complex, housingTypes.getFirst());
+    }
+
+    private MyHomeAnnouncementMappingReport reportOf(
+            AnnouncementWriteResult announcement,
+            SupplyRowsWriteResult supplyRows
+    ) {
+        int createdAnnouncement = announcement.created() ? 1 : 0;
+        int updatedAnnouncement = announcement.updated() ? 1 : 0;
+        int unchangedAnnouncement = announcement.unchanged() ? 1 : 0;
+        return new MyHomeAnnouncementMappingReport(
+                createdAnnouncement,
+                updatedAnnouncement,
+                unchangedAnnouncement,
+                supplyRows.created(),
+                supplyRows.updated(),
+                supplyRows.unchanged(),
+                supplyRows.failures().size()
+        );
+    }
+
+    private record AnnouncementWriteResult(Announcement announcement, boolean created, boolean updated) {
+
+        boolean unchanged() {
+            return !created && !updated;
+        }
+    }
+
+    private record SupplyRowsWriteResult(
+            int created,
+            int updated,
+            int unchanged,
+            List<MyHomeSupplyMatchingFailureData> failures
+    ) {
+    }
+
+    private record SupplyMatchResult(
+            HousingComplex complex,
+            HousingType housingType,
+            MyHomeSupplyMatchingFailureData failure
+    ) {
+
+        static SupplyMatchResult matched(HousingComplex complex, HousingType housingType) {
+            return new SupplyMatchResult(complex, housingType, null);
+        }
+
+        static SupplyMatchResult failure(
+                MyHomeSupplyRowMappingData data,
+                MyHomeAnnouncementMappingFailureReason reason,
+                String detail
+        ) {
+            return failure(data, null, reason, detail);
+        }
+
+        static SupplyMatchResult failure(
+                MyHomeSupplyRowMappingData data,
+                HousingComplex complex,
+                MyHomeAnnouncementMappingFailureReason reason,
+                String detail
+        ) {
+            return new SupplyMatchResult(
+                    complex,
+                    null,
+                    new MyHomeSupplyMatchingFailureData(data.source(), reason, detail)
+            );
+        }
+
+        String failureDetail() {
+            if (failure == null) {
+                return null;
+            }
+            return failure.detail();
+        }
+    }
+}
+
+record MyHomeAnnouncementWriteResult(
+        MyHomeAnnouncementMappingReport report,
+        List<MyHomeSupplyMatchingFailureData> failures
+) {
+}
+
+record MyHomeSupplyMatchingFailureData(
+        MyHomeAnnouncementSource source,
+        MyHomeAnnouncementMappingFailureReason reason,
+        String detail
+) {
+}

--- a/backend/src/main/java/com/toadzip/backend/ingest/service/MyHomeAnnouncementMappingWriter.java
+++ b/backend/src/main/java/com/toadzip/backend/ingest/service/MyHomeAnnouncementMappingWriter.java
@@ -4,6 +4,7 @@ import com.toadzip.backend.announcement.domain.Announcement;
 import com.toadzip.backend.announcement.domain.SupplyRow;
 import com.toadzip.backend.announcement.repository.AnnouncementRepository;
 import com.toadzip.backend.announcement.repository.SupplyRowRepository;
+import com.toadzip.backend.announcement.repository.SupplyTargetRepository;
 import com.toadzip.backend.housing.domain.HousingComplex;
 import com.toadzip.backend.housing.domain.HousingType;
 import com.toadzip.backend.housing.repository.HousingComplexRepository;
@@ -28,6 +29,8 @@ public class MyHomeAnnouncementMappingWriter {
 
     private final SupplyRowRepository supplyRowRepository;
 
+    private final SupplyTargetRepository supplyTargetRepository;
+
     private final HousingComplexRepository housingComplexRepository;
 
     private final HousingTypeRepository housingTypeRepository;
@@ -35,11 +38,13 @@ public class MyHomeAnnouncementMappingWriter {
     public MyHomeAnnouncementMappingWriter(
             AnnouncementRepository announcementRepository,
             SupplyRowRepository supplyRowRepository,
+            SupplyTargetRepository supplyTargetRepository,
             HousingComplexRepository housingComplexRepository,
             HousingTypeRepository housingTypeRepository
     ) {
         this.announcementRepository = announcementRepository;
         this.supplyRowRepository = supplyRowRepository;
+        this.supplyTargetRepository = supplyTargetRepository;
         this.housingComplexRepository = housingComplexRepository;
         this.housingTypeRepository = housingTypeRepository;
     }
@@ -150,7 +155,17 @@ public class MyHomeAnnouncementMappingWriter {
             }
             unchanged++;
         }
-        return new SupplyRowsWriteResult(created, updated, unchanged, failures);
+        List<SupplyRow> staleRows = List.copyOf(storedRows.values());
+        deleteStaleRows(staleRows);
+        return new SupplyRowsWriteResult(created, updated, unchanged, staleRows.size(), failures);
+    }
+
+    private void deleteStaleRows(List<SupplyRow> staleRows) {
+        if (staleRows.isEmpty()) {
+            return;
+        }
+        supplyTargetRepository.deleteAllBySupplyRowIn(staleRows);
+        supplyRowRepository.deleteAll(staleRows);
     }
 
     private SupplyRow createSupplyRow(
@@ -316,6 +331,7 @@ public class MyHomeAnnouncementMappingWriter {
                 supplyRows.created(),
                 supplyRows.updated(),
                 supplyRows.unchanged(),
+                supplyRows.deleted(),
                 supplyRows.failures().size()
         );
     }
@@ -331,6 +347,7 @@ public class MyHomeAnnouncementMappingWriter {
             int created,
             int updated,
             int unchanged,
+            int deleted,
             List<MyHomeSupplyMatchingFailureData> failures
     ) {
     }

--- a/backend/src/main/java/com/toadzip/backend/ingest/service/MyHomeAnnouncementMappingWriter.java
+++ b/backend/src/main/java/com/toadzip/backend/ingest/service/MyHomeAnnouncementMappingWriter.java
@@ -187,13 +187,32 @@ public class MyHomeAnnouncementMappingWriter {
             );
         }
         if (complexes.size() > 1) {
-            return SupplyMatchResult.failure(
-                    data,
-                    MyHomeAnnouncementMappingFailureReason.AMBIGUOUS_COMPLEX,
-                    "PNU와 공급유형이 일치하는 단지가 여러 개입니다."
-            );
+            HousingComplex matched = uniqueComplexByName(complexes, data.sourceComplexName());
+            if (matched == null) {
+                return SupplyMatchResult.failure(
+                        data,
+                        MyHomeAnnouncementMappingFailureReason.AMBIGUOUS_COMPLEX,
+                        "PNU와 공급유형이 일치하는 단지를 단지명으로도 하나로 확정할 수 없습니다."
+                );
+            }
+            return matchHousingType(data, matched);
         }
-        HousingComplex complex = complexes.getFirst();
+        return matchHousingType(data, complexes.getFirst());
+    }
+
+    private HousingComplex uniqueComplexByName(List<HousingComplex> complexes, String sourceName) {
+        String normalizedSourceName = MyHomeSupplyNameNormalizer.complexName(sourceName);
+        List<HousingComplex> matched = complexes.stream()
+                .filter(complex -> MyHomeSupplyNameNormalizer.complexName(complex.getName())
+                        .equals(normalizedSourceName))
+                .toList();
+        if (matched.size() != 1) {
+            return null;
+        }
+        return matched.getFirst();
+    }
+
+    private SupplyMatchResult matchHousingType(MyHomeSupplyRowMappingData data, HousingComplex complex) {
         List<HousingType> housingTypes = housingTypeRepository.findAllByHousingComplex(complex);
         if (housingTypes.isEmpty()) {
             return SupplyMatchResult.failure(
@@ -204,14 +223,30 @@ public class MyHomeAnnouncementMappingWriter {
             );
         }
         if (housingTypes.size() > 1) {
-            return SupplyMatchResult.failure(
-                    data,
-                    complex,
-                    MyHomeAnnouncementMappingFailureReason.AMBIGUOUS_HOUSING_TYPE,
-                    "공고 원본만으로 주택형 하나를 확정할 수 없습니다."
-            );
+            HousingType matched = uniqueHousingTypeByName(housingTypes, data.sourceHousingTypeName());
+            if (matched == null) {
+                return SupplyMatchResult.failure(
+                        data,
+                        complex,
+                        MyHomeAnnouncementMappingFailureReason.AMBIGUOUS_HOUSING_TYPE,
+                        "공고 원본의 주택형명을 보정해도 주택형 하나를 확정할 수 없습니다."
+                );
+            }
+            return SupplyMatchResult.matched(complex, matched);
         }
         return SupplyMatchResult.matched(complex, housingTypes.getFirst());
+    }
+
+    private HousingType uniqueHousingTypeByName(List<HousingType> housingTypes, String sourceName) {
+        String normalizedSourceName = MyHomeSupplyNameNormalizer.housingTypeName(sourceName);
+        List<HousingType> matched = housingTypes.stream()
+                .filter(housingType -> MyHomeSupplyNameNormalizer.housingTypeName(housingType.getName())
+                        .equals(normalizedSourceName))
+                .toList();
+        if (matched.size() != 1) {
+            return null;
+        }
+        return matched.getFirst();
     }
 
     private MyHomeAnnouncementMappingReport reportOf(

--- a/backend/src/main/java/com/toadzip/backend/ingest/service/MyHomeAnnouncementSourceMapper.java
+++ b/backend/src/main/java/com/toadzip/backend/ingest/service/MyHomeAnnouncementSourceMapper.java
@@ -65,7 +65,7 @@ public class MyHomeAnnouncementSourceMapper {
                 "이전 공고 식별자"
         );
         String originalUrl = requiredText(sources, this::originalUrlOf, "원문 URL");
-        String contact = requiredText(sources, MyHomeAnnouncementSource::getRefrnc, "문의처");
+        String contact = optionalText(sources, MyHomeAnnouncementSource::getRefrnc, "문의처");
         AnnouncementPublicationType publicationType = publicationTypeOf(sourceStatus, previousIdentifier);
         RentalType rentalType = rentalTypeOf(sourceSupplyType);
         LocalDate postedDate = commonDate(sources, MyHomeAnnouncementSource::getRcritPblancDe, "모집 공고일");

--- a/backend/src/main/java/com/toadzip/backend/ingest/service/MyHomeAnnouncementSourceMapper.java
+++ b/backend/src/main/java/com/toadzip/backend/ingest/service/MyHomeAnnouncementSourceMapper.java
@@ -1,0 +1,359 @@
+package com.toadzip.backend.ingest.service;
+
+import com.toadzip.backend.announcement.domain.AnnouncementPublicationType;
+import com.toadzip.backend.announcement.domain.ReceptionMethod;
+import com.toadzip.backend.announcement.domain.ReceptionPlace;
+import com.toadzip.backend.announcement.domain.RecruitmentType;
+import com.toadzip.backend.announcement.domain.SupplyCategory;
+import com.toadzip.backend.housing.domain.AgencyCode;
+import com.toadzip.backend.housing.domain.RentalType;
+import com.toadzip.backend.ingest.domain.MyHomeAnnouncementMappingFailureReason;
+import com.toadzip.backend.ingest.domain.MyHomeAnnouncementSource;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.time.format.ResolverStyle;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MyHomeAnnouncementSourceMapper {
+
+    private static final Map<String, RentalType> RENTAL_TYPES = Map.ofEntries(
+            Map.entry("행복주택", RentalType.HAPPY_HOUSING),
+            Map.entry("국민임대", RentalType.NATIONAL_RENTAL),
+            Map.entry("영구임대", RentalType.PERMANENT_RENTAL),
+            Map.entry("50년임대", RentalType.PUBLIC_RENTAL_50Y),
+            Map.entry("50년공공임대", RentalType.PUBLIC_RENTAL_50Y),
+            Map.entry("통합공공임대", RentalType.INTEGRATED_PUBLIC_RENTAL),
+            Map.entry("재개발임대", RentalType.REDEVELOPMENT_RENTAL)
+    );
+
+    private static final Map<String, String> COMPLEX_SUPPLY_TYPES = Map.ofEntries(
+            Map.entry("행복주택", "HAPPY_HOUSING"),
+            Map.entry("국민임대", "NATIONAL_RENTAL"),
+            Map.entry("영구임대", "PERMANENT_RENTAL"),
+            Map.entry("5년임대", "PUBLIC_RENTAL_5Y"),
+            Map.entry("10년임대", "PUBLIC_RENTAL_10Y"),
+            Map.entry("50년임대", "PUBLIC_RENTAL_50Y"),
+            Map.entry("50년공공임대", "PUBLIC_RENTAL_50Y"),
+            Map.entry("통합공공임대", "INTEGRATED_PUBLIC_RENTAL"),
+            Map.entry("재개발임대", "REDEVELOPMENT_RENTAL")
+    );
+
+    private static final DateTimeFormatter COMPACT_DATE = DateTimeFormatter.ofPattern("uuuuMMdd")
+            .withResolverStyle(ResolverStyle.STRICT);
+
+    private static final DateTimeFormatter DOTTED_DATE = DateTimeFormatter.ofPattern("uuuu.MM.dd")
+            .withResolverStyle(ResolverStyle.STRICT);
+
+    public MyHomeAnnouncementMappingData map(List<MyHomeAnnouncementSource> sources) {
+        String identifier = requiredText(sources, MyHomeAnnouncementSource::getPblancId, "공고 식별자");
+        String name = requiredText(sources, MyHomeAnnouncementSource::getPblancNm, "공고명");
+        String sourceStatus = requiredText(sources, MyHomeAnnouncementSource::getSttusNm, "공고 상태");
+        String sourceSupplyType = requiredText(sources, MyHomeAnnouncementSource::getSuplyTyNm, "공급유형");
+        String sourceProvider = requiredText(sources, MyHomeAnnouncementSource::getSuplyInsttNm, "공급기관");
+        String previousIdentifier = optionalText(
+                sources,
+                MyHomeAnnouncementSource::getBeforePblancId,
+                "이전 공고 식별자"
+        );
+        String originalUrl = requiredText(sources, this::originalUrlOf, "원문 URL");
+        String contact = requiredText(sources, MyHomeAnnouncementSource::getRefrnc, "문의처");
+        AnnouncementPublicationType publicationType = publicationTypeOf(sourceStatus, previousIdentifier);
+        RentalType rentalType = rentalTypeOf(sourceSupplyType);
+        LocalDate postedDate = commonDate(sources, MyHomeAnnouncementSource::getRcritPblancDe, "모집 공고일");
+        LocalDate applicationStartDate = commonDate(sources, MyHomeAnnouncementSource::getBeginDe, "모집 시작일");
+        LocalDate applicationEndDate = commonDate(sources, MyHomeAnnouncementSource::getEndDe, "모집 종료일");
+        LocalDate winnerAnnouncementDate = commonDate(
+                sources,
+                MyHomeAnnouncementSource::getPrzwnerPresnatnDe,
+                "당첨자 발표일"
+        );
+        validateApplicationPeriod(applicationStartDate, applicationEndDate);
+        List<MyHomeSupplyRowMappingData> supplyRows = ordered(sources).stream()
+                .map(source -> supplyRowOf(source, name, sourceSupplyType))
+                .toList();
+        return new MyHomeAnnouncementMappingData(
+                identifier,
+                previousIdentifier,
+                name,
+                publicationType,
+                rentalType,
+                recruitmentTypeOf(name),
+                providerOf(sourceProvider),
+                postedDate,
+                applicationStartDate,
+                applicationEndDate,
+                winnerAnnouncementDate,
+                originalUrl,
+                ReceptionPlace.create(sourceProvider, ReceptionMethod.ONLINE, null, contact, originalUrl),
+                supplyRows
+        );
+    }
+
+    private MyHomeSupplyRowMappingData supplyRowOf(
+            MyHomeAnnouncementSource source,
+            String announcementName,
+            String sourceSupplyType
+    ) {
+        if (source.getHouseSn() == null) {
+            throw missing("주택 일련번호");
+        }
+        String pnu = pnuOf(requiredText(source.getPnu(), "PNU"));
+        return new MyHomeSupplyRowMappingData(
+                source,
+                requiredText(source.getHsmpNm(), "단지명"),
+                requiredText(source.getHouseTyNm(), "주택유형명"),
+                pnu,
+                complexSupplyTypeOf(sourceSupplyType),
+                supplyCategoryOf(announcementName),
+                nonNegative(source.getSumSuplyCo(), "공급호수")
+        );
+    }
+
+    private List<MyHomeAnnouncementSource> ordered(List<MyHomeAnnouncementSource> sources) {
+        List<MyHomeAnnouncementSource> ordered = new ArrayList<>(sources);
+        ordered.sort(Comparator.comparing(
+                MyHomeAnnouncementSource::getSourceOrder,
+                Comparator.nullsLast(Comparator.naturalOrder())
+        ).thenComparing(MyHomeAnnouncementSource::getId, Comparator.nullsLast(Comparator.naturalOrder())));
+        return ordered;
+    }
+
+    private String requiredText(
+            List<MyHomeAnnouncementSource> sources,
+            Function<MyHomeAnnouncementSource, String> extractor,
+            String fieldName
+    ) {
+        String value = optionalText(sources, extractor, fieldName);
+        if (value == null) {
+            throw missing(fieldName);
+        }
+        return value;
+    }
+
+    private String optionalText(
+            List<MyHomeAnnouncementSource> sources,
+            Function<MyHomeAnnouncementSource, String> extractor,
+            String fieldName
+    ) {
+        Set<String> values = new LinkedHashSet<>();
+        for (MyHomeAnnouncementSource source : sources) {
+            String value = normalizedText(extractor.apply(source));
+            if (value != null) {
+                values.add(value);
+            }
+        }
+        if (values.size() > 1) {
+            throw conflict(fieldName);
+        }
+        return values.stream().findFirst().orElse(null);
+    }
+
+    private String requiredText(String value, String fieldName) {
+        String normalized = normalizedText(value);
+        if (normalized == null) {
+            throw missing(fieldName);
+        }
+        return normalized;
+    }
+
+    private String originalUrlOf(MyHomeAnnouncementSource source) {
+        if (normalizedText(source.getUrl()) != null) {
+            return normalizedText(source.getUrl());
+        }
+        if (normalizedText(source.getPcUrl()) != null) {
+            return normalizedText(source.getPcUrl());
+        }
+        return normalizedText(source.getMobileUrl());
+    }
+
+    private AnnouncementPublicationType publicationTypeOf(String status, String previousIdentifier) {
+        if (status.contains("취소")) {
+            requirePreviousIdentifier(previousIdentifier, "취소공고");
+            return AnnouncementPublicationType.CANCELLATION;
+        }
+        if (previousIdentifier != null) {
+            return AnnouncementPublicationType.CORRECTION;
+        }
+        if (status.contains("정정")) {
+            throw missing("정정공고의 이전 공고 식별자");
+        }
+        return AnnouncementPublicationType.ORIGINAL;
+    }
+
+    private void requirePreviousIdentifier(String previousIdentifier, String status) {
+        if (previousIdentifier == null) {
+            throw missing(status + "의 이전 공고 식별자");
+        }
+    }
+
+    private RentalType rentalTypeOf(String value) {
+        return RENTAL_TYPES.getOrDefault(value, RentalType.ETC);
+    }
+
+    private String complexSupplyTypeOf(String value) {
+        String supplyType = COMPLEX_SUPPLY_TYPES.get(value);
+        if (supplyType == null) {
+            throw invalid("지원하지 않는 단지 공급유형입니다: " + value);
+        }
+        return supplyType;
+    }
+
+    private AgencyCode providerOf(String value) {
+        if (value.startsWith("LH") || value.equals("한국토지주택공사")) {
+            return AgencyCode.LH;
+        }
+        if (Set.of("SH공사", "서울주택도시공사").contains(value)) {
+            return AgencyCode.SH;
+        }
+        if (value.equals("경기주택도시공사")) {
+            return AgencyCode.GH;
+        }
+        return AgencyCode.ETC;
+    }
+
+    private RecruitmentType recruitmentTypeOf(String name) {
+        if (name.contains("예비")) {
+            return RecruitmentType.WAITLIST;
+        }
+        if (name.contains("모집")) {
+            return RecruitmentType.NEW;
+        }
+        return RecruitmentType.ETC;
+    }
+
+    private SupplyCategory supplyCategoryOf(String announcementName) {
+        if (announcementName.contains("예비")
+                || announcementName.contains("추가")
+                || announcementName.contains("재공급")) {
+            return SupplyCategory.RESUPPLY;
+        }
+        return SupplyCategory.NEW_SUPPLY;
+    }
+
+    private LocalDate dateOf(String value, String fieldName) {
+        DateTimeFormatter formatter = COMPACT_DATE;
+        if (value.contains(".")) {
+            formatter = DOTTED_DATE;
+        }
+        if (value.contains("-")) {
+            formatter = DateTimeFormatter.ISO_LOCAL_DATE;
+        }
+        try {
+            return LocalDate.parse(value, formatter);
+        }
+        catch (DateTimeParseException exception) {
+            throw invalid(fieldName + " 형식이 올바르지 않습니다.");
+        }
+    }
+
+    private LocalDate commonDate(
+            List<MyHomeAnnouncementSource> sources,
+            Function<MyHomeAnnouncementSource, String> extractor,
+            String fieldName
+    ) {
+        return dateOf(requiredText(sources, extractor, fieldName), fieldName);
+    }
+
+    private String pnuOf(String pnu) {
+        if (pnu.length() != 19 || !pnu.chars().allMatch(Character::isDigit)) {
+            throw invalid("PNU는 19자리 숫자여야 합니다.");
+        }
+        return pnu;
+    }
+
+    private Integer nonNegative(Integer value, String fieldName) {
+        if (value != null && value < 0) {
+            throw invalid(fieldName + "는 음수일 수 없습니다.");
+        }
+        return value;
+    }
+
+    private void validateApplicationPeriod(LocalDate startDate, LocalDate endDate) {
+        if (endDate.isBefore(startDate)) {
+            throw invalid("모집 종료일은 모집 시작일보다 빠를 수 없습니다.");
+        }
+    }
+
+    private String normalizedText(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        return value.strip();
+    }
+
+    private MyHomeAnnouncementMappingRejectedException missing(String fieldName) {
+        return new MyHomeAnnouncementMappingRejectedException(
+                MyHomeAnnouncementMappingFailureReason.MISSING_REQUIRED_VALUE,
+                fieldName + " 값이 없습니다."
+        );
+    }
+
+    private MyHomeAnnouncementMappingRejectedException conflict(String fieldName) {
+        return new MyHomeAnnouncementMappingRejectedException(
+                MyHomeAnnouncementMappingFailureReason.CONFLICTING_SOURCE_VALUE,
+                "같은 공고의 " + fieldName + " 값이 서로 다릅니다."
+        );
+    }
+
+    private MyHomeAnnouncementMappingRejectedException invalid(String detail) {
+        return new MyHomeAnnouncementMappingRejectedException(
+                MyHomeAnnouncementMappingFailureReason.INVALID_VALUE,
+                detail
+        );
+    }
+}
+
+record MyHomeAnnouncementMappingData(
+        String sourceAnnouncementIdentifier,
+        String previousSourceAnnouncementIdentifier,
+        String name,
+        AnnouncementPublicationType publicationType,
+        RentalType rentalType,
+        RecruitmentType recruitmentType,
+        AgencyCode provider,
+        LocalDate postedDate,
+        LocalDate applicationStartDate,
+        LocalDate applicationEndDate,
+        LocalDate winnerAnnouncementDate,
+        String originalUrl,
+        ReceptionPlace receptionPlace,
+        List<MyHomeSupplyRowMappingData> supplyRows
+) {
+}
+
+record MyHomeSupplyRowMappingData(
+        MyHomeAnnouncementSource source,
+        String sourceComplexName,
+        String sourceHousingTypeName,
+        String pnu,
+        String complexSupplyType,
+        SupplyCategory supplyCategory,
+        Integer totalSupplyHouseholdCount
+) {
+}
+
+class MyHomeAnnouncementMappingRejectedException extends RuntimeException {
+
+    private final MyHomeAnnouncementMappingFailureReason reason;
+
+    MyHomeAnnouncementMappingRejectedException(
+            MyHomeAnnouncementMappingFailureReason reason,
+            String detail
+    ) {
+        super(detail);
+        this.reason = reason;
+    }
+
+    MyHomeAnnouncementMappingFailureReason reason() {
+        return reason;
+    }
+}

--- a/backend/src/main/java/com/toadzip/backend/ingest/service/MyHomeAnnouncementSourceMapper.java
+++ b/backend/src/main/java/com/toadzip/backend/ingest/service/MyHomeAnnouncementSourceMapper.java
@@ -9,6 +9,7 @@ import com.toadzip.backend.housing.domain.AgencyCode;
 import com.toadzip.backend.housing.domain.RentalType;
 import com.toadzip.backend.ingest.domain.MyHomeAnnouncementMappingFailureReason;
 import com.toadzip.backend.ingest.domain.MyHomeAnnouncementSource;
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
@@ -109,12 +110,15 @@ public class MyHomeAnnouncementSourceMapper {
         String pnu = pnuOf(requiredText(source.getPnu(), "PNU"));
         return new MyHomeSupplyRowMappingData(
                 source,
+                source.getSourceKey(),
                 requiredText(source.getHsmpNm(), "단지명"),
                 requiredText(source.getHouseTyNm(), "주택유형명"),
                 pnu,
                 complexSupplyTypeOf(sourceSupplyType),
                 supplyCategoryOf(announcementName),
-                nonNegative(source.getSumSuplyCo(), "공급호수")
+                nonNegative(source.getSumSuplyCo(), "공급호수"),
+                null,
+                null
         );
     }
 
@@ -328,16 +332,38 @@ record MyHomeAnnouncementMappingData(
         ReceptionPlace receptionPlace,
         List<MyHomeSupplyRowMappingData> supplyRows
 ) {
+
+    MyHomeAnnouncementMappingData withSupplyRows(List<MyHomeSupplyRowMappingData> resolvedSupplyRows) {
+        return new MyHomeAnnouncementMappingData(
+                sourceAnnouncementIdentifier,
+                previousSourceAnnouncementIdentifier,
+                name,
+                publicationType,
+                rentalType,
+                recruitmentType,
+                provider,
+                postedDate,
+                applicationStartDate,
+                applicationEndDate,
+                winnerAnnouncementDate,
+                originalUrl,
+                receptionPlace,
+                resolvedSupplyRows
+        );
+    }
 }
 
 record MyHomeSupplyRowMappingData(
         MyHomeAnnouncementSource source,
+        String sourceSupplyRowIdentifier,
         String sourceComplexName,
         String sourceHousingTypeName,
         String pnu,
         String complexSupplyType,
         SupplyCategory supplyCategory,
-        Integer totalSupplyHouseholdCount
+        Integer totalSupplyHouseholdCount,
+        BigDecimal exclusiveArea,
+        BigDecimal supplyArea
 ) {
 }
 

--- a/backend/src/main/java/com/toadzip/backend/ingest/service/MyHomeAnnouncementSupplyRowResolver.java
+++ b/backend/src/main/java/com/toadzip/backend/ingest/service/MyHomeAnnouncementSupplyRowResolver.java
@@ -1,0 +1,201 @@
+package com.toadzip.backend.ingest.service;
+
+import com.toadzip.backend.ingest.domain.ExternalDataSource;
+import com.toadzip.backend.ingest.domain.LhAnnouncementCollectionCheckpoint;
+import com.toadzip.backend.ingest.domain.LhAnnouncementSupplySource;
+import com.toadzip.backend.ingest.repository.LhAnnouncementCollectionCheckpointRepository;
+import com.toadzip.backend.ingest.repository.LhAnnouncementSupplySourceRepository;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MyHomeAnnouncementSupplyRowResolver {
+
+    private static final int AREA_SCALE = 4;
+
+    private final LhAnnouncementCollectionCheckpointRepository checkpointRepository;
+
+    private final LhAnnouncementSupplySourceRepository lhSupplyRepository;
+
+    public MyHomeAnnouncementSupplyRowResolver(
+            LhAnnouncementCollectionCheckpointRepository checkpointRepository,
+            LhAnnouncementSupplySourceRepository lhSupplyRepository
+    ) {
+        this.checkpointRepository = checkpointRepository;
+        this.lhSupplyRepository = lhSupplyRepository;
+    }
+
+    public MyHomeAnnouncementMappingData resolve(MyHomeAnnouncementMappingData data) {
+        List<LhAnnouncementSupplySource> lhSupplies = findLhSupplies(data.sourceAnnouncementIdentifier());
+        if (lhSupplies.isEmpty()) {
+            return data;
+        }
+        Map<MyHomeSupplyRowMappingData, List<LhAnnouncementSupplySource>> matched = matchByComplex(
+                data.supplyRows(),
+                lhSupplies
+        );
+        List<MyHomeSupplyRowMappingData> resolved = new ArrayList<>();
+        for (MyHomeSupplyRowMappingData sourceRow : data.supplyRows()) {
+            List<LhAnnouncementSupplySource> matchedSupplies = matched.get(sourceRow);
+            if (matchedSupplies == null || matchedSupplies.isEmpty()) {
+                resolved.add(sourceRow);
+                continue;
+            }
+            for (int index = 0; index < matchedSupplies.size(); index++) {
+                LhAnnouncementSupplySource lhSupply = matchedSupplies.get(index);
+                resolved.add(resolveRow(
+                        data.sourceAnnouncementIdentifier(),
+                        sourceRow,
+                        lhSupply,
+                        index == 0
+                ));
+            }
+        }
+        return data.withSupplyRows(List.copyOf(resolved));
+    }
+
+    private List<LhAnnouncementSupplySource> findLhSupplies(String announcementIdentifier) {
+        List<LhAnnouncementCollectionCheckpoint> checkpoints = checkpointRepository
+                .findAllBySourceAndSourceAnnouncementKeyOrderByIdAsc(
+                        ExternalDataSource.LH_ANNOUNCEMENT_SUPPLY,
+                        announcementIdentifier
+                );
+        Set<String> panIds = new LinkedHashSet<>();
+        for (LhAnnouncementCollectionCheckpoint checkpoint : checkpoints) {
+            panIds.add(checkpoint.getPanId());
+        }
+        if (panIds.isEmpty()) {
+            return List.of();
+        }
+        return lhSupplyRepository.findAllByPanIdInOrderByPanIdAscSourceOrderAsc(panIds);
+    }
+
+    private Map<MyHomeSupplyRowMappingData, List<LhAnnouncementSupplySource>> matchByComplex(
+            List<MyHomeSupplyRowMappingData> sourceRows,
+            List<LhAnnouncementSupplySource> lhSupplies
+    ) {
+        Map<MyHomeSupplyRowMappingData, List<LhAnnouncementSupplySource>> matched = new LinkedHashMap<>();
+        for (LhAnnouncementSupplySource lhSupply : lhSupplies) {
+            MyHomeSupplyRowMappingData sourceRow = uniqueSourceRow(sourceRows, lhSupply.getComplexLabel());
+            if (sourceRow == null) {
+                continue;
+            }
+            matched.computeIfAbsent(sourceRow, ignored -> new ArrayList<>()).add(lhSupply);
+        }
+        return matched;
+    }
+
+    private MyHomeSupplyRowMappingData uniqueSourceRow(
+            List<MyHomeSupplyRowMappingData> sourceRows,
+            String lhComplexLabel
+    ) {
+        List<MyHomeSupplyRowMappingData> matched = sourceRows.stream()
+                .filter(row -> MyHomeSupplyNameNormalizer.sameComplex(row.sourceComplexName(), lhComplexLabel))
+                .toList();
+        if (matched.size() != 1) {
+            return null;
+        }
+        return matched.getFirst();
+    }
+
+    private MyHomeSupplyRowMappingData resolveRow(
+            String announcementIdentifier,
+            MyHomeSupplyRowMappingData sourceRow,
+            LhAnnouncementSupplySource lhSupply,
+            boolean preserveOriginalIdentifier
+    ) {
+        String sourceHousingTypeName = sourceHousingTypeName(sourceRow, lhSupply);
+        return new MyHomeSupplyRowMappingData(
+                sourceRow.source(),
+                sourceIdentifier(announcementIdentifier, sourceRow, lhSupply, preserveOriginalIdentifier),
+                sourceRow.sourceComplexName(),
+                sourceHousingTypeName,
+                sourceRow.pnu(),
+                sourceRow.complexSupplyType(),
+                sourceRow.supplyCategory(),
+                nonNegativeInteger(lhSupply.getSuppliedUnitCount()),
+                area(lhSupply.getExclusiveArea()),
+                area(lhSupply.getSupplyArea())
+        );
+    }
+
+    private String sourceIdentifier(
+            String announcementIdentifier,
+            MyHomeSupplyRowMappingData sourceRow,
+            LhAnnouncementSupplySource source,
+            boolean preserveOriginalIdentifier
+    ) {
+        if (preserveOriginalIdentifier) {
+            return sourceRow.sourceSupplyRowIdentifier();
+        }
+        return announcementIdentifier + ":LH:" + source.getPanId() + ":" + source.getSourceOrder();
+    }
+
+    private String sourceHousingTypeName(
+            MyHomeSupplyRowMappingData sourceRow,
+            LhAnnouncementSupplySource lhSupply
+    ) {
+        String lhTypeName = normalizedText(lhSupply.getTypeName());
+        if (lhTypeName != null) {
+            return lhTypeName;
+        }
+        return sourceRow.sourceHousingTypeName();
+    }
+
+    private BigDecimal area(String raw) {
+        String normalized = normalizedNumber(raw);
+        if (normalized == null) {
+            return null;
+        }
+        try {
+            return new BigDecimal(normalized).setScale(AREA_SCALE, RoundingMode.HALF_UP);
+        }
+        catch (NumberFormatException exception) {
+            return null;
+        }
+    }
+
+    private Integer nonNegativeInteger(String raw) {
+        String normalized = normalizedNumber(raw);
+        if (normalized == null || normalized.contains(".")) {
+            return null;
+        }
+        try {
+            int value = Integer.parseInt(normalized);
+            if (value < 0) {
+                return null;
+            }
+            return value;
+        }
+        catch (NumberFormatException exception) {
+            return null;
+        }
+    }
+
+    private String normalizedNumber(String raw) {
+        String normalized = normalizedText(raw);
+        if (normalized == null) {
+            return null;
+        }
+        String withoutGrouping = normalized.replace(",", "");
+        String withoutUnit = withoutGrouping.replace("㎡", "").strip();
+        if (!withoutUnit.matches("[0-9]+(?:\\.[0-9]+)?")) {
+            return null;
+        }
+        return withoutUnit;
+    }
+
+    private String normalizedText(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        return value.strip();
+    }
+}

--- a/backend/src/main/java/com/toadzip/backend/ingest/service/MyHomeAnnouncementSupplyRowResolver.java
+++ b/backend/src/main/java/com/toadzip/backend/ingest/service/MyHomeAnnouncementSupplyRowResolver.java
@@ -1,7 +1,6 @@
 package com.toadzip.backend.ingest.service;
 
 import com.toadzip.backend.ingest.domain.ExternalDataSource;
-import com.toadzip.backend.ingest.domain.LhAnnouncementCollectionCheckpoint;
 import com.toadzip.backend.ingest.domain.LhAnnouncementSupplySource;
 import com.toadzip.backend.ingest.repository.LhAnnouncementCollectionCheckpointRepository;
 import com.toadzip.backend.ingest.repository.LhAnnouncementSupplySourceRepository;
@@ -9,10 +8,8 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -62,19 +59,13 @@ public class MyHomeAnnouncementSupplyRowResolver {
     }
 
     private List<LhAnnouncementSupplySource> findLhSupplies(String announcementIdentifier) {
-        List<LhAnnouncementCollectionCheckpoint> checkpoints = checkpointRepository
-                .findAllBySourceAndSourceAnnouncementKeyOrderByIdAsc(
+        return checkpointRepository
+                .findFirstBySourceAndSourceAnnouncementKeyOrderByIdDesc(
                         ExternalDataSource.LH_ANNOUNCEMENT_SUPPLY,
                         announcementIdentifier
-                );
-        Set<String> panIds = new LinkedHashSet<>();
-        for (LhAnnouncementCollectionCheckpoint checkpoint : checkpoints) {
-            panIds.add(checkpoint.getPanId());
-        }
-        if (panIds.isEmpty()) {
-            return List.of();
-        }
-        return lhSupplyRepository.findAllByPanIdInOrderByPanIdAscSourceOrderAsc(panIds);
+                )
+                .map(checkpoint -> lhSupplyRepository.findAllByPanIdOrderBySourceOrderAsc(checkpoint.getPanId()))
+                .orElseGet(List::of);
     }
 
     private Map<MyHomeSupplyRowMappingData, List<LhAnnouncementSupplySource>> matchByComplex(

--- a/backend/src/main/java/com/toadzip/backend/ingest/service/MyHomeSupplyNameNormalizer.java
+++ b/backend/src/main/java/com/toadzip/backend/ingest/service/MyHomeSupplyNameNormalizer.java
@@ -1,0 +1,50 @@
+package com.toadzip.backend.ingest.service;
+
+import java.text.Normalizer;
+import java.util.List;
+import java.util.Locale;
+
+final class MyHomeSupplyNameNormalizer {
+
+    private static final List<String> COMPLEX_SUFFIXES = List.of("아파트", "단지", "apt");
+
+    private static final List<String> HOUSING_TYPE_SUFFIXES = List.of("주택형", "타입", "type", "형");
+
+    private MyHomeSupplyNameNormalizer() {
+    }
+
+    static String complexName(String value) {
+        return removeSuffixes(alphanumeric(value), COMPLEX_SUFFIXES);
+    }
+
+    static String housingTypeName(String value) {
+        return removeSuffixes(alphanumeric(value), HOUSING_TYPE_SUFFIXES);
+    }
+
+    private static String alphanumeric(String value) {
+        String normalized = Normalizer.normalize(value, Normalizer.Form.NFKC)
+                .toLowerCase(Locale.ROOT);
+        StringBuilder result = new StringBuilder();
+        normalized.codePoints()
+                .filter(Character::isLetterOrDigit)
+                .forEach(result::appendCodePoint);
+        return result.toString();
+    }
+
+    private static String removeSuffixes(String value, List<String> suffixes) {
+        String normalized = value;
+        boolean removed = true;
+        while (removed) {
+            removed = false;
+            for (String suffix : suffixes) {
+                if (!normalized.endsWith(suffix) || normalized.length() == suffix.length()) {
+                    continue;
+                }
+                normalized = normalized.substring(0, normalized.length() - suffix.length());
+                removed = true;
+                break;
+            }
+        }
+        return normalized;
+    }
+}

--- a/backend/src/main/java/com/toadzip/backend/ingest/service/MyHomeSupplyNameNormalizer.java
+++ b/backend/src/main/java/com/toadzip/backend/ingest/service/MyHomeSupplyNameNormalizer.java
@@ -6,7 +6,18 @@ import java.util.Locale;
 
 final class MyHomeSupplyNameNormalizer {
 
-    private static final List<String> COMPLEX_SUFFIXES = List.of("아파트", "단지", "apt");
+    private static final List<String> COMPLEX_NOISE_WORDS = List.of(
+            "국민임대주택",
+            "국민임대",
+            "영구임대주택",
+            "영구임대",
+            "행복주택",
+            "통합공공임대",
+            "휴먼시아",
+            "아파트",
+            "단지",
+            "apt"
+    );
 
     private static final List<String> HOUSING_TYPE_SUFFIXES = List.of("주택형", "타입", "type", "형");
 
@@ -14,11 +25,24 @@ final class MyHomeSupplyNameNormalizer {
     }
 
     static String complexName(String value) {
-        return removeSuffixes(alphanumeric(value), COMPLEX_SUFFIXES);
+        String normalized = alphanumeric(value).replace("블록", "bl");
+        for (String noiseWord : COMPLEX_NOISE_WORDS) {
+            normalized = normalized.replace(noiseWord, "");
+        }
+        return normalized;
     }
 
     static String housingTypeName(String value) {
         return removeSuffixes(alphanumeric(value), HOUSING_TYPE_SUFFIXES);
+    }
+
+    static boolean sameComplex(String left, String right) {
+        String normalizedLeft = complexName(left);
+        String normalizedRight = complexName(right);
+        if (normalizedLeft.length() < 4 || normalizedRight.length() < 4) {
+            return normalizedLeft.equals(normalizedRight);
+        }
+        return normalizedLeft.contains(normalizedRight) || normalizedRight.contains(normalizedLeft);
     }
 
     private static String alphanumeric(String value) {

--- a/backend/src/test/java/com/toadzip/backend/DomainJpaPersistenceTest.java
+++ b/backend/src/test/java/com/toadzip/backend/DomainJpaPersistenceTest.java
@@ -43,6 +43,7 @@ import javax.sql.DataSource;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
@@ -66,19 +67,55 @@ class DomainJpaPersistenceTest {
         }
     }
 
-    @Test
-    void 접수처_연락처_컬럼은_null을_허용하지_않는다() {
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "previous_source_announcement_identifier",
+            "previous_announcement_id",
+            "correction_cancellation_reason",
+            "actual_competition_rate",
+            "predicted_competition_rate",
+            "reception_place_name",
+            "reception_method",
+            "reception_address",
+            "reception_contact",
+            "reception_url"
+    })
+    void 공고의_선택_컬럼은_null을_허용한다(String columnName) {
         Object isNullable = entityManager.createNativeQuery(
                         """
                         SELECT is_nullable
                         FROM information_schema.columns
                         WHERE LOWER(table_name) = 'announcements'
-                          AND LOWER(column_name) = 'reception_contact'
+                          AND LOWER(column_name) = :columnName
                         """
                 )
+                .setParameter("columnName", columnName)
                 .getSingleResult();
 
-        assertEquals("NO", isNullable);
+        assertEquals("YES", isNullable);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "housing_complex_id",
+            "housing_type_id",
+            "expected_move_in_month",
+            "matching_failure_reason",
+            "total_supply_household_count"
+    })
+    void 공급행의_선택_컬럼은_null을_허용한다(String columnName) {
+        Object isNullable = entityManager.createNativeQuery(
+                        """
+                        SELECT is_nullable
+                        FROM information_schema.columns
+                        WHERE LOWER(table_name) = 'supply_rows'
+                          AND LOWER(column_name) = :columnName
+                        """
+                )
+                .setParameter("columnName", columnName)
+                .getSingleResult();
+
+        assertEquals("YES", isNullable);
     }
 
     @ParameterizedTest

--- a/backend/src/test/java/com/toadzip/backend/announcement/domain/AnnouncementSourceUpdateTest.java
+++ b/backend/src/test/java/com/toadzip/backend/announcement/domain/AnnouncementSourceUpdateTest.java
@@ -1,0 +1,101 @@
+package com.toadzip.backend.announcement.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.toadzip.backend.housing.domain.AgencyCode;
+import com.toadzip.backend.housing.domain.RentalType;
+import java.time.LocalDate;
+import org.junit.jupiter.api.Test;
+
+class AnnouncementSourceUpdateTest {
+
+    @Test
+    void 원천에서_변경된_공고_정보를_갱신한다() {
+        Announcement announcement = announcement("기존 공고명");
+        ReceptionPlace receptionPlace = ReceptionPlace.create(
+                "SH 인터넷청약",
+                ReceptionMethod.ONLINE,
+                null,
+                "1600-3456",
+                "https://example.com/apply"
+        );
+
+        boolean updated = announcement.updateFromSource(
+                null,
+                null,
+                "변경 공고명",
+                AnnouncementPublicationType.ORIGINAL,
+                RentalType.NATIONAL_RENTAL,
+                RecruitmentType.WAITLIST,
+                AgencyCode.SH,
+                LocalDate.of(2026, 8, 2),
+                LocalDate.of(2026, 8, 11),
+                LocalDate.of(2026, 8, 15),
+                LocalDate.of(2026, 9, 2),
+                "https://example.com/announcements/changed",
+                null,
+                receptionPlace
+        );
+
+        assertThat(updated).isTrue();
+        assertThat(announcement.getName()).isEqualTo("변경 공고명");
+        assertThat(announcement.getRecruitmentType()).isEqualTo(RecruitmentType.WAITLIST);
+        assertThat(announcement.getProvider()).isEqualTo(AgencyCode.SH);
+        assertThat(announcement.getReceptionPlace()).isEqualTo(receptionPlace);
+    }
+
+    @Test
+    void 원천_공고_정보가_같으면_갱신하지_않는다() {
+        Announcement announcement = announcement("기존 공고명");
+
+        boolean updated = announcement.updateFromSource(
+                null,
+                null,
+                "기존 공고명",
+                AnnouncementPublicationType.ORIGINAL,
+                RentalType.NATIONAL_RENTAL,
+                RecruitmentType.NEW,
+                AgencyCode.LH,
+                LocalDate.of(2026, 8, 1),
+                LocalDate.of(2026, 8, 10),
+                LocalDate.of(2026, 8, 14),
+                LocalDate.of(2026, 9, 1),
+                "https://example.com/announcements/1",
+                null,
+                receptionPlace()
+        );
+
+        assertThat(updated).isFalse();
+    }
+
+    private Announcement announcement(String name) {
+        return Announcement.create(
+                "source-announcement-id",
+                null,
+                null,
+                name,
+                AnnouncementPublicationType.ORIGINAL,
+                RentalType.NATIONAL_RENTAL,
+                RecruitmentType.NEW,
+                AgencyCode.LH,
+                LocalDate.of(2026, 8, 1),
+                LocalDate.of(2026, 8, 10),
+                LocalDate.of(2026, 8, 14),
+                LocalDate.of(2026, 9, 1),
+                "https://example.com/announcements/1",
+                null,
+                0L,
+                receptionPlace()
+        );
+    }
+
+    private ReceptionPlace receptionPlace() {
+        return ReceptionPlace.create(
+                "LH 청약센터",
+                ReceptionMethod.ONLINE,
+                null,
+                "1600-1004",
+                "https://example.com/apply"
+        );
+    }
+}

--- a/backend/src/test/java/com/toadzip/backend/announcement/domain/AnnouncementValidationTest.java
+++ b/backend/src/test/java/com/toadzip/backend/announcement/domain/AnnouncementValidationTest.java
@@ -1,12 +1,12 @@
 package com.toadzip.backend.announcement.domain;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.time.LocalDate;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 class AnnouncementValidationTest {
@@ -26,19 +26,25 @@ class AnnouncementValidationTest {
         );
     }
 
-    @ParameterizedTest
-    @NullSource
-    @ValueSource(strings = {"", " "})
-    void 접수처_연락처는_비어_있을_수_없다(String contact) {
-        assertThrows(
-                IllegalArgumentException.class,
-                () -> ReceptionPlace.create(
+    @Test
+    void 접수처와_문의처는_비어_있을_수_있다() {
+        assertAll(
+                () -> assertDoesNotThrow(() -> ReceptionPlace.create(
                         "LH 청약센터",
                         "인터넷",
                         null,
-                        contact,
+                        null,
                         "https://apply.lh.or.kr"
-                )
+                )),
+                () -> assertDoesNotThrow(() -> createAnnouncement(
+                        validStringFields(),
+                        LocalDate.of(2026, 8, 1),
+                        LocalDate.of(2026, 8, 10),
+                        LocalDate.of(2026, 8, 14),
+                        LocalDate.of(2026, 9, 1),
+                        100L,
+                        null
+                ))
         );
     }
 
@@ -63,7 +69,7 @@ class AnnouncementValidationTest {
     }
 
     @Test
-    void 게시일과_접수일과_발표일과_접수처는_필수다() {
+    void 게시일과_접수일과_발표일은_필수다() {
         String[] fields = validStringFields();
         LocalDate postedDate = LocalDate.of(2026, 8, 1);
         LocalDate applicationStartDate = LocalDate.of(2026, 8, 10);
@@ -91,11 +97,6 @@ class AnnouncementValidationTest {
                         IllegalArgumentException.class,
                         () -> createAnnouncement(fields, postedDate, applicationStartDate, applicationEndDate,
                                 null, 100L, receptionPlace)
-                ),
-                () -> assertThrows(
-                        IllegalArgumentException.class,
-                        () -> createAnnouncement(fields, postedDate, applicationStartDate, applicationEndDate,
-                                winnerAnnouncementDate, 100L, null)
                 )
         );
     }

--- a/backend/src/test/java/com/toadzip/backend/announcement/domain/SupplyRowSourceUpdateTest.java
+++ b/backend/src/test/java/com/toadzip/backend/announcement/domain/SupplyRowSourceUpdateTest.java
@@ -1,0 +1,71 @@
+package com.toadzip.backend.announcement.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.YearMonth;
+import org.junit.jupiter.api.Test;
+
+class SupplyRowSourceUpdateTest {
+
+    @Test
+    void 원천에서_변경된_공급행_정보를_갱신한다() {
+        SupplyRow supplyRow = supplyRow("기존 단지");
+
+        boolean updated = supplyRow.updateFromSource(
+                null,
+                null,
+                2,
+                "변경 단지",
+                "아파트",
+                "1111010100100010000",
+                null,
+                SupplyCategory.RESUPPLY,
+                "일치하는 단지가 없습니다.",
+                30
+        );
+
+        assertThat(updated).isTrue();
+        assertThat(supplyRow.getDisplayOrder()).isEqualTo(2);
+        assertThat(supplyRow.getSourceComplexName()).isEqualTo("변경 단지");
+        assertThat(supplyRow.getSupplyCategory()).isEqualTo(SupplyCategory.RESUPPLY);
+        assertThat(supplyRow.getMatchingFailureReason()).isEqualTo("일치하는 단지가 없습니다.");
+        assertThat(supplyRow.getTotalSupplyHouseholdCount()).isEqualTo(30);
+    }
+
+    @Test
+    void 원천_공급행_정보가_같으면_갱신하지_않는다() {
+        SupplyRow supplyRow = supplyRow("기존 단지");
+
+        boolean updated = supplyRow.updateFromSource(
+                null,
+                null,
+                1,
+                "기존 단지",
+                "아파트",
+                "1111010100100010000",
+                YearMonth.of(2027, 3),
+                SupplyCategory.NEW_SUPPLY,
+                null,
+                20
+        );
+
+        assertThat(updated).isFalse();
+    }
+
+    private SupplyRow supplyRow(String complexName) {
+        return SupplyRow.create(
+                new Announcement(),
+                null,
+                null,
+                "source-supply-row-id",
+                1,
+                complexName,
+                "아파트",
+                "1111010100100010000",
+                YearMonth.of(2027, 3),
+                SupplyCategory.NEW_SUPPLY,
+                null,
+                20
+        );
+    }
+}

--- a/backend/src/test/java/com/toadzip/backend/announcement/service/AnnouncementQueryServiceTest.java
+++ b/backend/src/test/java/com/toadzip/backend/announcement/service/AnnouncementQueryServiceTest.java
@@ -698,6 +698,33 @@ class AnnouncementQueryServiceTest {
     }
 
     @Test
+    void 접수처가_없는_공고_상세는_빈_접수처_목록을_반환한다() {
+        Announcement announcement = persist(Announcement.create(
+                "without-reception-place",
+                null,
+                null,
+                "접수처 없는 공고",
+                AnnouncementPublicationType.ORIGINAL,
+                RentalType.HAPPY_HOUSING,
+                RecruitmentType.NEW,
+                AgencyCode.LH,
+                LocalDate.of(2026, 8, 1),
+                LocalDate.of(2026, 8, 10),
+                LocalDate.of(2026, 8, 10),
+                LocalDate.of(2026, 9, 1),
+                "https://example.com/announcements/without-reception-place",
+                null,
+                0L,
+                null
+        ));
+        entityManager.flush();
+
+        AnnouncementDetailResponse response = announcementQueryService.getAnnouncement(announcement.getId());
+
+        assertEquals(List.of(), response.receptionPlaces());
+    }
+
+    @Test
     void 없는_공고_상세는_기능_예외로_실패한다() {
         AnnouncementNotFoundException exception = assertThrows(
                 AnnouncementNotFoundException.class,

--- a/backend/src/test/java/com/toadzip/backend/ingest/controller/MyHomeAnnouncementMappingControllerTest.java
+++ b/backend/src/test/java/com/toadzip/backend/ingest/controller/MyHomeAnnouncementMappingControllerTest.java
@@ -33,13 +33,14 @@ class MyHomeAnnouncementMappingControllerTest {
     @Test
     void 저장된_마이홈_원천의_공고와_공급행_매핑을_실행한다() throws Exception {
         when(mappingService.mapAll()).thenReturn(new MyHomeAnnouncementMappingReport(
-                1, 0, 0, 2, 0, 0, 1
+                1, 0, 0, 2, 0, 0, 0, 1
         ));
 
         mockMvc.perform(post("/api/admin/ingest/myhome/announcement-mappings"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.createdAnnouncementCount").value(1))
                 .andExpect(jsonPath("$.createdSupplyRowCount").value(2))
+                .andExpect(jsonPath("$.deletedSupplyRowCount").value(0))
                 .andExpect(jsonPath("$.failedSourceRowCount").value(1));
 
         verify(mappingService).mapAll();

--- a/backend/src/test/java/com/toadzip/backend/ingest/controller/MyHomeAnnouncementMappingControllerTest.java
+++ b/backend/src/test/java/com/toadzip/backend/ingest/controller/MyHomeAnnouncementMappingControllerTest.java
@@ -1,0 +1,66 @@
+package com.toadzip.backend.ingest.controller;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.toadzip.backend.ingest.domain.MyHomeAnnouncementMappingFailureReason;
+import com.toadzip.backend.ingest.dto.MyHomeAnnouncementMappingFailureResponse;
+import com.toadzip.backend.ingest.dto.MyHomeAnnouncementMappingReport;
+import com.toadzip.backend.ingest.service.MyHomeAnnouncementMappingService;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(MyHomeAnnouncementMappingController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class MyHomeAnnouncementMappingControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private MyHomeAnnouncementMappingService mappingService;
+
+    @Test
+    void 저장된_마이홈_원천의_공고와_공급행_매핑을_실행한다() throws Exception {
+        when(mappingService.mapAll()).thenReturn(new MyHomeAnnouncementMappingReport(
+                1, 0, 0, 2, 0, 0, 1
+        ));
+
+        mockMvc.perform(post("/api/admin/ingest/myhome/announcement-mappings"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.createdAnnouncementCount").value(1))
+                .andExpect(jsonPath("$.createdSupplyRowCount").value(2))
+                .andExpect(jsonPath("$.failedSourceRowCount").value(1));
+
+        verify(mappingService).mapAll();
+    }
+
+    @Test
+    void 매핑에_실패한_원천과_사유를_조회한다() throws Exception {
+        when(mappingService.findFailures()).thenReturn(List.of(new MyHomeAnnouncementMappingFailureResponse(
+                "source-key",
+                "21026",
+                1,
+                MyHomeAnnouncementMappingFailureReason.COMPLEX_NOT_FOUND,
+                "PNU와 공급유형이 일치하는 단지가 없습니다.",
+                Instant.parse("2026-08-28T00:00:00Z")
+        )));
+
+        mockMvc.perform(get("/api/admin/ingest/myhome/announcement-mappings/failures"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].sourceKey").value("source-key"))
+                .andExpect(jsonPath("$[0].sourceAnnouncementIdentifier").value("21026"))
+                .andExpect(jsonPath("$[0].sourceHouseSerialNumber").value(1))
+                .andExpect(jsonPath("$[0].reason").value("COMPLEX_NOT_FOUND"));
+    }
+}

--- a/backend/src/test/java/com/toadzip/backend/ingest/service/MyHomeAnnouncementMappingServiceTest.java
+++ b/backend/src/test/java/com/toadzip/backend/ingest/service/MyHomeAnnouncementMappingServiceTest.java
@@ -5,8 +5,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.toadzip.backend.announcement.domain.Announcement;
 import com.toadzip.backend.announcement.domain.AnnouncementPublicationType;
 import com.toadzip.backend.announcement.domain.SupplyRow;
+import com.toadzip.backend.announcement.domain.SupplyTarget;
 import com.toadzip.backend.announcement.repository.AnnouncementRepository;
 import com.toadzip.backend.announcement.repository.SupplyRowRepository;
+import com.toadzip.backend.announcement.repository.SupplyTargetRepository;
 import com.toadzip.backend.housing.domain.Address;
 import com.toadzip.backend.housing.domain.HousingComplex;
 import com.toadzip.backend.housing.domain.HousingType;
@@ -21,6 +23,7 @@ import com.toadzip.backend.ingest.domain.LhAnnouncementSupplySource;
 import com.toadzip.backend.ingest.domain.LhAnnouncementSupplySourceData;
 import com.toadzip.backend.ingest.repository.LhAnnouncementCollectionCheckpointRepository;
 import com.toadzip.backend.ingest.repository.LhAnnouncementSupplySourceRepository;
+import com.toadzip.backend.ingest.repository.LhSourceStore;
 import com.toadzip.backend.ingest.repository.MyHomeAnnouncementMappingFailureRepository;
 import com.toadzip.backend.ingest.repository.MyHomeAnnouncementSourceRepository;
 import java.math.BigDecimal;
@@ -56,6 +59,9 @@ class MyHomeAnnouncementMappingServiceTest {
     private SupplyRowRepository supplyRowRepository;
 
     @Autowired
+    private SupplyTargetRepository supplyTargetRepository;
+
+    @Autowired
     private HousingComplexRepository complexRepository;
 
     @Autowired
@@ -67,8 +73,12 @@ class MyHomeAnnouncementMappingServiceTest {
     @Autowired
     private LhAnnouncementSupplySourceRepository lhSupplyRepository;
 
+    @Autowired
+    private LhSourceStore lhSourceStore;
+
     @BeforeEach
     void setUp() {
+        supplyTargetRepository.deleteAll();
         supplyRowRepository.deleteAll();
         announcementRepository.deleteAll();
         housingTypeRepository.deleteAll();
@@ -322,6 +332,66 @@ class MyHomeAnnouncementMappingServiceTest {
         assertThat(supplyRow("21026:LH:PAN-1:3")).satisfies(row -> {
             assertThat(row.getHousingType()).isNull();
             assertThat(row.getMatchingFailureReason()).contains("면적으로도 주택형 하나를 확정할 수 없습니다");
+        });
+    }
+
+    @Test
+    void 최신_lh_공급_스냅샷에서_사라진_공급행을_삭제한다() {
+        saveMappedComplex();
+        sourceRepository.save(source(0, data("21026", 1, "LH", "동삼2")));
+        saveLhSupplyCheckpoint("21026", "PAN-1");
+        lhSourceStore.replaceSupplies("PAN-1", List.of(
+                lhSupply(0, "PAN-1", "동삼2", "46A", "46.8000", "67.0000"),
+                lhSupply(1, "PAN-1", "동삼2", "46A", "46.8000", "67.0000"),
+                lhSupply(2, "PAN-1", "동삼2", "46A", "46.8000", "67.0000")
+        ));
+        service.mapAll();
+        assertThat(supplyRowRepository.findAll()).hasSize(3);
+        SupplyRow staleRow = supplyRow("21026:LH:PAN-1:2");
+        supplyTargetRepository.save(SupplyTarget.create(
+                staleRow,
+                "청년",
+                null,
+                1,
+                null,
+                null,
+                null,
+                null,
+                null,
+                1
+        ));
+
+        lhSourceStore.replaceSupplies("PAN-1", List.of(
+                lhSupply(0, "PAN-1", "동삼2", "46A", "46.8000", "67.0000")
+        ));
+
+        var report = service.mapAll();
+
+        assertThat(report.deletedSupplyRowCount()).isEqualTo(2);
+        assertThat(supplyRowRepository.findAll()).singleElement()
+                .extracting(SupplyRow::getSourceSupplyRowIdentifier)
+                .isEqualTo(MyHomeAnnouncementSource.sourceKeyOf(data("21026", 1, "LH", "동삼2")));
+        assertThat(supplyTargetRepository.findAll()).isEmpty();
+    }
+
+    @Test
+    void 최신_체크포인트의_lh_공급행만_매핑한다() {
+        saveMappedComplex();
+        sourceRepository.save(source(0, data("21026", 1, "LH", "동삼2")));
+        saveLhSupplyCheckpoint("21026", "PAN-OLD");
+        lhSourceStore.replaceSupplies("PAN-OLD", List.of(
+                lhSupply(0, "PAN-OLD", "동삼2", "과거형", "99.0000", "99.0000")
+        ));
+        saveLhSupplyCheckpoint("21026", "PAN-CURRENT");
+        lhSourceStore.replaceSupplies("PAN-CURRENT", List.of(
+                lhSupply(0, "PAN-CURRENT", "동삼2", "46A", "46.8000", "67.0000")
+        ));
+
+        service.mapAll();
+
+        assertThat(supplyRowRepository.findAll()).singleElement().satisfies(row -> {
+            assertThat(row.getSourceHousingTypeName()).isEqualTo("46A");
+            assertThat(row.getHousingType()).isNotNull();
         });
     }
 

--- a/backend/src/test/java/com/toadzip/backend/ingest/service/MyHomeAnnouncementMappingServiceTest.java
+++ b/backend/src/test/java/com/toadzip/backend/ingest/service/MyHomeAnnouncementMappingServiceTest.java
@@ -1,0 +1,322 @@
+package com.toadzip.backend.ingest.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.toadzip.backend.announcement.domain.Announcement;
+import com.toadzip.backend.announcement.domain.AnnouncementPublicationType;
+import com.toadzip.backend.announcement.domain.SupplyRow;
+import com.toadzip.backend.announcement.repository.AnnouncementRepository;
+import com.toadzip.backend.announcement.repository.SupplyRowRepository;
+import com.toadzip.backend.housing.domain.Address;
+import com.toadzip.backend.housing.domain.HousingComplex;
+import com.toadzip.backend.housing.domain.HousingType;
+import com.toadzip.backend.housing.repository.HousingComplexRepository;
+import com.toadzip.backend.housing.repository.HousingTypeRepository;
+import com.toadzip.backend.ingest.domain.MyHomeAnnouncementMappingFailureReason;
+import com.toadzip.backend.ingest.domain.MyHomeAnnouncementSource;
+import com.toadzip.backend.ingest.domain.MyHomeAnnouncementSourceData;
+import com.toadzip.backend.ingest.repository.MyHomeAnnouncementMappingFailureRepository;
+import com.toadzip.backend.ingest.repository.MyHomeAnnouncementSourceRepository;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class MyHomeAnnouncementMappingServiceTest {
+
+    private static final Instant COLLECTED_AT = Instant.parse("2026-08-28T00:00:00Z");
+
+    private static final String PNU = "1111010100100010000";
+
+    @Autowired
+    private MyHomeAnnouncementMappingService service;
+
+    @Autowired
+    private MyHomeAnnouncementSourceRepository sourceRepository;
+
+    @Autowired
+    private MyHomeAnnouncementMappingFailureRepository failureRepository;
+
+    @Autowired
+    private AnnouncementRepository announcementRepository;
+
+    @Autowired
+    private SupplyRowRepository supplyRowRepository;
+
+    @Autowired
+    private HousingComplexRepository complexRepository;
+
+    @Autowired
+    private HousingTypeRepository housingTypeRepository;
+
+    @BeforeEach
+    void setUp() {
+        supplyRowRepository.deleteAll();
+        announcementRepository.deleteAll();
+        housingTypeRepository.deleteAll();
+        complexRepository.deleteAll();
+        failureRepository.deleteAll();
+        sourceRepository.deleteAll();
+    }
+
+    @Test
+    void 공급기관과_관계없이_같은_pblancId를_하나의_공고와_여러_공급행으로_매핑한다() {
+        saveMappedComplex();
+        sourceRepository.saveAll(List.of(
+                source(0, data("21026", 1, "부산도시공사", "동삼2")),
+                source(1, data("21026", 2, "부산도시공사", "동삼3"))
+        ));
+
+        var report = service.mapAll();
+
+        assertThat(report.createdAnnouncementCount()).isOne();
+        assertThat(report.createdSupplyRowCount()).isEqualTo(2);
+        assertThat(report.failedSourceRowCount()).isZero();
+        assertThat(announcementRepository.count()).isOne();
+        assertThat(supplyRowRepository.findAll()).hasSize(2).allSatisfy(row -> {
+            assertThat(row.getHousingComplex()).isNotNull();
+            assertThat(row.getHousingType()).isNotNull();
+            assertThat(row.getMatchingFailureReason()).isNull();
+        });
+    }
+
+    @Test
+    void 같은_원본을_반복_매핑해도_공고와_공급행을_중복_생성하지_않는다() {
+        saveMappedComplex();
+        sourceRepository.save(source(0, data("21026", 1, "부산도시공사", "동삼2")));
+        service.mapAll();
+
+        var report = service.mapAll();
+
+        assertThat(report.unchangedAnnouncementCount()).isOne();
+        assertThat(report.unchangedSupplyRowCount()).isOne();
+        assertThat(announcementRepository.count()).isOne();
+        assertThat(supplyRowRepository.count()).isOne();
+    }
+
+    @Test
+    void 변경된_원본_정보를_기존_공고와_공급행에_반영한다() {
+        saveMappedComplex();
+        sourceRepository.save(source(0, data("21026", 1, "부산도시공사", "동삼2")));
+        service.mapAll();
+        MyHomeAnnouncementSource source = sourceRepository.findAll().getFirst();
+        MyHomeAnnouncementSourceData changed = data("21026", 1, "서울주택도시공사", "동삼2 변경");
+        source.replaceWith(withNameAndSupplyCount(changed, "변경된 국민임대 모집공고", 35));
+        source.markCollectedAt(COLLECTED_AT.plusSeconds(60));
+        sourceRepository.save(source);
+
+        var report = service.mapAll();
+
+        assertThat(report.updatedAnnouncementCount()).isOne();
+        assertThat(report.updatedSupplyRowCount()).isOne();
+        assertThat(announcementRepository.findAll()).singleElement()
+                .extracting(Announcement::getName)
+                .isEqualTo("변경된 국민임대 모집공고");
+        assertThat(supplyRowRepository.findAll()).singleElement().satisfies(row -> {
+            assertThat(row.getSourceComplexName()).isEqualTo("동삼2 변경");
+            assertThat(row.getTotalSupplyHouseholdCount()).isEqualTo(35);
+        });
+    }
+
+    @Test
+    void 이전_공고_식별자로_정정공고를_연결한다() {
+        saveMappedComplex();
+        sourceRepository.saveAll(List.of(
+                source(1, withPrevious(data("21027", 2, "LH서울", "동삼2"), "21026")),
+                source(0, data("21026", 1, "LH서울", "동삼2"))
+        ));
+
+        var report = service.mapAll();
+
+        assertThat(report.createdAnnouncementCount()).isEqualTo(2);
+        Announcement correction = announcementRepository.findBySourceAnnouncementIdentifier("21027").orElseThrow();
+        assertThat(correction.getStatus()).isEqualTo(AnnouncementPublicationType.CORRECTION);
+        assertThat(correction.getPreviousSourceAnnouncementIdentifier()).isEqualTo("21026");
+        assertThat(correction.getPreviousAnnouncement()).isNotNull();
+    }
+
+    @Test
+    void 단지_매칭에_실패해도_공급행을_보존하고_실패_사유를_기록한다() {
+        sourceRepository.save(source(0, data("21026", 1, "부산도시공사", "동삼2")));
+
+        var report = service.mapAll();
+
+        assertThat(report.createdAnnouncementCount()).isOne();
+        assertThat(report.createdSupplyRowCount()).isOne();
+        assertThat(report.failedSourceRowCount()).isOne();
+        assertThat(supplyRowRepository.findAll()).singleElement().satisfies(row -> {
+            assertThat(row.getHousingComplex()).isNull();
+            assertThat(row.getHousingType()).isNull();
+            assertThat(row.getMatchingFailureReason()).contains("일치하는 단지가 없습니다");
+        });
+        assertThat(failureRepository.findAll()).singleElement()
+                .extracting(failure -> failure.getReason())
+                .isEqualTo(MyHomeAnnouncementMappingFailureReason.COMPLEX_NOT_FOUND);
+    }
+
+    @Test
+    void 주택형을_하나로_확정할_수_없으면_단지만_연결하고_실패_사유를_기록한다() {
+        saveMappedComplex();
+        HousingComplex complex = complexRepository.findAll().getFirst();
+        housingTypeRepository.save(HousingType.createFromMyHome(
+                complex,
+                "second-source-housing-type-id",
+                "59A",
+                new BigDecimal("59.9500"),
+                new BigDecimal("84.0500")
+        ));
+        sourceRepository.save(source(0, data("21026", 1, "부산도시공사", "동삼2")));
+
+        var report = service.mapAll();
+
+        assertThat(report.failedSourceRowCount()).isOne();
+        assertThat(supplyRowRepository.findAll()).singleElement().satisfies(row -> {
+            assertThat(row.getHousingComplex()).isNotNull();
+            assertThat(row.getHousingType()).isNull();
+            assertThat(row.getMatchingFailureReason()).contains("주택형 하나를 확정할 수 없습니다");
+        });
+        assertThat(failureRepository.findAll()).singleElement()
+                .extracting(failure -> failure.getReason())
+                .isEqualTo(MyHomeAnnouncementMappingFailureReason.AMBIGUOUS_HOUSING_TYPE);
+    }
+
+    @Test
+    void 필수_날짜를_변환할_수_없으면_공고를_만들지_않고_실패를_기록한다() {
+        MyHomeAnnouncementSourceData invalid = withPostedDate(
+                data("21026", 1, "부산도시공사", "동삼2"),
+                "20260230"
+        );
+        sourceRepository.save(source(0, invalid));
+
+        var report = service.mapAll();
+
+        assertThat(report.failedSourceRowCount()).isOne();
+        assertThat(announcementRepository.count()).isZero();
+        assertThat(supplyRowRepository.count()).isZero();
+        assertThat(failureRepository.findAll()).singleElement()
+                .extracting(failure -> failure.getReason())
+                .isEqualTo(MyHomeAnnouncementMappingFailureReason.INVALID_VALUE);
+    }
+
+    private void saveMappedComplex() {
+        Address address = Address.create(
+                "서울특별시 종로구 테스트로 1",
+                PNU,
+                PNU.substring(0, 10),
+                "11",
+                "11110",
+                new BigDecimal("37.566206"),
+                new BigDecimal("126.977706")
+        );
+        HousingComplex complex = complexRepository.save(HousingComplex.createFromMyHome(
+                "동삼2",
+                "123:NATIONAL_RENTAL",
+                "NATIONAL_RENTAL",
+                address,
+                100,
+                "LH",
+                null,
+                "DISTRICT",
+                "APARTMENT",
+                "CORRIDOR",
+                true,
+                80
+        ));
+        housingTypeRepository.save(HousingType.createFromMyHome(
+                complex,
+                "source-housing-type-id",
+                "46A",
+                new BigDecimal("46.8000"),
+                new BigDecimal("67.0000")
+        ));
+    }
+
+    private MyHomeAnnouncementSource source(int order, MyHomeAnnouncementSourceData data) {
+        MyHomeAnnouncementSource source = MyHomeAnnouncementSource.from(order, data);
+        source.markCollectedAt(COLLECTED_AT);
+        return source;
+    }
+
+    private MyHomeAnnouncementSourceData data(
+            String pblancId,
+            int houseSn,
+            String provider,
+            String complexName
+    ) {
+        return new MyHomeAnnouncementSourceData(
+                pblancId,
+                houseSn,
+                "모집중",
+                "국민임대 입주자 모집공고",
+                provider,
+                "아파트",
+                "국민임대",
+                null,
+                "20260813",
+                "20261106",
+                "20260824",
+                "20260831",
+                "1600-1004",
+                "https://example.com/announcements/" + pblancId,
+                null,
+                null,
+                complexName,
+                "서울특별시",
+                "종로구",
+                "서울특별시 종로구 테스트로 1",
+                "테스트로",
+                "테스트동",
+                PNU,
+                "지역난방",
+                "100",
+                20,
+                10_000_000L,
+                2_000_000L,
+                8_000_000L,
+                200_000L
+        );
+    }
+
+    private MyHomeAnnouncementSourceData withNameAndSupplyCount(
+            MyHomeAnnouncementSourceData data,
+            String name,
+            int supplyCount
+    ) {
+        return new MyHomeAnnouncementSourceData(
+                data.pblancId(), data.houseSn(), data.sttusNm(), name, data.suplyInsttNm(),
+                data.houseTyNm(), data.suplyTyNm(), data.beforePblancId(), data.rcritPblancDe(),
+                data.przwnerPresnatnDe(), data.beginDe(), data.endDe(), data.refrnc(), data.url(),
+                data.pcUrl(), data.mobileUrl(), data.hsmpNm(), data.brtcNm(), data.signguNm(),
+                data.fullAdres(), data.rnCodeNm(), data.refrnLegaldongNm(), data.pnu(), data.heatMthdNm(),
+                data.totHshldCo(), supplyCount, data.rentGtn(), data.enty(), data.surlus(), data.mtRntchrg()
+        );
+    }
+
+    private MyHomeAnnouncementSourceData withPrevious(MyHomeAnnouncementSourceData data, String previousIdentifier) {
+        return new MyHomeAnnouncementSourceData(
+                data.pblancId(), data.houseSn(), "정정공고", data.pblancNm(), data.suplyInsttNm(),
+                data.houseTyNm(), data.suplyTyNm(), previousIdentifier, data.rcritPblancDe(),
+                data.przwnerPresnatnDe(), data.beginDe(), data.endDe(), data.refrnc(), data.url(),
+                data.pcUrl(), data.mobileUrl(), data.hsmpNm(), data.brtcNm(), data.signguNm(),
+                data.fullAdres(), data.rnCodeNm(), data.refrnLegaldongNm(), data.pnu(), data.heatMthdNm(),
+                data.totHshldCo(), data.sumSuplyCo(), data.rentGtn(), data.enty(), data.surlus(), data.mtRntchrg()
+        );
+    }
+
+    private MyHomeAnnouncementSourceData withPostedDate(MyHomeAnnouncementSourceData data, String postedDate) {
+        return new MyHomeAnnouncementSourceData(
+                data.pblancId(), data.houseSn(), data.sttusNm(), data.pblancNm(), data.suplyInsttNm(),
+                data.houseTyNm(), data.suplyTyNm(), data.beforePblancId(), postedDate,
+                data.przwnerPresnatnDe(), data.beginDe(), data.endDe(), data.refrnc(), data.url(),
+                data.pcUrl(), data.mobileUrl(), data.hsmpNm(), data.brtcNm(), data.signguNm(),
+                data.fullAdres(), data.rnCodeNm(), data.refrnLegaldongNm(), data.pnu(), data.heatMthdNm(),
+                data.totHshldCo(), data.sumSuplyCo(), data.rentGtn(), data.enty(), data.surlus(), data.mtRntchrg()
+        );
+    }
+}

--- a/backend/src/test/java/com/toadzip/backend/ingest/service/MyHomeAnnouncementMappingServiceTest.java
+++ b/backend/src/test/java/com/toadzip/backend/ingest/service/MyHomeAnnouncementMappingServiceTest.java
@@ -204,6 +204,28 @@ class MyHomeAnnouncementMappingServiceTest {
                 .isEqualTo(MyHomeAnnouncementMappingFailureReason.INVALID_VALUE);
     }
 
+    @Test
+    void 문의처가_없어도_공고와_공급행을_매핑한다() {
+        MyHomeAnnouncementSourceData withoutContact = withContact(
+                data("21026", 1, "부산도시공사", "동삼2"),
+                null
+        );
+        sourceRepository.save(source(0, withoutContact));
+
+        var report = service.mapAll();
+
+        assertThat(report.createdAnnouncementCount()).isOne();
+        assertThat(report.createdSupplyRowCount()).isOne();
+        assertThat(announcementRepository.findAll()).singleElement().satisfies(announcement ->
+                assertThat(announcement.getReceptionPlace().getContact()).isNull()
+        );
+
+        var repeatedReport = service.mapAll();
+
+        assertThat(repeatedReport.unchangedAnnouncementCount()).isOne();
+        assertThat(repeatedReport.unchangedSupplyRowCount()).isOne();
+    }
+
     private void saveMappedComplex() {
         Address address = Address.create(
                 "서울특별시 종로구 테스트로 1",
@@ -314,6 +336,17 @@ class MyHomeAnnouncementMappingServiceTest {
                 data.pblancId(), data.houseSn(), data.sttusNm(), data.pblancNm(), data.suplyInsttNm(),
                 data.houseTyNm(), data.suplyTyNm(), data.beforePblancId(), postedDate,
                 data.przwnerPresnatnDe(), data.beginDe(), data.endDe(), data.refrnc(), data.url(),
+                data.pcUrl(), data.mobileUrl(), data.hsmpNm(), data.brtcNm(), data.signguNm(),
+                data.fullAdres(), data.rnCodeNm(), data.refrnLegaldongNm(), data.pnu(), data.heatMthdNm(),
+                data.totHshldCo(), data.sumSuplyCo(), data.rentGtn(), data.enty(), data.surlus(), data.mtRntchrg()
+        );
+    }
+
+    private MyHomeAnnouncementSourceData withContact(MyHomeAnnouncementSourceData data, String contact) {
+        return new MyHomeAnnouncementSourceData(
+                data.pblancId(), data.houseSn(), data.sttusNm(), data.pblancNm(), data.suplyInsttNm(),
+                data.houseTyNm(), data.suplyTyNm(), data.beforePblancId(), data.rcritPblancDe(),
+                data.przwnerPresnatnDe(), data.beginDe(), data.endDe(), contact, data.url(),
                 data.pcUrl(), data.mobileUrl(), data.hsmpNm(), data.brtcNm(), data.signguNm(),
                 data.fullAdres(), data.rnCodeNm(), data.refrnLegaldongNm(), data.pnu(), data.heatMthdNm(),
                 data.totHshldCo(), data.sumSuplyCo(), data.rentGtn(), data.enty(), data.surlus(), data.mtRntchrg()

--- a/backend/src/test/java/com/toadzip/backend/ingest/service/MyHomeAnnouncementMappingServiceTest.java
+++ b/backend/src/test/java/com/toadzip/backend/ingest/service/MyHomeAnnouncementMappingServiceTest.java
@@ -161,6 +161,22 @@ class MyHomeAnnouncementMappingServiceTest {
     }
 
     @Test
+    void 단지명_표기를_보정해_여러_단지_후보_중_하나를_확정한다() {
+        HousingComplex matched = saveMappedComplex("동삼2", "123:NATIONAL_RENTAL");
+        saveMappedComplex("동삼3", "124:NATIONAL_RENTAL");
+        sourceRepository.save(source(0, data("21026", 1, "부산도시공사", "동삼 2단지")));
+
+        var report = service.mapAll();
+
+        assertThat(report.failedSourceRowCount()).isZero();
+        assertThat(supplyRowRepository.findAll()).singleElement().satisfies(row -> {
+            assertThat(row.getHousingComplex().getId()).isEqualTo(matched.getId());
+            assertThat(row.getHousingType()).isNotNull();
+            assertThat(row.getMatchingFailureReason()).isNull();
+        });
+    }
+
+    @Test
     void 주택형을_하나로_확정할_수_없으면_단지만_연결하고_실패_사유를_기록한다() {
         saveMappedComplex();
         HousingComplex complex = complexRepository.findAll().getFirst();
@@ -184,6 +200,65 @@ class MyHomeAnnouncementMappingServiceTest {
         assertThat(failureRepository.findAll()).singleElement()
                 .extracting(failure -> failure.getReason())
                 .isEqualTo(MyHomeAnnouncementMappingFailureReason.AMBIGUOUS_HOUSING_TYPE);
+    }
+
+    @Test
+    void 주택형명_표기를_보정해_여러_주택형_중_하나를_확정한다() {
+        saveMappedComplex();
+        HousingComplex complex = complexRepository.findAll().getFirst();
+        HousingType expected = housingTypeRepository.findAllByHousingComplex(complex).getFirst();
+        housingTypeRepository.save(HousingType.createFromMyHome(
+                complex,
+                "second-source-housing-type-id",
+                "59A",
+                new BigDecimal("59.9500"),
+                new BigDecimal("84.0500")
+        ));
+        MyHomeAnnouncementSourceData sourceData = withHousingType(
+                data("21026", 1, "부산도시공사", "동삼2"),
+                "46-A형"
+        );
+        sourceRepository.save(source(0, sourceData));
+
+        var report = service.mapAll();
+
+        assertThat(report.failedSourceRowCount()).isZero();
+        assertThat(supplyRowRepository.findAll()).singleElement().satisfies(row -> {
+            assertThat(row.getHousingType().getId()).isEqualTo(expected.getId());
+            assertThat(row.getMatchingFailureReason()).isNull();
+        });
+    }
+
+    @Test
+    void 미확정_공급행은_원천_주택형명이_보정되면_재매핑하여_연결한다() {
+        saveMappedComplex();
+        HousingComplex complex = complexRepository.findAll().getFirst();
+        HousingType expected = housingTypeRepository.findAllByHousingComplex(complex).getFirst();
+        housingTypeRepository.save(HousingType.createFromMyHome(
+                complex,
+                "second-source-housing-type-id",
+                "59A",
+                new BigDecimal("59.9500"),
+                new BigDecimal("84.0500")
+        ));
+        sourceRepository.save(source(0, data("21026", 1, "부산도시공사", "동삼2")));
+        service.mapAll();
+        MyHomeAnnouncementSource source = sourceRepository.findAll().getFirst();
+        source.replaceWith(withHousingType(
+                data("21026", 1, "부산도시공사", "동삼2"),
+                "46 A 타입"
+        ));
+        source.markCollectedAt(COLLECTED_AT.plusSeconds(60));
+        sourceRepository.save(source);
+
+        var report = service.mapAll();
+
+        assertThat(report.updatedSupplyRowCount()).isOne();
+        assertThat(report.failedSourceRowCount()).isZero();
+        assertThat(supplyRowRepository.findAll()).singleElement().satisfies(row -> {
+            assertThat(row.getHousingType().getId()).isEqualTo(expected.getId());
+            assertThat(row.getMatchingFailureReason()).isNull();
+        });
     }
 
     @Test
@@ -227,6 +302,10 @@ class MyHomeAnnouncementMappingServiceTest {
     }
 
     private void saveMappedComplex() {
+        saveMappedComplex("동삼2", "123:NATIONAL_RENTAL");
+    }
+
+    private HousingComplex saveMappedComplex(String name, String sourceIdentifier) {
         Address address = Address.create(
                 "서울특별시 종로구 테스트로 1",
                 PNU,
@@ -237,8 +316,8 @@ class MyHomeAnnouncementMappingServiceTest {
                 new BigDecimal("126.977706")
         );
         HousingComplex complex = complexRepository.save(HousingComplex.createFromMyHome(
-                "동삼2",
-                "123:NATIONAL_RENTAL",
+                name,
+                sourceIdentifier,
                 "NATIONAL_RENTAL",
                 address,
                 100,
@@ -252,11 +331,12 @@ class MyHomeAnnouncementMappingServiceTest {
         ));
         housingTypeRepository.save(HousingType.createFromMyHome(
                 complex,
-                "source-housing-type-id",
+                "source-housing-type-id:" + sourceIdentifier,
                 "46A",
                 new BigDecimal("46.8000"),
                 new BigDecimal("67.0000")
         ));
+        return complex;
     }
 
     private MyHomeAnnouncementSource source(int order, MyHomeAnnouncementSourceData data) {
@@ -347,6 +427,17 @@ class MyHomeAnnouncementMappingServiceTest {
                 data.pblancId(), data.houseSn(), data.sttusNm(), data.pblancNm(), data.suplyInsttNm(),
                 data.houseTyNm(), data.suplyTyNm(), data.beforePblancId(), data.rcritPblancDe(),
                 data.przwnerPresnatnDe(), data.beginDe(), data.endDe(), contact, data.url(),
+                data.pcUrl(), data.mobileUrl(), data.hsmpNm(), data.brtcNm(), data.signguNm(),
+                data.fullAdres(), data.rnCodeNm(), data.refrnLegaldongNm(), data.pnu(), data.heatMthdNm(),
+                data.totHshldCo(), data.sumSuplyCo(), data.rentGtn(), data.enty(), data.surlus(), data.mtRntchrg()
+        );
+    }
+
+    private MyHomeAnnouncementSourceData withHousingType(MyHomeAnnouncementSourceData data, String housingType) {
+        return new MyHomeAnnouncementSourceData(
+                data.pblancId(), data.houseSn(), data.sttusNm(), data.pblancNm(), data.suplyInsttNm(),
+                housingType, data.suplyTyNm(), data.beforePblancId(), data.rcritPblancDe(),
+                data.przwnerPresnatnDe(), data.beginDe(), data.endDe(), data.refrnc(), data.url(),
                 data.pcUrl(), data.mobileUrl(), data.hsmpNm(), data.brtcNm(), data.signguNm(),
                 data.fullAdres(), data.rnCodeNm(), data.refrnLegaldongNm(), data.pnu(), data.heatMthdNm(),
                 data.totHshldCo(), data.sumSuplyCo(), data.rentGtn(), data.enty(), data.surlus(), data.mtRntchrg()

--- a/backend/src/test/java/com/toadzip/backend/ingest/service/MyHomeAnnouncementMappingServiceTest.java
+++ b/backend/src/test/java/com/toadzip/backend/ingest/service/MyHomeAnnouncementMappingServiceTest.java
@@ -15,6 +15,12 @@ import com.toadzip.backend.housing.repository.HousingTypeRepository;
 import com.toadzip.backend.ingest.domain.MyHomeAnnouncementMappingFailureReason;
 import com.toadzip.backend.ingest.domain.MyHomeAnnouncementSource;
 import com.toadzip.backend.ingest.domain.MyHomeAnnouncementSourceData;
+import com.toadzip.backend.ingest.domain.ExternalDataSource;
+import com.toadzip.backend.ingest.domain.LhAnnouncementCollectionCheckpoint;
+import com.toadzip.backend.ingest.domain.LhAnnouncementSupplySource;
+import com.toadzip.backend.ingest.domain.LhAnnouncementSupplySourceData;
+import com.toadzip.backend.ingest.repository.LhAnnouncementCollectionCheckpointRepository;
+import com.toadzip.backend.ingest.repository.LhAnnouncementSupplySourceRepository;
 import com.toadzip.backend.ingest.repository.MyHomeAnnouncementMappingFailureRepository;
 import com.toadzip.backend.ingest.repository.MyHomeAnnouncementSourceRepository;
 import java.math.BigDecimal;
@@ -55,6 +61,12 @@ class MyHomeAnnouncementMappingServiceTest {
     @Autowired
     private HousingTypeRepository housingTypeRepository;
 
+    @Autowired
+    private LhAnnouncementCollectionCheckpointRepository checkpointRepository;
+
+    @Autowired
+    private LhAnnouncementSupplySourceRepository lhSupplyRepository;
+
     @BeforeEach
     void setUp() {
         supplyRowRepository.deleteAll();
@@ -63,6 +75,8 @@ class MyHomeAnnouncementMappingServiceTest {
         complexRepository.deleteAll();
         failureRepository.deleteAll();
         sourceRepository.deleteAll();
+        checkpointRepository.deleteAll();
+        lhSupplyRepository.deleteAll();
     }
 
     @Test
@@ -262,6 +276,56 @@ class MyHomeAnnouncementMappingServiceTest {
     }
 
     @Test
+    void lh_공급행을_정제_단지에_연결하고_주택형명과_면적으로_정제_주택형을_확정한다() {
+        saveMappedComplex();
+        HousingComplex complex = complexRepository.findAll().getFirst();
+        HousingType nameMatched = housingTypeRepository.findAllByHousingComplex(complex).getFirst();
+        HousingType exclusiveAreaMatched = housingTypeRepository.save(HousingType.createFromMyHome(
+                complex,
+                "second-source-housing-type-id",
+                "59A",
+                new BigDecimal("59.9500"),
+                new BigDecimal("84.0500")
+        ));
+        HousingType supplyAreaMatched = housingTypeRepository.save(HousingType.createFromMyHome(
+                complex,
+                "third-source-housing-type-id",
+                "36A",
+                new BigDecimal("36.1000"),
+                new BigDecimal("50.0000")
+        ));
+        sourceRepository.save(source(0, data("21026", 1, "LH", "동삼2")));
+        service.mapAll();
+        saveLhSupplyCheckpoint("21026", "PAN-1");
+        lhSupplyRepository.saveAll(List.of(
+                lhSupply(0, "PAN-1", "동삼 2단지 국민임대", "46-A형", "99.0000", "99.0000"),
+                lhSupply(1, "PAN-1", "동삼 2단지 국민임대", "59형", "59.9500", "99.0000"),
+                lhSupply(2, "PAN-1", "동삼 2단지 국민임대", "기타", "99.0000", "50.0000"),
+                lhSupply(3, "PAN-1", "동삼 2단지 국민임대", "미상", "77.0000", "88.0000")
+        ));
+
+        var report = service.mapAll();
+
+        assertThat(report.createdSupplyRowCount()).isEqualTo(3);
+        assertThat(report.updatedSupplyRowCount()).isOne();
+        assertThat(report.failedSourceRowCount()).isOne();
+        assertThat(supplyRowRepository.findAll()).hasSize(4);
+        SupplyRow firstResolvedRow = supplyRowRepository.findAll().stream()
+                .filter(row -> !row.getSourceSupplyRowIdentifier().contains(":LH:"))
+                .findFirst()
+                .orElseThrow();
+        assertThat(firstResolvedRow.getHousingType().getId()).isEqualTo(nameMatched.getId());
+        assertThat(supplyRow("21026:LH:PAN-1:1").getHousingType().getId())
+                .isEqualTo(exclusiveAreaMatched.getId());
+        assertThat(supplyRow("21026:LH:PAN-1:2").getHousingType().getId())
+                .isEqualTo(supplyAreaMatched.getId());
+        assertThat(supplyRow("21026:LH:PAN-1:3")).satisfies(row -> {
+            assertThat(row.getHousingType()).isNull();
+            assertThat(row.getMatchingFailureReason()).contains("면적으로도 주택형 하나를 확정할 수 없습니다");
+        });
+    }
+
+    @Test
     void 필수_날짜를_변환할_수_없으면_공고를_만들지_않고_실패를_기록한다() {
         MyHomeAnnouncementSourceData invalid = withPostedDate(
                 data("21026", 1, "부산도시공사", "동삼2"),
@@ -341,6 +405,46 @@ class MyHomeAnnouncementMappingServiceTest {
 
     private MyHomeAnnouncementSource source(int order, MyHomeAnnouncementSourceData data) {
         MyHomeAnnouncementSource source = MyHomeAnnouncementSource.from(order, data);
+        source.markCollectedAt(COLLECTED_AT);
+        return source;
+    }
+
+    private SupplyRow supplyRow(String sourceIdentifier) {
+        return supplyRowRepository.findBySourceSupplyRowIdentifier(sourceIdentifier).orElseThrow();
+    }
+
+    private void saveLhSupplyCheckpoint(String announcementIdentifier, String panId) {
+        checkpointRepository.save(LhAnnouncementCollectionCheckpoint.complete(
+                ExternalDataSource.LH_ANNOUNCEMENT_SUPPLY,
+                announcementIdentifier,
+                "PAN_ID=" + panId + "&UPP_AIS_TP_CD=06&AIS_TP_CD=07",
+                panId,
+                COLLECTED_AT
+        ));
+    }
+
+    private LhAnnouncementSupplySource lhSupply(
+            int sourceOrder,
+            String panId,
+            String complexLabel,
+            String typeName,
+            String exclusiveArea,
+            String supplyArea
+    ) {
+        LhAnnouncementSupplySource source = new LhAnnouncementSupplySource(
+                sourceOrder,
+                panId,
+                new LhAnnouncementSupplySourceData(
+                        complexLabel,
+                        typeName,
+                        exclusiveArea,
+                        supplyArea,
+                        "100",
+                        "10",
+                        null,
+                        null
+                )
+        );
         source.markCollectedAt(COLLECTED_AT);
         return source;
     }


### PR DESCRIPTION
## 관련 이슈

Closes #18

## 작업 목적

- 수집한 마이홈 공고 원본을 두꺼비집의 공고·공급행 데이터 구조로 변환
- 공고 공급행을 #17에서 정규화한 단지·주택형과 연결하고, 반복 수집과 원천 변경에도 데이터 정합성을 유지

## 작업 내역

- 날짜, 공고 상태, 공급유형, 모집유형과 공급기관을 도메인 값으로 표준화하고 이전 공고 식별자로 정정·취소 공고를 연결
- PNU·공급유형·정규화된 단지명으로 단지를 찾고, 주택형명과 LH 공급 면적으로 주택형을 보정 매칭
- 매칭되지 않은 공급행은 보존하면서 실패 원천과 사유를 별도 저장하고 관리자 API에서 조회할 수 있게 함
- 원천 식별자 유일 제약과 매핑 실행 잠금으로 중복 생성 및 동시 실행을 방지했습니다.

## 리뷰 포인트

- 공고 공통 원천 값이 충돌하거나 필수값을 변환할 수 없으면 해당 공고 전체를 거절하고, 단지·주택형 매칭 실패는 공급행을 유지한 채 실패로 기록합니다.
- LH 공급 보정은 가장 최근 완료된 공급 체크포인트를 권위 있는 스냅샷으로 사용합니다.
- 관리자 매핑 결과에 `deletedSupplyRowCount`를 포함해 공급행 동기화 결과를 확인할 수 있습니다.
- 공고별 쓰기는 트랜잭션으로 격리하고 전체 실행은 PostgreSQL advisory lock과 로컬 잠금으로 중복 실행을 차단합니다.

## 검증 결과

- 테스트 방법: `./gradlew --rerun-tasks check`
- 테스트 결과: PostgreSQL 테스트 DB와 공유 테스트 DB 환경에서 전체 백엔드 검사 통과
- 테스트 방법: `sh tests/harness/validate-harness-test.sh && sh scripts/validate-harness.sh`
- 테스트 결과: 하네스 동작 및 저장소 규칙 검사 통과
- 테스트 방법: `git diff --check develop...HEAD`
- 테스트 결과: 공백 오류 없음
- 테스트 방법: 기존 브랜치와 최신 `develop` 기반 브랜치의 `git range-diff`
- 테스트 결과: 18번 커밋 6개의 패치가 모두 동일함
