### PR TITLE
feat(ingest): LH 공고 상세·공급 정보 보강 (#19)

### DIFF
--- a/backend/src/main/java/com/toadzip/backend/announcement/domain/Announcement.java
+++ b/backend/src/main/java/com/toadzip/backend/announcement/domain/Announcement.java
@@ -95,6 +95,8 @@ public class Announcement {
 
     private String correctionCancellationReason;
 
+    private String lhPanId;
+
     @Column(nullable = false)
     private long viewCount;
 
@@ -292,6 +294,18 @@ public class Announcement {
         originalUrl = incoming.originalUrl;
         correctionCancellationReason = incoming.correctionCancellationReason;
         receptionPlace = incoming.receptionPlace;
+    }
+
+    public boolean enrichFromLh(String panId, String correctionReason, ReceptionPlace receptionPlace) {
+        if (Objects.equals(lhPanId, panId)
+                && Objects.equals(correctionCancellationReason, correctionReason)
+                && hasSameReceptionPlace(receptionPlace)) {
+            return false;
+        }
+        lhPanId = panId;
+        correctionCancellationReason = correctionReason;
+        this.receptionPlace = receptionPlace;
+        return true;
     }
 
     public static Announcement create(

--- a/backend/src/main/java/com/toadzip/backend/announcement/domain/AnnouncementAttachment.java
+++ b/backend/src/main/java/com/toadzip/backend/announcement/domain/AnnouncementAttachment.java
@@ -45,6 +45,8 @@ public class AnnouncementAttachment {
     @Column(nullable = false)
     private int displayOrder;
 
+    private String sourceAttachmentIdentifier;
+
     private AnnouncementAttachment(
             Announcement announcement,
             String fileName,
@@ -72,6 +74,34 @@ public class AnnouncementAttachment {
             int displayOrder
     ) {
         return new AnnouncementAttachment(announcement, fileName, fileType, fileUrl, displayOrder);
+    }
+
+    public static AnnouncementAttachment createFromSource(
+            Announcement announcement,
+            String sourceAttachmentIdentifier,
+            String fileName,
+            AttachmentType fileType,
+            String fileUrl,
+            int displayOrder
+    ) {
+        AnnouncementAttachment attachment = create(announcement, fileName, fileType, fileUrl, displayOrder);
+        attachment.sourceAttachmentIdentifier = sourceAttachmentIdentifier;
+        return attachment;
+    }
+
+    public boolean updateFromSource(String fileName, AttachmentType fileType, String fileUrl, int displayOrder) {
+        AnnouncementAttachment incoming = create(announcement, fileName, fileType, fileUrl, displayOrder);
+        if (this.fileName.equals(incoming.fileName)
+                && this.fileType == incoming.fileType
+                && this.fileUrl.equals(incoming.fileUrl)
+                && this.displayOrder == incoming.displayOrder) {
+            return false;
+        }
+        this.fileName = incoming.fileName;
+        this.fileType = incoming.fileType;
+        this.fileUrl = incoming.fileUrl;
+        this.displayOrder = incoming.displayOrder;
+        return true;
     }
 
     public static AnnouncementAttachment create(

--- a/backend/src/main/java/com/toadzip/backend/announcement/domain/AnnouncementSchedule.java
+++ b/backend/src/main/java/com/toadzip/backend/announcement/domain/AnnouncementSchedule.java
@@ -49,6 +49,8 @@ public class AnnouncementSchedule {
     @Column(nullable = false)
     private int displayOrder;
 
+    private String sourceScheduleIdentifier;
+
     private AnnouncementSchedule(
             Announcement announcement,
             ScheduleType scheduleType,
@@ -81,6 +83,43 @@ public class AnnouncementSchedule {
             int displayOrder
     ) {
         return new AnnouncementSchedule(announcement, scheduleType, name, startAt, endAt, displayOrder);
+    }
+
+    public static AnnouncementSchedule createFromSource(
+            Announcement announcement,
+            String sourceScheduleIdentifier,
+            ScheduleType scheduleType,
+            String name,
+            LocalDateTime startAt,
+            LocalDateTime endAt,
+            int displayOrder
+    ) {
+        AnnouncementSchedule schedule = create(announcement, scheduleType, name, startAt, endAt, displayOrder);
+        schedule.sourceScheduleIdentifier = sourceScheduleIdentifier;
+        return schedule;
+    }
+
+    public boolean updateFromSource(
+            ScheduleType scheduleType,
+            String name,
+            LocalDateTime startAt,
+            LocalDateTime endAt,
+            int displayOrder
+    ) {
+        AnnouncementSchedule incoming = create(announcement, scheduleType, name, startAt, endAt, displayOrder);
+        if (this.scheduleType == incoming.scheduleType
+                && this.name.equals(incoming.name)
+                && this.startAt.equals(incoming.startAt)
+                && this.endAt.equals(incoming.endAt)
+                && this.displayOrder == incoming.displayOrder) {
+            return false;
+        }
+        this.scheduleType = incoming.scheduleType;
+        this.name = incoming.name;
+        this.startAt = incoming.startAt;
+        this.endAt = incoming.endAt;
+        this.displayOrder = incoming.displayOrder;
+        return true;
     }
 
     public static AnnouncementSchedule create(

--- a/backend/src/main/java/com/toadzip/backend/announcement/domain/SupplyRow.java
+++ b/backend/src/main/java/com/toadzip/backend/announcement/domain/SupplyRow.java
@@ -76,6 +76,8 @@ public class SupplyRow {
 
     private Integer totalSupplyHouseholdCount;
 
+    private String lhSourceSupplyRowIdentifier;
+
     private SupplyRow(
             Announcement announcement,
             HousingComplex housingComplex,
@@ -200,6 +202,22 @@ public class SupplyRow {
         supplyCategory = incoming.supplyCategory;
         matchingFailureReason = incoming.matchingFailureReason;
         totalSupplyHouseholdCount = incoming.totalSupplyHouseholdCount;
+    }
+
+    public boolean enrichFromLh(
+            String sourceSupplyRowIdentifier,
+            YearMonth expectedMoveInMonth,
+            Integer totalSupplyHouseholdCount
+    ) {
+        if (Objects.equals(lhSourceSupplyRowIdentifier, sourceSupplyRowIdentifier)
+                && Objects.equals(this.expectedMoveInMonth, expectedMoveInMonth)
+                && Objects.equals(this.totalSupplyHouseholdCount, totalSupplyHouseholdCount)) {
+            return false;
+        }
+        lhSourceSupplyRowIdentifier = sourceSupplyRowIdentifier;
+        this.expectedMoveInMonth = expectedMoveInMonth;
+        this.totalSupplyHouseholdCount = totalSupplyHouseholdCount;
+        return true;
     }
 
     private void validateRequired(Object value, String fieldName) {

--- a/backend/src/main/java/com/toadzip/backend/announcement/domain/SupplyTarget.java
+++ b/backend/src/main/java/com/toadzip/backend/announcement/domain/SupplyTarget.java
@@ -21,6 +21,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = PROTECTED)
 public class SupplyTarget {
 
+    private static final String SOURCE_APPLICATION_CONDITION = "공고문 참조";
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -48,6 +50,8 @@ public class SupplyTarget {
 
     @Column(nullable = false)
     private int displayOrder;
+
+    private String sourceSupplyTargetIdentifier;
 
     private SupplyTarget(
             SupplyRow supplyRow,
@@ -107,6 +111,53 @@ public class SupplyTarget {
                 applicationCondition,
                 displayOrder
         );
+    }
+
+    public static SupplyTarget createFromSource(
+            SupplyRow supplyRow,
+            String sourceSupplyTargetIdentifier,
+            String target,
+            String supplyRank,
+            Integer supplyHouseholdCount,
+            BigDecimal rentalDeposit,
+            BigDecimal monthlyRent,
+            int displayOrder
+    ) {
+        SupplyTarget supplyTarget = create(
+                supplyRow, target, supplyRank, supplyHouseholdCount, null,
+                rentalDeposit, monthlyRent, null, SOURCE_APPLICATION_CONDITION, displayOrder
+        );
+        supplyTarget.sourceSupplyTargetIdentifier = sourceSupplyTargetIdentifier;
+        return supplyTarget;
+    }
+
+    public boolean updateFromSource(
+            String target,
+            String supplyRank,
+            Integer supplyHouseholdCount,
+            BigDecimal rentalDeposit,
+            BigDecimal monthlyRent,
+            int displayOrder
+    ) {
+        SupplyTarget incoming = createFromSource(
+                supplyRow, sourceSupplyTargetIdentifier, target, supplyRank,
+                supplyHouseholdCount, rentalDeposit, monthlyRent, displayOrder
+        );
+        if (this.target.equals(incoming.target)
+                && this.supplyRank.equals(incoming.supplyRank)
+                && java.util.Objects.equals(this.supplyHouseholdCount, incoming.supplyHouseholdCount)
+                && java.util.Objects.equals(this.rentalDeposit, incoming.rentalDeposit)
+                && java.util.Objects.equals(this.monthlyRent, incoming.monthlyRent)
+                && this.displayOrder == incoming.displayOrder) {
+            return false;
+        }
+        this.target = incoming.target;
+        this.supplyRank = incoming.supplyRank;
+        this.supplyHouseholdCount = incoming.supplyHouseholdCount;
+        this.rentalDeposit = incoming.rentalDeposit;
+        this.monthlyRent = incoming.monthlyRent;
+        this.displayOrder = incoming.displayOrder;
+        return true;
     }
 
     private void validateRequired(Object value, String fieldName) {

--- a/backend/src/main/java/com/toadzip/backend/announcement/repository/AnnouncementAttachmentRepository.java
+++ b/backend/src/main/java/com/toadzip/backend/announcement/repository/AnnouncementAttachmentRepository.java
@@ -3,11 +3,14 @@ package com.toadzip.backend.announcement.repository;
 import com.toadzip.backend.announcement.domain.AnnouncementAttachment;
 import java.util.Collection;
 import java.util.List;
+import com.toadzip.backend.announcement.domain.Announcement;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface AnnouncementAttachmentRepository extends JpaRepository<AnnouncementAttachment, Long> {
+
+    List<AnnouncementAttachment> findAllByAnnouncement(Announcement announcement);
 
     @Query("""
             SELECT attachment

--- a/backend/src/main/java/com/toadzip/backend/announcement/repository/AnnouncementScheduleRepository.java
+++ b/backend/src/main/java/com/toadzip/backend/announcement/repository/AnnouncementScheduleRepository.java
@@ -3,11 +3,14 @@ package com.toadzip.backend.announcement.repository;
 import com.toadzip.backend.announcement.domain.AnnouncementSchedule;
 import java.util.Collection;
 import java.util.List;
+import com.toadzip.backend.announcement.domain.Announcement;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface AnnouncementScheduleRepository extends JpaRepository<AnnouncementSchedule, Long> {
+
+    List<AnnouncementSchedule> findAllByAnnouncement(Announcement announcement);
 
     @Query("""
             SELECT schedule

--- a/backend/src/main/java/com/toadzip/backend/announcement/repository/SupplyTargetRepository.java
+++ b/backend/src/main/java/com/toadzip/backend/announcement/repository/SupplyTargetRepository.java
@@ -15,6 +15,8 @@ public interface SupplyTargetRepository extends JpaRepository<SupplyTarget, Long
     @Query("DELETE FROM SupplyTarget target WHERE target.supplyRow IN :supplyRows")
     int deleteAllBySupplyRowIn(@Param("supplyRows") Collection<SupplyRow> supplyRows);
 
+    List<SupplyTarget> findAllBySupplyRow(SupplyRow supplyRow);
+
     @Query("""
             SELECT target
             FROM SupplyTarget target

--- a/backend/src/main/java/com/toadzip/backend/ingest/controller/LhAnnouncementEnrichmentController.java
+++ b/backend/src/main/java/com/toadzip/backend/ingest/controller/LhAnnouncementEnrichmentController.java
@@ -1,0 +1,32 @@
+package com.toadzip.backend.ingest.controller;
+
+import com.toadzip.backend.ingest.dto.LhAnnouncementEnrichmentFailureResponse;
+import com.toadzip.backend.ingest.dto.LhAnnouncementEnrichmentReport;
+import com.toadzip.backend.ingest.service.LhAnnouncementEnrichmentService;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/admin/ingest/lh/announcement-enrichments")
+public class LhAnnouncementEnrichmentController {
+
+    private final LhAnnouncementEnrichmentService enrichmentService;
+
+    public LhAnnouncementEnrichmentController(LhAnnouncementEnrichmentService enrichmentService) {
+        this.enrichmentService = enrichmentService;
+    }
+
+    @PostMapping
+    public ResponseEntity<LhAnnouncementEnrichmentReport> enrichAll() {
+        return ResponseEntity.ok(enrichmentService.enrichAll());
+    }
+
+    @GetMapping("/failures")
+    public ResponseEntity<List<LhAnnouncementEnrichmentFailureResponse>> findFailures() {
+        return ResponseEntity.ok(enrichmentService.findFailures());
+    }
+}

--- a/backend/src/main/java/com/toadzip/backend/ingest/domain/LhAnnouncementEnrichmentFailure.java
+++ b/backend/src/main/java/com/toadzip/backend/ingest/domain/LhAnnouncementEnrichmentFailure.java
@@ -1,0 +1,88 @@
+package com.toadzip.backend.ingest.domain;
+
+import static lombok.AccessLevel.PROTECTED;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "lh_announcement_enrichment_failures")
+@NoArgsConstructor(access = PROTECTED)
+public class LhAnnouncementEnrichmentFailure {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 500)
+    private String sourceKey;
+
+    private String sourceAnnouncementIdentifier;
+
+    private String panId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 50)
+    private LhAnnouncementEnrichmentFailureReason reason;
+
+    @Column(nullable = false, length = 1000)
+    private String detail;
+
+    @Column(nullable = false)
+    private Instant occurredAt;
+
+    private LhAnnouncementEnrichmentFailure(
+            String sourceKey,
+            String sourceAnnouncementIdentifier,
+            String panId,
+            LhAnnouncementEnrichmentFailureReason reason,
+            String detail,
+            Instant occurredAt
+    ) {
+        requireText(sourceKey, "원천 키");
+        require(reason, "실패 사유");
+        requireText(detail, "실패 상세");
+        require(occurredAt, "실패 시각");
+        this.sourceKey = sourceKey;
+        this.sourceAnnouncementIdentifier = sourceAnnouncementIdentifier;
+        this.panId = panId;
+        this.reason = reason;
+        this.detail = detail;
+        this.occurredAt = occurredAt;
+    }
+
+    public static LhAnnouncementEnrichmentFailure create(
+            String sourceKey,
+            String sourceAnnouncementIdentifier,
+            String panId,
+            LhAnnouncementEnrichmentFailureReason reason,
+            String detail,
+            Instant occurredAt
+    ) {
+        return new LhAnnouncementEnrichmentFailure(
+                sourceKey, sourceAnnouncementIdentifier, panId, reason, detail, occurredAt
+        );
+    }
+
+    private static void requireText(String value, String fieldName) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(fieldName + "은 필수입니다.");
+        }
+    }
+
+    private static void require(Object value, String fieldName) {
+        if (value == null) {
+            throw new IllegalArgumentException(fieldName + "은 필수입니다.");
+        }
+    }
+}

--- a/backend/src/main/java/com/toadzip/backend/ingest/domain/LhAnnouncementEnrichmentFailureReason.java
+++ b/backend/src/main/java/com/toadzip/backend/ingest/domain/LhAnnouncementEnrichmentFailureReason.java
@@ -1,0 +1,14 @@
+package com.toadzip.backend.ingest.domain;
+
+public enum LhAnnouncementEnrichmentFailureReason {
+    ANNOUNCEMENT_NOT_FOUND,
+    PAN_ID_NOT_FOUND,
+    LH_DETAIL_SOURCE_NOT_FOUND,
+    LH_SUPPLY_SOURCE_NOT_FOUND,
+    UNSUPPORTED_SUPPLY_TYPE,
+    INVALID_VALUE,
+    COMPLEX_NOT_FOUND,
+    AMBIGUOUS_COMPLEX,
+    HOUSING_TYPE_NOT_FOUND,
+    AMBIGUOUS_HOUSING_TYPE
+}

--- a/backend/src/main/java/com/toadzip/backend/ingest/dto/LhAnnouncementEnrichmentFailureResponse.java
+++ b/backend/src/main/java/com/toadzip/backend/ingest/dto/LhAnnouncementEnrichmentFailureResponse.java
@@ -1,0 +1,22 @@
+package com.toadzip.backend.ingest.dto;
+
+import com.toadzip.backend.ingest.domain.LhAnnouncementEnrichmentFailure;
+import com.toadzip.backend.ingest.domain.LhAnnouncementEnrichmentFailureReason;
+import java.time.Instant;
+
+public record LhAnnouncementEnrichmentFailureResponse(
+        String sourceKey,
+        String sourceAnnouncementIdentifier,
+        String panId,
+        LhAnnouncementEnrichmentFailureReason reason,
+        String detail,
+        Instant occurredAt
+) {
+
+    public static LhAnnouncementEnrichmentFailureResponse from(LhAnnouncementEnrichmentFailure failure) {
+        return new LhAnnouncementEnrichmentFailureResponse(
+                failure.getSourceKey(), failure.getSourceAnnouncementIdentifier(), failure.getPanId(),
+                failure.getReason(), failure.getDetail(), failure.getOccurredAt()
+        );
+    }
+}

--- a/backend/src/main/java/com/toadzip/backend/ingest/dto/LhAnnouncementEnrichmentReport.java
+++ b/backend/src/main/java/com/toadzip/backend/ingest/dto/LhAnnouncementEnrichmentReport.java
@@ -1,0 +1,38 @@
+package com.toadzip.backend.ingest.dto;
+
+public record LhAnnouncementEnrichmentReport(
+        int updatedAnnouncementCount,
+        int unchangedAnnouncementCount,
+        int createdScheduleCount,
+        int updatedScheduleCount,
+        int createdAttachmentCount,
+        int updatedAttachmentCount,
+        int updatedSupplyRowCount,
+        int createdSupplyTargetCount,
+        int updatedSupplyTargetCount,
+        int failedSourceCount
+) {
+
+    public static LhAnnouncementEnrichmentReport empty() {
+        return new LhAnnouncementEnrichmentReport(0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+    }
+
+    public LhAnnouncementEnrichmentReport plus(LhAnnouncementEnrichmentReport other) {
+        return new LhAnnouncementEnrichmentReport(
+                updatedAnnouncementCount + other.updatedAnnouncementCount,
+                unchangedAnnouncementCount + other.unchangedAnnouncementCount,
+                createdScheduleCount + other.createdScheduleCount,
+                updatedScheduleCount + other.updatedScheduleCount,
+                createdAttachmentCount + other.createdAttachmentCount,
+                updatedAttachmentCount + other.updatedAttachmentCount,
+                updatedSupplyRowCount + other.updatedSupplyRowCount,
+                createdSupplyTargetCount + other.createdSupplyTargetCount,
+                updatedSupplyTargetCount + other.updatedSupplyTargetCount,
+                failedSourceCount + other.failedSourceCount
+        );
+    }
+
+    public static LhAnnouncementEnrichmentReport failed() {
+        return new LhAnnouncementEnrichmentReport(0, 0, 0, 0, 0, 0, 0, 0, 0, 1);
+    }
+}

--- a/backend/src/main/java/com/toadzip/backend/ingest/repository/LhAnnouncementDetailSourceRepository.java
+++ b/backend/src/main/java/com/toadzip/backend/ingest/repository/LhAnnouncementDetailSourceRepository.java
@@ -12,5 +12,7 @@ public interface LhAnnouncementDetailSourceRepository extends JpaRepository<LhAn
     @Query("select distinct source.panId from LhAnnouncementDetailSource source where source.panId in :panIds")
     List<String> findStoredPanIds(Collection<String> panIds);
 
+    List<LhAnnouncementDetailSource> findAllByPanIdOrderBySourceOrderAsc(String panId);
+
     void deleteByPanId(String panId);
 }

--- a/backend/src/main/java/com/toadzip/backend/ingest/repository/LhAnnouncementEnrichmentExecutionLock.java
+++ b/backend/src/main/java/com/toadzip/backend/ingest/repository/LhAnnouncementEnrichmentExecutionLock.java
@@ -1,0 +1,65 @@
+package com.toadzip.backend.ingest.repository;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Optional;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Supplier;
+import javax.sql.DataSource;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class LhAnnouncementEnrichmentExecutionLock {
+
+    private static final long LOCK_KEY = 8_432_026_082_800_019L;
+    private static final String TRY_LOCK_SQL = "SELECT pg_try_advisory_lock(?)";
+    private static final String UNLOCK_SQL = "SELECT pg_advisory_unlock(?)";
+
+    private final DataSource dataSource;
+    private final ReentrantLock localLock = new ReentrantLock();
+
+    public LhAnnouncementEnrichmentExecutionLock(DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    public <T> Optional<T> tryRun(Supplier<T> action) {
+        if (!localLock.tryLock()) {
+            return Optional.empty();
+        }
+        try (Connection connection = dataSource.getConnection()) {
+            if (!tryLock(connection)) {
+                return Optional.empty();
+            }
+            try {
+                return Optional.of(action.get());
+            }
+            finally {
+                unlock(connection);
+            }
+        }
+        catch (SQLException exception) {
+            throw new IllegalStateException("LH 공고 보강 잠금을 확인할 수 없습니다.", exception);
+        }
+        finally {
+            localLock.unlock();
+        }
+    }
+
+    private boolean tryLock(Connection connection) throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement(TRY_LOCK_SQL)) {
+            statement.setLong(1, LOCK_KEY);
+            try (ResultSet result = statement.executeQuery()) {
+                return result.next() && result.getBoolean(1);
+            }
+        }
+    }
+
+    private void unlock(Connection connection) throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement(UNLOCK_SQL)) {
+            statement.setLong(1, LOCK_KEY);
+            statement.executeQuery();
+        }
+    }
+}

--- a/backend/src/main/java/com/toadzip/backend/ingest/repository/LhAnnouncementEnrichmentFailureRepository.java
+++ b/backend/src/main/java/com/toadzip/backend/ingest/repository/LhAnnouncementEnrichmentFailureRepository.java
@@ -1,0 +1,11 @@
+package com.toadzip.backend.ingest.repository;
+
+import com.toadzip.backend.ingest.domain.LhAnnouncementEnrichmentFailure;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LhAnnouncementEnrichmentFailureRepository
+        extends JpaRepository<LhAnnouncementEnrichmentFailure, Long> {
+
+    List<LhAnnouncementEnrichmentFailure> findAllByOrderBySourceKeyAsc();
+}

--- a/backend/src/main/java/com/toadzip/backend/ingest/repository/LhAnnouncementEnrichmentFailureStore.java
+++ b/backend/src/main/java/com/toadzip/backend/ingest/repository/LhAnnouncementEnrichmentFailureStore.java
@@ -1,0 +1,22 @@
+package com.toadzip.backend.ingest.repository;
+
+import com.toadzip.backend.ingest.domain.LhAnnouncementEnrichmentFailure;
+import java.util.List;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+public class LhAnnouncementEnrichmentFailureStore {
+
+    private final LhAnnouncementEnrichmentFailureRepository repository;
+
+    public LhAnnouncementEnrichmentFailureStore(LhAnnouncementEnrichmentFailureRepository repository) {
+        this.repository = repository;
+    }
+
+    @Transactional
+    public void replaceAll(List<LhAnnouncementEnrichmentFailure> failures) {
+        repository.deleteAllInBatch();
+        repository.saveAll(failures);
+    }
+}

--- a/backend/src/main/java/com/toadzip/backend/ingest/service/LhAnnouncementEnrichmentMapper.java
+++ b/backend/src/main/java/com/toadzip/backend/ingest/service/LhAnnouncementEnrichmentMapper.java
@@ -35,9 +35,9 @@ public class LhAnnouncementEnrichmentMapper {
     ) {
         List<LhScheduleData> schedules = new ArrayList<>();
         List<LhAttachmentData> attachments = new ArrayList<>();
+        List<LhComplexData> complexes = new ArrayList<>();
         String correctionReason = null;
         ReceptionPlace receptionPlace = null;
-        YearMonth expectedMoveInMonth = null;
         for (LhAnnouncementDetailSource detail : details) {
             if ("ETC_INFO".equals(detail.getDatasetType()) && detail.getCorrectionReason() != null) {
                 correctionReason = detail.getCorrectionReason();
@@ -51,15 +51,43 @@ public class LhAnnouncementEnrichmentMapper {
             if ("ANNOUNCEMENT_FILE".equals(detail.getDatasetType())) {
                 attachments.add(attachmentOf(panId, detail));
             }
-            if ("COMPLEX".equals(detail.getDatasetType()) && expectedMoveInMonth == null) {
-                expectedMoveInMonth = yearMonthOf(detail.getExpectedMoveInYearMonth(), "입주예정월");
+            if ("COMPLEX".equals(detail.getDatasetType())) {
+                complexes.add(new LhComplexData(detail.getComplexName(), detail.getExpectedMoveInYearMonth()));
             }
         }
-        YearMonth resolvedExpectedMoveInMonth = expectedMoveInMonth;
         return new LhAnnouncementEnrichmentData(
                 panId, correctionReason, receptionPlace, schedules, attachments,
-                supplies.stream().map(source -> supplyOf(panId, source, resolvedExpectedMoveInMonth)).toList()
+                supplies.stream()
+                        .map(source -> supplyOf(panId, source, expectedMoveInMonthOf(source, complexes)))
+                        .toList()
         );
+    }
+
+    private YearMonth expectedMoveInMonthOf(
+            LhAnnouncementSupplySource supply,
+            List<LhComplexData> complexes
+    ) {
+        List<LhComplexData> matches = complexes.stream()
+                .filter(complex -> sameComplex(complex.name(), supply.getComplexLabel()))
+                .toList();
+        if (matches.size() == 1) {
+            return yearMonthOf(matches.getFirst().expectedMoveInYearMonth(), "입주예정월");
+        }
+        if (matches.isEmpty() && complexes.size() == 1) {
+            return yearMonthOf(complexes.getFirst().expectedMoveInYearMonth(), "입주예정월");
+        }
+        return null;
+    }
+
+    private boolean sameComplex(String left, String right) {
+        return normalizedName(left).equals(normalizedName(right));
+    }
+
+    private String normalizedName(String value) {
+        if (value == null) {
+            return "";
+        }
+        return value.replaceAll("\\s+", "").replace("-", "").strip().toLowerCase();
     }
 
     private ReceptionPlace receptionOf(LhAnnouncementDetailSource detail) {
@@ -327,6 +355,9 @@ record LhScheduleData(
 }
 
 record LhAttachmentData(String sourceIdentifier, String name, AttachmentType type, String url) {
+}
+
+record LhComplexData(String name, String expectedMoveInYearMonth) {
 }
 
 record LhSupplyData(

--- a/backend/src/main/java/com/toadzip/backend/ingest/service/LhAnnouncementEnrichmentMapper.java
+++ b/backend/src/main/java/com/toadzip/backend/ingest/service/LhAnnouncementEnrichmentMapper.java
@@ -1,0 +1,356 @@
+package com.toadzip.backend.ingest.service;
+
+import com.toadzip.backend.announcement.domain.AttachmentType;
+import com.toadzip.backend.announcement.domain.ReceptionMethod;
+import com.toadzip.backend.announcement.domain.ReceptionPlace;
+import com.toadzip.backend.announcement.domain.ScheduleType;
+import com.toadzip.backend.ingest.domain.LhAnnouncementDetailSource;
+import com.toadzip.backend.ingest.domain.LhAnnouncementEnrichmentFailureReason;
+import com.toadzip.backend.ingest.domain.LhAnnouncementSupplySource;
+import java.math.BigDecimal;
+import java.time.DateTimeException;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.springframework.stereotype.Component;
+
+@Component
+public class LhAnnouncementEnrichmentMapper {
+
+    private static final Pattern DATE_TIME = Pattern.compile(
+            "(20\\d{2})\\D*(\\d{1,2})\\D*(\\d{1,2})(?:\\D+(\\d{1,2})\\D*(\\d{2}))?"
+    );
+
+    private static final Pattern YEAR_MONTH = Pattern.compile("((?:19|20)\\d{2})\\D*(\\d{1,2})");
+
+    private static final int MAX_RECEPTION_NAME_LENGTH = 255;
+
+    public LhAnnouncementEnrichmentData map(
+            String panId,
+            List<LhAnnouncementDetailSource> details,
+            List<LhAnnouncementSupplySource> supplies
+    ) {
+        List<LhScheduleData> schedules = new ArrayList<>();
+        List<LhAttachmentData> attachments = new ArrayList<>();
+        String correctionReason = null;
+        ReceptionPlace receptionPlace = null;
+        YearMonth expectedMoveInMonth = null;
+        for (LhAnnouncementDetailSource detail : details) {
+            if ("ETC_INFO".equals(detail.getDatasetType()) && detail.getCorrectionReason() != null) {
+                correctionReason = detail.getCorrectionReason();
+            }
+            if ("RECEPTION".equals(detail.getDatasetType()) && receptionPlace == null) {
+                receptionPlace = receptionOf(detail);
+            }
+            if ("SCHEDULE".equals(detail.getDatasetType())) {
+                schedules.addAll(schedulesOf(panId, detail));
+            }
+            if ("ANNOUNCEMENT_FILE".equals(detail.getDatasetType())) {
+                attachments.add(attachmentOf(panId, detail));
+            }
+            if ("COMPLEX".equals(detail.getDatasetType()) && expectedMoveInMonth == null) {
+                expectedMoveInMonth = yearMonthOf(detail.getExpectedMoveInYearMonth(), "입주예정월");
+            }
+        }
+        YearMonth resolvedExpectedMoveInMonth = expectedMoveInMonth;
+        return new LhAnnouncementEnrichmentData(
+                panId, correctionReason, receptionPlace, schedules, attachments,
+                supplies.stream().map(source -> supplyOf(panId, source, resolvedExpectedMoveInMonth)).toList()
+        );
+    }
+
+    private ReceptionPlace receptionOf(LhAnnouncementDetailSource detail) {
+        String address = joined(detail.getReceptionAddress(), detail.getReceptionDetailAddress());
+        String name = textWithin(detail.getReceptionGuidance(), MAX_RECEPTION_NAME_LENGTH);
+        if (name == null || name.isBlank()) {
+            name = "LH 접수처";
+        }
+        return ReceptionPlace.create(name, ReceptionMethod.VISIT, address, detail.getPhone(), null);
+    }
+
+    private String textWithin(String value, int maximumLength) {
+        if (value == null || value.length() > maximumLength) {
+            return null;
+        }
+        return value;
+    }
+
+    private List<LhScheduleData> schedulesOf(String panId, LhAnnouncementDetailSource source) {
+        List<LhScheduleData> schedules = new ArrayList<>();
+        addRange(schedules, panId, source, ScheduleType.APPLICATION, "접수", source.getApplicationPeriod());
+        addDate(schedules, panId, source, ScheduleType.WINNER_ANNOUNCEMENT, "당첨자 발표", source.getDocumentTargetAnnouncementDate());
+        addRange(
+                schedules, panId, source, ScheduleType.DOCUMENT_SUBMISSION, "서류제출",
+                source.getDocumentSubmissionBeginDate(), source.getDocumentSubmissionEndDate()
+        );
+        addRange(schedules, panId, source, ScheduleType.CONTRACT, "계약", source.getContractBeginDate(), source.getContractEndDate());
+        return schedules;
+    }
+
+    private void addRange(
+            List<LhScheduleData> schedules,
+            String panId,
+            LhAnnouncementDetailSource source,
+            ScheduleType type,
+            String name,
+            String range
+    ) {
+        if (unavailable(range)) {
+            return;
+        }
+        List<LocalDateTime> values = dateTimes(range, name);
+        if (values.size() < 2) {
+            throw invalid(name + " 기간의 시작·종료 시각을 해석할 수 없습니다.");
+        }
+        schedules.add(schedule(panId, source, type, name, values.getFirst(), values.get(1)));
+    }
+
+    private void addRange(
+            List<LhScheduleData> schedules,
+            String panId,
+            LhAnnouncementDetailSource source,
+            ScheduleType type,
+            String name,
+            String begin,
+            String end
+    ) {
+        if (unavailable(begin) && unavailable(end)) {
+            return;
+        }
+        if (unavailable(begin) || unavailable(end)) {
+            throw invalid(name + " 기간의 시작 또는 종료 시각이 없습니다.");
+        }
+        schedules.add(schedule(panId, source, type, name, dateTime(begin, name), dateTime(end, name)));
+    }
+
+    private void addDate(
+            List<LhScheduleData> schedules,
+            String panId,
+            LhAnnouncementDetailSource source,
+            ScheduleType type,
+            String name,
+            String value
+    ) {
+        if (!unavailable(value)) {
+            LocalDateTime at = dateTime(value, name);
+            schedules.add(schedule(panId, source, type, name, at, at));
+        }
+    }
+
+    private LhScheduleData schedule(
+            String panId,
+            LhAnnouncementDetailSource source,
+            ScheduleType type,
+            String name,
+            LocalDateTime startAt,
+            LocalDateTime endAt
+    ) {
+        if (endAt.isBefore(startAt)) {
+            throw invalid(name + " 종료 시각이 시작 시각보다 빠릅니다.");
+        }
+        return new LhScheduleData(
+                identifier(panId, "SCHEDULE", source.getSourceOrder(), type.name()), type, name, startAt, endAt
+        );
+    }
+
+    private LhAttachmentData attachmentOf(String panId, LhAnnouncementDetailSource source) {
+        if (blank(source.getName()) || blank(source.getUrl())) {
+            throw invalid("첨부파일명 또는 URL이 없습니다.");
+        }
+        return new LhAttachmentData(
+                identifier(panId, "ANNOUNCEMENT_FILE", source.getSourceOrder(), null), source.getName(),
+                attachmentTypeOf(source.getKind()), source.getUrl()
+        );
+    }
+
+    private LhSupplyData supplyOf(String panId, LhAnnouncementSupplySource source, YearMonth expectedMoveInMonth) {
+        if (blank(source.getComplexLabel()) || blank(source.getTypeName())) {
+            throw invalid("LH 공급 원본의 단지명 또는 주택형명이 없습니다.");
+        }
+        return new LhSupplyData(
+                identifier(panId, "SUPPLY", source.getSourceOrder(), null), source.getComplexLabel(),
+                source.getTypeName(), expectedMoveInMonth, integerOf(source.getTotalUnitCount(), "전체 세대수"),
+                integerOf(source.getSuppliedUnitCount(), "공급 세대수"), amountOf(source.getDepositText(), "임대보증금"),
+                amountOf(source.getMonthlyRentText(), "월 임대료")
+        );
+    }
+
+    private AttachmentType attachmentTypeOf(String kind) {
+        if (kind != null && kind.contains("취소")) {
+            return AttachmentType.CANCELLATION;
+        }
+        if (kind != null && kind.contains("정정")) {
+            return AttachmentType.CORRECTION;
+        }
+        if (kind != null && kind.contains("공고")) {
+            return AttachmentType.ANNOUNCEMENT;
+        }
+        return AttachmentType.REFERENCE;
+    }
+
+    private List<LocalDateTime> dateTimes(String value, String fieldName) {
+        List<LocalDateTime> values = new ArrayList<>();
+        Matcher matcher = DATE_TIME.matcher(value);
+        while (matcher.find()) {
+            values.add(dateTime(matcher, fieldName));
+        }
+        return values;
+    }
+
+    private LocalDateTime dateTime(String value, String fieldName) {
+        Matcher matcher = DATE_TIME.matcher(value);
+        if (!matcher.find()) {
+            throw invalid(fieldName + " 형식이 올바르지 않습니다.");
+        }
+        return dateTime(matcher, fieldName);
+    }
+
+    private LocalDateTime dateTime(Matcher matcher, String fieldName) {
+        try {
+            int hour = matcher.group(4) == null ? 0 : Integer.parseInt(matcher.group(4));
+            int minute = matcher.group(5) == null ? 0 : Integer.parseInt(matcher.group(5));
+            return LocalDateTime.of(
+                    Integer.parseInt(matcher.group(1)), Integer.parseInt(matcher.group(2)),
+                    Integer.parseInt(matcher.group(3)), hour, minute
+            );
+        }
+        catch (DateTimeException | NumberFormatException exception) {
+            throw invalid(fieldName + " 형식이 올바르지 않습니다.");
+        }
+    }
+
+    private YearMonth yearMonthOf(String value, String fieldName) {
+        if (unavailable(value)) {
+            return null;
+        }
+        Matcher matcher = YEAR_MONTH.matcher(value);
+        if (!matcher.find()) {
+            throw invalid(fieldName + " 형식이 올바르지 않습니다.");
+        }
+        try {
+            return YearMonth.of(Integer.parseInt(matcher.group(1)), Integer.parseInt(matcher.group(2)));
+        }
+        catch (DateTimeException | NumberFormatException exception) {
+            throw invalid(fieldName + " 형식이 올바르지 않습니다.");
+        }
+    }
+
+    private Integer integerOf(String value, String fieldName) {
+        if (unavailable(value)) {
+            return null;
+        }
+        String digits = value.replaceAll("[^0-9]", "");
+        if (digits.isEmpty()) {
+            throw invalid(fieldName + " 형식이 올바르지 않습니다.");
+        }
+        try {
+            return Integer.valueOf(digits);
+        }
+        catch (NumberFormatException exception) {
+            throw invalid(fieldName + " 형식이 올바르지 않습니다.");
+        }
+    }
+
+    private BigDecimal amountOf(String value, String fieldName) {
+        if (unavailable(value)) {
+            return null;
+        }
+        String digits = value.replaceAll("[^0-9]", "");
+        if (digits.isEmpty()) {
+            throw invalid(fieldName + " 형식이 올바르지 않습니다.");
+        }
+        return new BigDecimal(digits);
+    }
+
+    private String identifier(String panId, String datasetType, Integer sourceOrder, String suffix) {
+        String identifier = "LH:" + panId + ":" + datasetType + ":" + sourceOrder;
+        if (suffix == null) {
+            return identifier;
+        }
+        return identifier + ":" + suffix;
+    }
+
+    private String joined(String first, String second) {
+        if (blank(first)) {
+            return second;
+        }
+        if (blank(second)) {
+            return first;
+        }
+        return first + " " + second;
+    }
+
+    private boolean blank(String value) {
+        return value == null || value.isBlank();
+    }
+
+    private boolean unavailable(String value) {
+        if (blank(value)) {
+            return true;
+        }
+        String normalized = value.replaceAll("\\s+", "").strip();
+        return normalized.equals("~")
+                || normalized.equals("-")
+                || normalized.startsWith("9999")
+                || normalized.contains("공고문참조")
+                || normalized.contains("미정")
+                || normalized.contains("별도 안내");
+    }
+
+    private LhAnnouncementEnrichmentRejectedException invalid(String detail) {
+        return new LhAnnouncementEnrichmentRejectedException(
+                LhAnnouncementEnrichmentFailureReason.INVALID_VALUE, detail
+        );
+    }
+}
+
+record LhAnnouncementEnrichmentData(
+        String panId,
+        String correctionReason,
+        ReceptionPlace receptionPlace,
+        List<LhScheduleData> schedules,
+        List<LhAttachmentData> attachments,
+        List<LhSupplyData> supplies
+) {
+}
+
+record LhScheduleData(
+        String sourceIdentifier,
+        ScheduleType type,
+        String name,
+        LocalDateTime startAt,
+        LocalDateTime endAt
+) {
+}
+
+record LhAttachmentData(String sourceIdentifier, String name, AttachmentType type, String url) {
+}
+
+record LhSupplyData(
+        String sourceIdentifier,
+        String complexName,
+        String housingTypeName,
+        YearMonth expectedMoveInMonth,
+        Integer totalHouseholdCount,
+        Integer supplyHouseholdCount,
+        BigDecimal rentalDeposit,
+        BigDecimal monthlyRent
+) {
+}
+
+class LhAnnouncementEnrichmentRejectedException extends RuntimeException {
+
+    private final LhAnnouncementEnrichmentFailureReason reason;
+
+    LhAnnouncementEnrichmentRejectedException(LhAnnouncementEnrichmentFailureReason reason, String detail) {
+        super(detail);
+        this.reason = reason;
+    }
+
+    LhAnnouncementEnrichmentFailureReason reason() {
+        return reason;
+    }
+}

--- a/backend/src/main/java/com/toadzip/backend/ingest/service/LhAnnouncementEnrichmentService.java
+++ b/backend/src/main/java/com/toadzip/backend/ingest/service/LhAnnouncementEnrichmentService.java
@@ -1,0 +1,221 @@
+package com.toadzip.backend.ingest.service;
+
+import com.toadzip.backend.announcement.domain.Announcement;
+import com.toadzip.backend.announcement.repository.AnnouncementRepository;
+import com.toadzip.backend.housing.domain.AgencyCode;
+import com.toadzip.backend.housing.domain.RentalType;
+import com.toadzip.backend.ingest.domain.LhAnnouncementDetailSource;
+import com.toadzip.backend.ingest.domain.LhAnnouncementEnrichmentFailure;
+import com.toadzip.backend.ingest.domain.LhAnnouncementEnrichmentFailureReason;
+import com.toadzip.backend.ingest.domain.LhAnnouncementSupplySource;
+import com.toadzip.backend.ingest.domain.MyHomeAnnouncementSource;
+import com.toadzip.backend.ingest.dto.LhAnnouncementEnrichmentFailureResponse;
+import com.toadzip.backend.ingest.dto.LhAnnouncementEnrichmentReport;
+import com.toadzip.backend.ingest.exception.exception.IngestAlreadyRunningException;
+import com.toadzip.backend.ingest.repository.LhAnnouncementDetailSourceRepository;
+import com.toadzip.backend.ingest.repository.LhAnnouncementEnrichmentExecutionLock;
+import com.toadzip.backend.ingest.repository.LhAnnouncementEnrichmentFailureRepository;
+import com.toadzip.backend.ingest.repository.LhAnnouncementEnrichmentFailureStore;
+import com.toadzip.backend.ingest.repository.LhAnnouncementSupplySourceRepository;
+import com.toadzip.backend.ingest.repository.MyHomeAnnouncementSourceRepository;
+import java.net.URI;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Slf4j
+@Service
+public class LhAnnouncementEnrichmentService {
+
+    private final MyHomeAnnouncementSourceRepository myHomeSourceRepository;
+    private final AnnouncementRepository announcementRepository;
+    private final LhAnnouncementDetailSourceRepository detailSourceRepository;
+    private final LhAnnouncementSupplySourceRepository supplySourceRepository;
+    private final LhAnnouncementEnrichmentFailureRepository failureRepository;
+    private final LhAnnouncementEnrichmentFailureStore failureStore;
+    private final LhAnnouncementEnrichmentExecutionLock executionLock;
+    private final LhAnnouncementEnrichmentMapper mapper;
+    private final LhAnnouncementEnrichmentWriter writer;
+    private final Clock clock;
+
+    public LhAnnouncementEnrichmentService(
+            MyHomeAnnouncementSourceRepository myHomeSourceRepository,
+            AnnouncementRepository announcementRepository,
+            LhAnnouncementDetailSourceRepository detailSourceRepository,
+            LhAnnouncementSupplySourceRepository supplySourceRepository,
+            LhAnnouncementEnrichmentFailureRepository failureRepository,
+            LhAnnouncementEnrichmentFailureStore failureStore,
+            LhAnnouncementEnrichmentExecutionLock executionLock,
+            LhAnnouncementEnrichmentMapper mapper,
+            LhAnnouncementEnrichmentWriter writer,
+            Clock clock
+    ) {
+        this.myHomeSourceRepository = myHomeSourceRepository;
+        this.announcementRepository = announcementRepository;
+        this.detailSourceRepository = detailSourceRepository;
+        this.supplySourceRepository = supplySourceRepository;
+        this.failureRepository = failureRepository;
+        this.failureStore = failureStore;
+        this.executionLock = executionLock;
+        this.mapper = mapper;
+        this.writer = writer;
+        this.clock = clock;
+    }
+
+    public LhAnnouncementEnrichmentReport enrichAll() {
+        return executionLock.tryRun(this::enrichAllUnlocked).orElseThrow(this::alreadyRunning);
+    }
+
+    private LhAnnouncementEnrichmentReport enrichAllUnlocked() {
+        Instant occurredAt = clock.instant();
+        List<LhAnnouncementEnrichmentFailure> failures = new ArrayList<>();
+        LhAnnouncementEnrichmentReport report = LhAnnouncementEnrichmentReport.empty();
+        for (MyHomeAnnouncementSource source : lhSourcesByAnnouncement().values()) {
+            report = report.plus(enrich(source, failures, occurredAt));
+        }
+        failureStore.replaceAll(failures);
+        return report;
+    }
+
+    private Map<String, MyHomeAnnouncementSource> lhSourcesByAnnouncement() {
+        Map<String, MyHomeAnnouncementSource> sources = new LinkedHashMap<>();
+        for (MyHomeAnnouncementSource source : myHomeSourceRepository.findAll()) {
+            if (!isLh(source) || blank(source.getPblancId())) {
+                continue;
+            }
+            sources.putIfAbsent(source.getPblancId().strip(), source);
+        }
+        return sources;
+    }
+
+    private LhAnnouncementEnrichmentReport enrich(
+            MyHomeAnnouncementSource source,
+            List<LhAnnouncementEnrichmentFailure> failures,
+            Instant occurredAt
+    ) {
+        Announcement announcement = announcementRepository
+                .findBySourceAnnouncementIdentifier(source.getPblancId())
+                .orElse(null);
+        if (announcement == null) {
+            return reject(source, null, LhAnnouncementEnrichmentFailureReason.ANNOUNCEMENT_NOT_FOUND,
+                    "마이홈 기준으로 생성된 LH 공고를 찾을 수 없습니다.", failures, occurredAt);
+        }
+        if (announcement.getProvider() != AgencyCode.LH) {
+            return LhAnnouncementEnrichmentReport.empty();
+        }
+        if (announcement.getSupplyType() == RentalType.ETC) {
+            return reject(source, null, LhAnnouncementEnrichmentFailureReason.UNSUPPORTED_SUPPLY_TYPE,
+                    "지원하지 않는 공급유형의 LH 공고입니다.", failures, occurredAt);
+        }
+        String panId = panIdOf(source);
+        if (panId == null) {
+            return reject(source, null, LhAnnouncementEnrichmentFailureReason.PAN_ID_NOT_FOUND,
+                    "마이홈 공고 URL에서 panId를 찾을 수 없습니다.", failures, occurredAt);
+        }
+        List<LhAnnouncementDetailSource> details = detailSourceRepository.findAllByPanIdOrderBySourceOrderAsc(panId);
+        if (details.isEmpty()) {
+            return reject(source, panId, LhAnnouncementEnrichmentFailureReason.LH_DETAIL_SOURCE_NOT_FOUND,
+                    "연결된 LH 공고 상세 원본이 없습니다.", failures, occurredAt);
+        }
+        List<LhAnnouncementSupplySource> supplies = supplySourceRepository.findAllByPanIdOrderBySourceOrderAsc(panId);
+        if (supplies.isEmpty()) {
+            return reject(source, panId, LhAnnouncementEnrichmentFailureReason.LH_SUPPLY_SOURCE_NOT_FOUND,
+                    "연결된 LH 공고 공급 원본이 없습니다.", failures, occurredAt);
+        }
+        try {
+            LhAnnouncementEnrichmentData data = mapper.map(panId, details, supplies);
+            LhAnnouncementEnrichmentWriteResult result = writer.write(announcement, data);
+            addSupplyFailures(source, panId, result.failures(), failures, occurredAt);
+            return result.report();
+        }
+        catch (LhAnnouncementEnrichmentRejectedException exception) {
+            return reject(source, panId, exception.reason(), exception.getMessage(), failures, occurredAt);
+        }
+    }
+
+    private void addSupplyFailures(
+            MyHomeAnnouncementSource source,
+            String panId,
+            List<LhSupplyMatchingFailureData> supplyFailures,
+            List<LhAnnouncementEnrichmentFailure> failures,
+            Instant occurredAt
+    ) {
+        for (LhSupplyMatchingFailureData failure : supplyFailures) {
+            failures.add(LhAnnouncementEnrichmentFailure.create(
+                    failure.source().sourceIdentifier(), source.getPblancId(), panId,
+                    failure.reason(), failure.detail(), occurredAt
+            ));
+        }
+    }
+
+    private LhAnnouncementEnrichmentReport reject(
+            MyHomeAnnouncementSource source,
+            String panId,
+            LhAnnouncementEnrichmentFailureReason reason,
+            String detail,
+            List<LhAnnouncementEnrichmentFailure> failures,
+            Instant occurredAt
+    ) {
+        failures.add(LhAnnouncementEnrichmentFailure.create(
+                source.getSourceKey(), source.getPblancId(), panId, reason, detail, occurredAt
+        ));
+        return LhAnnouncementEnrichmentReport.failed();
+    }
+
+    @Transactional(readOnly = true)
+    public List<LhAnnouncementEnrichmentFailureResponse> findFailures() {
+        return failureRepository.findAllByOrderBySourceKeyAsc().stream()
+                .map(LhAnnouncementEnrichmentFailureResponse::from)
+                .toList();
+    }
+
+    private boolean isLh(MyHomeAnnouncementSource source) {
+        String provider = source.getSuplyInsttNm();
+        return provider != null && (provider.startsWith("LH") || provider.equals("한국토지주택공사"));
+    }
+
+    private String panIdOf(MyHomeAnnouncementSource source) {
+        String panId = panIdFromUrl(source.getUrl(), source.getSourceKey());
+        if (panId != null) {
+            return panId;
+        }
+        panId = panIdFromUrl(source.getPcUrl(), source.getSourceKey());
+        if (panId != null) {
+            return panId;
+        }
+        return panIdFromUrl(source.getMobileUrl(), source.getSourceKey());
+    }
+
+    private String panIdFromUrl(String url, String sourceKey) {
+        if (blank(url)) {
+            return null;
+        }
+        try {
+            String panId = UriComponentsBuilder.fromUri(URI.create(url)).build().getQueryParams().getFirst("panId");
+            if (blank(panId)) {
+                return null;
+            }
+            return panId.strip();
+        }
+        catch (IllegalArgumentException exception) {
+            log.debug("LH 공고 URL을 해석할 수 없습니다: sourceKey={}", sourceKey);
+            return null;
+        }
+    }
+
+    private boolean blank(String value) {
+        return value == null || value.isBlank();
+    }
+
+    private IngestAlreadyRunningException alreadyRunning() {
+        log.warn("LH 공고 보강이 이미 실행 중이므로 중복 실행을 건너뜁니다.");
+        return new IngestAlreadyRunningException("LH 공고 보강이 이미 실행 중입니다.");
+    }
+}

--- a/backend/src/main/java/com/toadzip/backend/ingest/service/LhAnnouncementEnrichmentWriter.java
+++ b/backend/src/main/java/com/toadzip/backend/ingest/service/LhAnnouncementEnrichmentWriter.java
@@ -1,0 +1,317 @@
+package com.toadzip.backend.ingest.service;
+
+import com.toadzip.backend.announcement.domain.Announcement;
+import com.toadzip.backend.announcement.domain.AnnouncementAttachment;
+import com.toadzip.backend.announcement.domain.AnnouncementSchedule;
+import com.toadzip.backend.announcement.domain.ReceptionPlace;
+import com.toadzip.backend.announcement.domain.SupplyRow;
+import com.toadzip.backend.announcement.domain.SupplyTarget;
+import com.toadzip.backend.announcement.repository.AnnouncementAttachmentRepository;
+import com.toadzip.backend.announcement.repository.AnnouncementRepository;
+import com.toadzip.backend.announcement.repository.AnnouncementScheduleRepository;
+import com.toadzip.backend.announcement.repository.SupplyRowRepository;
+import com.toadzip.backend.announcement.repository.SupplyTargetRepository;
+import com.toadzip.backend.ingest.domain.LhAnnouncementEnrichmentFailureReason;
+import com.toadzip.backend.ingest.dto.LhAnnouncementEnrichmentReport;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class LhAnnouncementEnrichmentWriter {
+
+    private static final String ALL_TARGET = "전체";
+    private static final String ALL_RANK = "전체";
+
+    private final AnnouncementScheduleRepository scheduleRepository;
+    private final AnnouncementRepository announcementRepository;
+    private final AnnouncementAttachmentRepository attachmentRepository;
+    private final SupplyRowRepository supplyRowRepository;
+    private final SupplyTargetRepository supplyTargetRepository;
+
+    public LhAnnouncementEnrichmentWriter(
+            AnnouncementScheduleRepository scheduleRepository,
+            AnnouncementRepository announcementRepository,
+            AnnouncementAttachmentRepository attachmentRepository,
+            SupplyRowRepository supplyRowRepository,
+            SupplyTargetRepository supplyTargetRepository
+    ) {
+        this.scheduleRepository = scheduleRepository;
+        this.announcementRepository = announcementRepository;
+        this.attachmentRepository = attachmentRepository;
+        this.supplyRowRepository = supplyRowRepository;
+        this.supplyTargetRepository = supplyTargetRepository;
+    }
+
+    @Transactional
+    public LhAnnouncementEnrichmentWriteResult write(Announcement announcement, LhAnnouncementEnrichmentData data) {
+        Announcement managedAnnouncement = announcementRepository.save(announcement);
+        int updatedAnnouncements = managedAnnouncement.enrichFromLh(
+                data.panId(), valueOrCurrent(data.correctionReason(), managedAnnouncement.getCorrectionCancellationReason()),
+                receptionOrCurrent(data.receptionPlace(), managedAnnouncement.getReceptionPlace())
+        ) ? 1 : 0;
+        SchedulesWriteResult schedules = writeSchedules(managedAnnouncement, data);
+        AttachmentsWriteResult attachments = writeAttachments(managedAnnouncement, data);
+        SupplyWriteResult supplies = writeSupplies(managedAnnouncement, data);
+        return new LhAnnouncementEnrichmentWriteResult(
+                new LhAnnouncementEnrichmentReport(
+                        updatedAnnouncements, updatedAnnouncements == 0 ? 1 : 0,
+                        schedules.created(), schedules.updated(), attachments.created(), attachments.updated(),
+                        supplies.updatedRows(), supplies.createdTargets(), supplies.updatedTargets(), supplies.failures().size()
+                ),
+                supplies.failures()
+        );
+    }
+
+    private SchedulesWriteResult writeSchedules(Announcement announcement, LhAnnouncementEnrichmentData data) {
+        Map<String, AnnouncementSchedule> stored = schedulesBySource(announcement);
+        Set<String> retained = new HashSet<>();
+        int created = 0;
+        int updated = 0;
+        int order = 1;
+        for (LhScheduleData source : data.schedules()) {
+            retained.add(source.sourceIdentifier());
+            AnnouncementSchedule schedule = stored.get(source.sourceIdentifier());
+            if (schedule == null) {
+                scheduleRepository.save(AnnouncementSchedule.createFromSource(
+                        announcement, source.sourceIdentifier(), source.type(), source.name(),
+                        source.startAt(), source.endAt(), order++
+                ));
+                created++;
+                continue;
+            }
+            if (schedule.updateFromSource(source.type(), source.name(), source.startAt(), source.endAt(), order++)) {
+                updated++;
+            }
+        }
+        scheduleRepository.deleteAll(staleSchedules(announcement, retained, data.panId()));
+        return new SchedulesWriteResult(created, updated);
+    }
+
+    private AttachmentsWriteResult writeAttachments(Announcement announcement, LhAnnouncementEnrichmentData data) {
+        Map<String, AnnouncementAttachment> stored = attachmentsBySource(announcement);
+        Set<String> retained = new HashSet<>();
+        int created = 0;
+        int updated = 0;
+        int order = 1;
+        for (LhAttachmentData source : data.attachments()) {
+            retained.add(source.sourceIdentifier());
+            AnnouncementAttachment attachment = stored.get(source.sourceIdentifier());
+            if (attachment == null) {
+                attachmentRepository.save(AnnouncementAttachment.createFromSource(
+                        announcement, source.sourceIdentifier(), source.name(), source.type(), source.url(), order++
+                ));
+                created++;
+                continue;
+            }
+            if (attachment.updateFromSource(source.name(), source.type(), source.url(), order++)) {
+                updated++;
+            }
+        }
+        attachmentRepository.deleteAll(staleAttachments(announcement, retained, data.panId()));
+        return new AttachmentsWriteResult(created, updated);
+    }
+
+    private SupplyWriteResult writeSupplies(Announcement announcement, LhAnnouncementEnrichmentData data) {
+        List<SupplyRow> rows = supplyRowRepository.findAllByAnnouncement(announcement);
+        List<LhSupplyMatchingFailureData> failures = new ArrayList<>();
+        Set<String> retainedTargetIdentifiers = new HashSet<>();
+        int updatedRows = 0;
+        int createdTargets = 0;
+        int updatedTargets = 0;
+        for (LhSupplyData source : data.supplies()) {
+            SupplyMatchResult match = match(rows, source);
+            if (match.failure() != null) {
+                failures.add(match.failure());
+                continue;
+            }
+            SupplyRow row = match.row();
+            if (row.enrichFromLh(source.sourceIdentifier(), source.expectedMoveInMonth(), source.totalHouseholdCount())) {
+                updatedRows++;
+            }
+            SupplyTargetWriteResult target = writeTarget(row, source);
+            retainedTargetIdentifiers.add(target.sourceIdentifier());
+            createdTargets += target.created();
+            updatedTargets += target.updated();
+        }
+        deleteStaleTargets(rows, retainedTargetIdentifiers, data.panId());
+        return new SupplyWriteResult(updatedRows, createdTargets, updatedTargets, failures);
+    }
+
+    private SupplyTargetWriteResult writeTarget(SupplyRow row, LhSupplyData source) {
+        String identifier = source.sourceIdentifier() + ":TARGET";
+        if (source.rentalDeposit() == null || source.monthlyRent() == null) {
+            return new SupplyTargetWriteResult(identifier, 0, 0);
+        }
+        SupplyTarget stored = supplyTargetRepository.findAllBySupplyRow(row).stream()
+                .filter(target -> identifier.equals(target.getSourceSupplyTargetIdentifier()))
+                .findFirst()
+                .orElse(null);
+        if (stored == null) {
+            supplyTargetRepository.save(SupplyTarget.createFromSource(
+                    row, identifier, ALL_TARGET, ALL_RANK, source.supplyHouseholdCount(),
+                    source.rentalDeposit(), source.monthlyRent(), 1
+            ));
+            return new SupplyTargetWriteResult(identifier, 1, 0);
+        }
+        boolean updated = stored.updateFromSource(
+                ALL_TARGET, ALL_RANK, source.supplyHouseholdCount(), source.rentalDeposit(), source.monthlyRent(), 1
+        );
+        return new SupplyTargetWriteResult(identifier, 0, updated ? 1 : 0);
+    }
+
+    private SupplyMatchResult match(List<SupplyRow> rows, LhSupplyData source) {
+        for (SupplyRow row : rows) {
+            if (source.sourceIdentifier().equals(row.getLhSourceSupplyRowIdentifier())) {
+                return SupplyMatchResult.matched(row);
+            }
+        }
+        List<SupplyRow> complexMatches = rows.stream()
+                .filter(row -> same(row.getSourceComplexName(), source.complexName())
+                        || row.getHousingComplex() != null && same(row.getHousingComplex().getName(), source.complexName()))
+                .toList();
+        if (complexMatches.isEmpty()) {
+            return SupplyMatchResult.failure(source, LhAnnouncementEnrichmentFailureReason.COMPLEX_NOT_FOUND,
+                    "LH 공급 원본과 일치하는 기존 공급 단지가 없습니다.");
+        }
+        List<SupplyRow> typeMatches = complexMatches.stream()
+                .filter(row -> same(row.getSourceHousingTypeName(), source.housingTypeName())
+                        || row.getHousingType() != null && same(row.getHousingType().getName(), source.housingTypeName()))
+                .toList();
+        if (typeMatches.size() == 1) {
+            return SupplyMatchResult.matched(typeMatches.getFirst());
+        }
+        if (typeMatches.size() > 1) {
+            return SupplyMatchResult.failure(source, LhAnnouncementEnrichmentFailureReason.AMBIGUOUS_HOUSING_TYPE,
+                    "LH 공급 원본에 일치하는 주택형 공급행이 여러 개입니다.");
+        }
+        if (complexMatches.size() == 1) {
+            return SupplyMatchResult.matched(complexMatches.getFirst());
+        }
+        return SupplyMatchResult.failure(source, LhAnnouncementEnrichmentFailureReason.AMBIGUOUS_COMPLEX,
+                "LH 공급 원본에 일치하는 기존 공급 단지가 여러 개입니다.");
+    }
+
+    private Map<String, AnnouncementSchedule> schedulesBySource(Announcement announcement) {
+        Map<String, AnnouncementSchedule> schedules = new HashMap<>();
+        for (AnnouncementSchedule schedule : scheduleRepository.findAllByAnnouncement(announcement)) {
+            if (schedule.getSourceScheduleIdentifier() != null) {
+                schedules.put(schedule.getSourceScheduleIdentifier(), schedule);
+            }
+        }
+        return schedules;
+    }
+
+    private Map<String, AnnouncementAttachment> attachmentsBySource(Announcement announcement) {
+        Map<String, AnnouncementAttachment> attachments = new HashMap<>();
+        for (AnnouncementAttachment attachment : attachmentRepository.findAllByAnnouncement(announcement)) {
+            if (attachment.getSourceAttachmentIdentifier() != null) {
+                attachments.put(attachment.getSourceAttachmentIdentifier(), attachment);
+            }
+        }
+        return attachments;
+    }
+
+    private List<AnnouncementSchedule> staleSchedules(Announcement announcement, Set<String> retained, String panId) {
+        return scheduleRepository.findAllByAnnouncement(announcement).stream()
+                .filter(schedule -> lhSourceForPan(schedule.getSourceScheduleIdentifier(), panId))
+                .filter(schedule -> !retained.contains(schedule.getSourceScheduleIdentifier()))
+                .toList();
+    }
+
+    private List<AnnouncementAttachment> staleAttachments(Announcement announcement, Set<String> retained, String panId) {
+        return attachmentRepository.findAllByAnnouncement(announcement).stream()
+                .filter(attachment -> lhSourceForPan(attachment.getSourceAttachmentIdentifier(), panId))
+                .filter(attachment -> !retained.contains(attachment.getSourceAttachmentIdentifier()))
+                .toList();
+    }
+
+    private void deleteStaleTargets(List<SupplyRow> rows, Set<String> retained, String panId) {
+        for (SupplyRow row : rows) {
+            List<SupplyTarget> stale = supplyTargetRepository.findAllBySupplyRow(row).stream()
+                    .filter(target -> lhSourceForPan(target.getSourceSupplyTargetIdentifier(), panId))
+                    .filter(target -> !retained.contains(target.getSourceSupplyTargetIdentifier()))
+                    .toList();
+            supplyTargetRepository.deleteAll(stale);
+        }
+    }
+
+    private String valueOrCurrent(String value, String current) {
+        if (value == null) {
+            return current;
+        }
+        return value;
+    }
+
+    private ReceptionPlace receptionOrCurrent(ReceptionPlace value, ReceptionPlace current) {
+        if (value == null) {
+            return current;
+        }
+        return value;
+    }
+
+    private boolean lhSourceForPan(String identifier, String panId) {
+        return identifier != null && identifier.startsWith("LH:" + panId + ":");
+    }
+
+    private boolean same(String left, String right) {
+        return normalized(left).equals(normalized(right));
+    }
+
+    private String normalized(String value) {
+        if (value == null) {
+            return "";
+        }
+        return value.replaceAll("\\s+", "").replace("-", "").strip().toLowerCase();
+    }
+
+    private record SchedulesWriteResult(int created, int updated) {
+    }
+
+    private record AttachmentsWriteResult(int created, int updated) {
+    }
+
+    private record SupplyWriteResult(
+            int updatedRows,
+            int createdTargets,
+            int updatedTargets,
+            List<LhSupplyMatchingFailureData> failures
+    ) {
+    }
+
+    private record SupplyTargetWriteResult(String sourceIdentifier, int created, int updated) {
+    }
+
+    private record SupplyMatchResult(SupplyRow row, LhSupplyMatchingFailureData failure) {
+
+        static SupplyMatchResult matched(SupplyRow row) {
+            return new SupplyMatchResult(row, null);
+        }
+
+        static SupplyMatchResult failure(
+                LhSupplyData source,
+                LhAnnouncementEnrichmentFailureReason reason,
+                String detail
+        ) {
+            return new SupplyMatchResult(null, new LhSupplyMatchingFailureData(source, reason, detail));
+        }
+    }
+}
+
+record LhAnnouncementEnrichmentWriteResult(
+        LhAnnouncementEnrichmentReport report,
+        List<LhSupplyMatchingFailureData> failures
+) {
+}
+
+record LhSupplyMatchingFailureData(
+        LhSupplyData source,
+        LhAnnouncementEnrichmentFailureReason reason,
+        String detail
+) {
+}

--- a/backend/src/main/java/com/toadzip/backend/ingest/service/LhAnnouncementEnrichmentWriter.java
+++ b/backend/src/main/java/com/toadzip/backend/ingest/service/LhAnnouncementEnrichmentWriter.java
@@ -145,13 +145,16 @@ public class LhAnnouncementEnrichmentWriter {
 
     private SupplyTargetWriteResult writeTarget(SupplyRow row, LhSupplyData source) {
         String identifier = source.sourceIdentifier() + ":TARGET";
-        if (source.rentalDeposit() == null || source.monthlyRent() == null) {
-            return new SupplyTargetWriteResult(identifier, 0, 0);
-        }
         SupplyTarget stored = supplyTargetRepository.findAllBySupplyRow(row).stream()
                 .filter(target -> identifier.equals(target.getSourceSupplyTargetIdentifier()))
                 .findFirst()
                 .orElse(null);
+        if (source.rentalDeposit() == null || source.monthlyRent() == null) {
+            if (stored != null) {
+                supplyTargetRepository.delete(stored);
+            }
+            return new SupplyTargetWriteResult(identifier, 0, 0);
+        }
         if (stored == null) {
             supplyTargetRepository.save(SupplyTarget.createFromSource(
                     row, identifier, ALL_TARGET, ALL_RANK, source.supplyHouseholdCount(),

--- a/backend/src/main/java/com/toadzip/backend/ingest/service/LhAnnouncementEnrichmentWriter.java
+++ b/backend/src/main/java/com/toadzip/backend/ingest/service/LhAnnouncementEnrichmentWriter.java
@@ -191,7 +191,8 @@ public class LhAnnouncementEnrichmentWriter {
                     "LH 공급 원본에 일치하는 주택형 공급행이 여러 개입니다.");
         }
         if (complexMatches.size() == 1) {
-            return SupplyMatchResult.matched(complexMatches.getFirst());
+            return SupplyMatchResult.failure(source, LhAnnouncementEnrichmentFailureReason.HOUSING_TYPE_NOT_FOUND,
+                    "LH 공급 원본과 일치하는 기존 주택형 공급행이 없습니다.");
         }
         return SupplyMatchResult.failure(source, LhAnnouncementEnrichmentFailureReason.AMBIGUOUS_COMPLEX,
                 "LH 공급 원본에 일치하는 기존 공급 단지가 여러 개입니다.");

--- a/backend/src/main/java/com/toadzip/backend/ingest/service/LhAnnouncementEnrichmentWriter.java
+++ b/backend/src/main/java/com/toadzip/backend/ingest/service/LhAnnouncementEnrichmentWriter.java
@@ -167,21 +167,21 @@ public class LhAnnouncementEnrichmentWriter {
 
     private SupplyMatchResult match(List<SupplyRow> rows, LhSupplyData source) {
         for (SupplyRow row : rows) {
-            if (source.sourceIdentifier().equals(row.getLhSourceSupplyRowIdentifier())) {
+            if (source.sourceIdentifier().equals(row.getLhSourceSupplyRowIdentifier())
+                    && matchesComplex(row, source)
+                    && matchesHousingType(row, source)) {
                 return SupplyMatchResult.matched(row);
             }
         }
         List<SupplyRow> complexMatches = rows.stream()
-                .filter(row -> same(row.getSourceComplexName(), source.complexName())
-                        || row.getHousingComplex() != null && same(row.getHousingComplex().getName(), source.complexName()))
+                .filter(row -> matchesComplex(row, source))
                 .toList();
         if (complexMatches.isEmpty()) {
             return SupplyMatchResult.failure(source, LhAnnouncementEnrichmentFailureReason.COMPLEX_NOT_FOUND,
                     "LH 공급 원본과 일치하는 기존 공급 단지가 없습니다.");
         }
         List<SupplyRow> typeMatches = complexMatches.stream()
-                .filter(row -> same(row.getSourceHousingTypeName(), source.housingTypeName())
-                        || row.getHousingType() != null && same(row.getHousingType().getName(), source.housingTypeName()))
+                .filter(row -> matchesHousingType(row, source))
                 .toList();
         if (typeMatches.size() == 1) {
             return SupplyMatchResult.matched(typeMatches.getFirst());
@@ -196,6 +196,22 @@ public class LhAnnouncementEnrichmentWriter {
         }
         return SupplyMatchResult.failure(source, LhAnnouncementEnrichmentFailureReason.AMBIGUOUS_COMPLEX,
                 "LH 공급 원본에 일치하는 기존 공급 단지가 여러 개입니다.");
+    }
+
+    private boolean matchesComplex(SupplyRow row, LhSupplyData source) {
+        if (same(row.getSourceComplexName(), source.complexName())) {
+            return true;
+        }
+        return row.getHousingComplex() != null
+                && same(row.getHousingComplex().getName(), source.complexName());
+    }
+
+    private boolean matchesHousingType(SupplyRow row, LhSupplyData source) {
+        if (same(row.getSourceHousingTypeName(), source.housingTypeName())) {
+            return true;
+        }
+        return row.getHousingType() != null
+                && same(row.getHousingType().getName(), source.housingTypeName());
     }
 
     private Map<String, AnnouncementSchedule> schedulesBySource(Announcement announcement) {

--- a/backend/src/test/java/com/toadzip/backend/announcement/domain/AnnouncementJpaMappingTest.java
+++ b/backend/src/test/java/com/toadzip/backend/announcement/domain/AnnouncementJpaMappingTest.java
@@ -42,6 +42,7 @@ class AnnouncementJpaMappingTest {
                         "winnerAnnouncementDate",
                         "originalUrl",
                         "correctionCancellationReason",
+                        "lhPanId",
                         "viewCount",
                         "actualCompetitionRate",
                         "predictedCompetitionRate",
@@ -63,7 +64,8 @@ class AnnouncementJpaMappingTest {
                         "expectedMoveInMonth",
                         "supplyCategory",
                         "matchingFailureReason",
-                        "totalSupplyHouseholdCount"
+                        "totalSupplyHouseholdCount",
+                        "lhSourceSupplyRowIdentifier"
                 )
         );
         assertEntityAttributes(
@@ -79,16 +81,23 @@ class AnnouncementJpaMappingTest {
                         "monthlyRent",
                         "convertedDeposit",
                         "applicationCondition",
-                        "displayOrder"
+                        "displayOrder",
+                        "sourceSupplyTargetIdentifier"
                 )
         );
         assertEntityAttributes(
                 "AnnouncementSchedule",
-                Set.of("id", "announcement", "scheduleType", "name", "startAt", "endAt", "displayOrder")
+                Set.of(
+                        "id", "announcement", "scheduleType", "name", "startAt", "endAt", "displayOrder",
+                        "sourceScheduleIdentifier"
+                )
         );
         assertEntityAttributes(
                 "AnnouncementAttachment",
-                Set.of("id", "announcement", "fileName", "fileType", "fileUrl", "displayOrder")
+                Set.of(
+                        "id", "announcement", "fileName", "fileType", "fileUrl", "displayOrder",
+                        "sourceAttachmentIdentifier"
+                )
         );
         assertEmbeddableAttributes(
                 "ReceptionPlace",

--- a/backend/src/test/java/com/toadzip/backend/ingest/service/LhAnnouncementEnrichmentMapperTest.java
+++ b/backend/src/test/java/com/toadzip/backend/ingest/service/LhAnnouncementEnrichmentMapperTest.java
@@ -1,0 +1,69 @@
+package com.toadzip.backend.ingest.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.groups.Tuple.tuple;
+
+import com.toadzip.backend.ingest.domain.LhAnnouncementDetailSource;
+import com.toadzip.backend.ingest.domain.LhAnnouncementSupplySource;
+import com.toadzip.backend.ingest.domain.LhAnnouncementSupplySourceData;
+import java.time.YearMonth;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class LhAnnouncementEnrichmentMapperTest {
+
+    private static final String PAN_ID = "100";
+
+    private final LhAnnouncementEnrichmentMapper mapper = new LhAnnouncementEnrichmentMapper();
+
+    @Test
+    void 다단지_공고는_공급행의_단지에_해당하는_입주예정월을_매핑한다() {
+        List<LhAnnouncementDetailSource> details = List.of(
+                complexDetail(0, "동삼2", "202612"),
+                complexDetail(1, "청운3", "202703")
+        );
+        List<LhAnnouncementSupplySource> supplies = List.of(
+                supply(0, "동삼2", "46A"),
+                supply(1, "청운3", "59B")
+        );
+
+        LhAnnouncementEnrichmentData result = mapper.map(PAN_ID, details, supplies);
+
+        assertThat(result.supplies())
+                .extracting(LhSupplyData::complexName, LhSupplyData::expectedMoveInMonth)
+                .containsExactly(
+                        tuple("동삼2", YearMonth.of(2026, 12)),
+                        tuple("청운3", YearMonth.of(2027, 3))
+                );
+    }
+
+    @Test
+    void 다단지_공고에서_단지가_불일치하면_입주예정월을_매핑하지_않는다() {
+        List<LhAnnouncementDetailSource> details = List.of(
+                complexDetail(0, "동삼2", "202612"),
+                complexDetail(1, "청운3", "202703")
+        );
+
+        LhAnnouncementEnrichmentData result = mapper.map(
+                PAN_ID, details, List.of(supply(0, "매칭되지 않는 단지", "46A"))
+        );
+
+        assertThat(result.supplies()).singleElement()
+                .extracting(LhSupplyData::expectedMoveInMonth)
+                .isNull();
+    }
+
+    private LhAnnouncementDetailSource complexDetail(int order, String complexName, String expectedMoveInYearMonth) {
+        return new LhAnnouncementDetailSource(
+                order, PAN_ID, "COMPLEX", complexName, null, null, null, null, null,
+                expectedMoveInYearMonth, null, null, null, null, null, null, null, null, null,
+                null, null, null, null, null, null, null, null, null, null
+        );
+    }
+
+    private LhAnnouncementSupplySource supply(int order, String complexName, String housingTypeName) {
+        return new LhAnnouncementSupplySource(order, PAN_ID, new LhAnnouncementSupplySourceData(
+                complexName, housingTypeName, null, null, "100", "20", "10,000,000", "200,000"
+        ));
+    }
+}

--- a/backend/src/test/java/com/toadzip/backend/ingest/service/LhAnnouncementEnrichmentServiceTest.java
+++ b/backend/src/test/java/com/toadzip/backend/ingest/service/LhAnnouncementEnrichmentServiceTest.java
@@ -1,0 +1,273 @@
+package com.toadzip.backend.ingest.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.toadzip.backend.announcement.domain.Announcement;
+import com.toadzip.backend.announcement.domain.SupplyTarget;
+import com.toadzip.backend.announcement.repository.AnnouncementAttachmentRepository;
+import com.toadzip.backend.announcement.repository.AnnouncementRepository;
+import com.toadzip.backend.announcement.repository.AnnouncementScheduleRepository;
+import com.toadzip.backend.announcement.repository.SupplyRowRepository;
+import com.toadzip.backend.announcement.repository.SupplyTargetRepository;
+import com.toadzip.backend.housing.domain.Address;
+import com.toadzip.backend.housing.domain.HousingComplex;
+import com.toadzip.backend.housing.domain.HousingType;
+import com.toadzip.backend.housing.repository.HousingComplexRepository;
+import com.toadzip.backend.housing.repository.HousingTypeRepository;
+import com.toadzip.backend.ingest.domain.LhAnnouncementDetailSource;
+import com.toadzip.backend.ingest.domain.LhAnnouncementSupplySource;
+import com.toadzip.backend.ingest.domain.LhAnnouncementSupplySourceData;
+import com.toadzip.backend.ingest.domain.LhAnnouncementEnrichmentFailureReason;
+import com.toadzip.backend.ingest.domain.MyHomeAnnouncementSource;
+import com.toadzip.backend.ingest.domain.MyHomeAnnouncementSourceData;
+import com.toadzip.backend.ingest.repository.LhAnnouncementDetailSourceRepository;
+import com.toadzip.backend.ingest.repository.LhAnnouncementEnrichmentFailureRepository;
+import com.toadzip.backend.ingest.repository.LhAnnouncementSupplySourceRepository;
+import com.toadzip.backend.ingest.repository.MyHomeAnnouncementMappingFailureRepository;
+import com.toadzip.backend.ingest.repository.MyHomeAnnouncementSourceRepository;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class LhAnnouncementEnrichmentServiceTest {
+
+    private static final String PNU = "1111010100100010000";
+    private static final String PAN_ID = "100";
+
+    @Autowired
+    private MyHomeAnnouncementMappingService mappingService;
+
+    @Autowired
+    private LhAnnouncementEnrichmentService enrichmentService;
+
+    @Autowired
+    private MyHomeAnnouncementSourceRepository myHomeSourceRepository;
+
+    @Autowired
+    private MyHomeAnnouncementMappingFailureRepository mappingFailureRepository;
+
+    @Autowired
+    private LhAnnouncementDetailSourceRepository detailSourceRepository;
+
+    @Autowired
+    private LhAnnouncementSupplySourceRepository supplySourceRepository;
+
+    @Autowired
+    private LhAnnouncementEnrichmentFailureRepository enrichmentFailureRepository;
+
+    @Autowired
+    private AnnouncementRepository announcementRepository;
+
+    @Autowired
+    private AnnouncementScheduleRepository scheduleRepository;
+
+    @Autowired
+    private AnnouncementAttachmentRepository attachmentRepository;
+
+    @Autowired
+    private SupplyTargetRepository supplyTargetRepository;
+
+    @Autowired
+    private SupplyRowRepository supplyRowRepository;
+
+    @Autowired
+    private HousingTypeRepository housingTypeRepository;
+
+    @Autowired
+    private HousingComplexRepository housingComplexRepository;
+
+    @BeforeEach
+    void setUp() {
+        cleanUp();
+    }
+
+    @AfterEach
+    void tearDown() {
+        cleanUp();
+    }
+
+    private void cleanUp() {
+        supplyTargetRepository.deleteAll();
+        supplyRowRepository.deleteAll();
+        scheduleRepository.deleteAll();
+        attachmentRepository.deleteAll();
+        announcementRepository.deleteAll();
+        housingTypeRepository.deleteAll();
+        housingComplexRepository.deleteAll();
+        enrichmentFailureRepository.deleteAll();
+        detailSourceRepository.deleteAll();
+        supplySourceRepository.deleteAll();
+        mappingFailureRepository.deleteAll();
+        myHomeSourceRepository.deleteAll();
+    }
+
+    @Test
+    void 기존_LH_공고를_일정_첨부파일_접수처_공급정보로_보강하고_반복해도_중복하지_않는다() {
+        saveComplex();
+        myHomeSourceRepository.save(myHomeSource());
+        mappingService.mapAll();
+        saveLhSources("10,000,000", "200,000");
+
+        var first = enrichmentService.enrichAll();
+
+        assertThat(first.updatedAnnouncementCount()).isOne();
+        assertThat(first.createdScheduleCount()).isOne();
+        assertThat(first.createdAttachmentCount()).isOne();
+        assertThat(first.updatedSupplyRowCount()).isOne();
+        assertThat(first.createdSupplyTargetCount()).isOne();
+        assertThat(announcementRepository.findAll()).singleElement().satisfies(announcement -> {
+            assertThat(announcement.getLhPanId()).isEqualTo(PAN_ID);
+            assertThat(announcement.getCorrectionCancellationReason()).isEqualTo("정정 사유");
+            assertThat(announcement.getReceptionPlace().getContact()).isEqualTo("1600-1004");
+        });
+        assertThat(scheduleRepository.count()).isOne();
+        assertThat(attachmentRepository.count()).isOne();
+        assertThat(supplyTargetRepository.findAll()).singleElement().satisfies(target -> {
+            assertThat(target.getSupplyHouseholdCount()).isEqualTo(20);
+            assertThat(target.getRentalDeposit()).isEqualByComparingTo("10000000");
+            assertThat(target.getMonthlyRent()).isEqualByComparingTo("200000");
+        });
+
+        var repeated = enrichmentService.enrichAll();
+
+        assertThat(repeated.unchangedAnnouncementCount()).isOne();
+        assertThat(scheduleRepository.count()).isOne();
+        assertThat(attachmentRepository.count()).isOne();
+        assertThat(supplyTargetRepository.count()).isOne();
+        assertThat(announcementRepository.count()).isOne();
+
+        detailSourceRepository.deleteAll();
+        supplySourceRepository.deleteAll();
+        saveLhSources("12,000,000", "250,000");
+
+        var changed = enrichmentService.enrichAll();
+
+        assertThat(changed.updatedSupplyTargetCount()).isOne();
+        assertThat(supplyTargetRepository.findAll()).singleElement().satisfies(target -> {
+            assertThat(target.getRentalDeposit()).isEqualByComparingTo("12000000");
+            assertThat(target.getMonthlyRent()).isEqualByComparingTo("250000");
+        });
+    }
+
+    @Test
+    void 마이홈_URL에_panId가_없으면_공고를_새로_생성하지_않고_실패를_기록한다() {
+        saveComplex();
+        MyHomeAnnouncementSource source = myHomeSource();
+        source.replaceWith(new MyHomeAnnouncementSourceData(
+                "21026", 1, "모집중", "국민임대 입주자 모집공고", "LH서울", "아파트", "국민임대", null,
+                "20260813", "20261106", "20260824", "20260831", "1600-1004",
+                "https://example.com/announcements", null, null, "동삼2", "서울특별시", "종로구",
+                "서울특별시 종로구 테스트로 1", "테스트로", "테스트동", PNU, "지역난방", "100", 20,
+                10_000_000L, 2_000_000L, 8_000_000L, 200_000L
+        ));
+        myHomeSourceRepository.save(source);
+        mappingService.mapAll();
+
+        var report = enrichmentService.enrichAll();
+
+        assertThat(report.failedSourceCount()).isOne();
+        assertThat(announcementRepository.count()).isOne();
+        assertThat(enrichmentFailureRepository.findAll()).singleElement()
+                .extracting(failure -> failure.getReason())
+                .isEqualTo(LhAnnouncementEnrichmentFailureReason.PAN_ID_NOT_FOUND);
+    }
+
+    @Test
+    void 공고문_참조로_표시된_임대료는_추정하지_않고_공급행만_보강한다() {
+        saveComplex();
+        myHomeSourceRepository.save(myHomeSource());
+        mappingService.mapAll();
+        saveLhSources("공고문 참조", "공고문 참조");
+
+        var report = enrichmentService.enrichAll();
+
+        assertThat(report.failedSourceCount()).isZero();
+        assertThat(report.createdSupplyTargetCount()).isZero();
+        assertThat(supplyTargetRepository.count()).isZero();
+    }
+
+    @Test
+    void 긴_접수_안내문은_접수처명으로_저장하지_않고_기본명을_사용한다() {
+        saveComplex();
+        myHomeSourceRepository.save(myHomeSource());
+        mappingService.mapAll();
+        saveLhSources("10,000,000", "200,000", "안내".repeat(200));
+
+        var report = enrichmentService.enrichAll();
+
+        assertThat(report.failedSourceCount()).isZero();
+        assertThat(announcementRepository.findAll()).singleElement().satisfies(announcement ->
+                assertThat(announcement.getReceptionPlace().getName()).isEqualTo("LH 접수처")
+        );
+    }
+
+    private void saveComplex() {
+        Address address = Address.create(
+                "서울특별시 종로구 테스트로 1", PNU, PNU.substring(0, 10), "11", "11110",
+                new BigDecimal("37.566206"), new BigDecimal("126.977706")
+        );
+        HousingComplex complex = housingComplexRepository.save(HousingComplex.createFromMyHome(
+                "동삼2", "123:NATIONAL_RENTAL", "NATIONAL_RENTAL", address, 100, "LH", null,
+                "DISTRICT", "APARTMENT", "CORRIDOR", true, 80
+        ));
+        housingTypeRepository.save(HousingType.createFromMyHome(
+                complex, "source-housing-type-id", "46A", new BigDecimal("46.8000"), new BigDecimal("67.0000")
+        ));
+    }
+
+    private MyHomeAnnouncementSource myHomeSource() {
+        MyHomeAnnouncementSource source = MyHomeAnnouncementSource.from(0, new MyHomeAnnouncementSourceData(
+                "21026", 1, "모집중", "국민임대 입주자 모집공고", "LH서울", "아파트", "국민임대", null,
+                "20260813", "20261106", "20260824", "20260831", "1600-1004",
+                "https://example.com/announcements?panId=" + PAN_ID, null, null, "동삼2", "서울특별시", "종로구",
+                "서울특별시 종로구 테스트로 1", "테스트로", "테스트동", PNU, "지역난방", "100", 20,
+                10_000_000L, 2_000_000L, 8_000_000L, 200_000L
+        ));
+        source.markCollectedAt(Instant.parse("2026-08-28T00:00:00Z"));
+        return source;
+    }
+
+    private void saveLhSources(String deposit, String rent) {
+        saveLhSources(deposit, rent, "LH 현장접수처");
+    }
+
+    private void saveLhSources(String deposit, String rent, String receptionGuidance) {
+        detailSourceRepository.saveAll(List.of(
+                detail(0, "ETC_INFO", null, null, null, null, null, null, null, "정정 사유"),
+                detail(1, "SCHEDULE", "2026.08.24 10:00 ~ 2026.08.31 17:00", null, null, null, null, null, null, null),
+                detail(2, "RECEPTION", null, "서울특별시 종로구 접수로 1", "101호", "1600-1004", receptionGuidance, null, null, null),
+                detail(3, "ANNOUNCEMENT_FILE", null, null, null, null, null, "공고문.pdf", "https://example.com/file.pdf", null),
+                detail(4, "COMPLEX", null, null, null, null, null, null, null, null)
+        ));
+        supplySourceRepository.save(new LhAnnouncementSupplySource(0, PAN_ID,
+                new LhAnnouncementSupplySourceData("동삼2", "46A", "46.8", "67.0", "100", "20", deposit, rent)));
+    }
+
+    private LhAnnouncementDetailSource detail(
+            int order,
+            String datasetType,
+            String applicationPeriod,
+            String address,
+            String detailAddress,
+            String phone,
+            String guidance,
+            String name,
+            String url,
+            String correctionReason
+    ) {
+        return new LhAnnouncementDetailSource(
+                order, PAN_ID, datasetType, null, address, detailAddress, null, null, null,
+                datasetType.equals("COMPLEX") ? "202612" : null, guidance, applicationPeriod, null, null, null,
+                null, null, address, detailAddress, null, null, phone, guidance, null, name, url, null,
+                correctionReason, null
+        );
+    }
+}

--- a/backend/src/test/java/com/toadzip/backend/ingest/service/LhAnnouncementEnrichmentServiceTest.java
+++ b/backend/src/test/java/com/toadzip/backend/ingest/service/LhAnnouncementEnrichmentServiceTest.java
@@ -209,6 +209,25 @@ class LhAnnouncementEnrichmentServiceTest {
         );
     }
 
+    @Test
+    void 단지만_일치하고_주택형이_다르면_공급행을_보강하지_않고_실패를_기록한다() {
+        saveComplex();
+        myHomeSourceRepository.save(myHomeSource());
+        mappingService.mapAll();
+        saveLhSources("10,000,000", "200,000", "LH 현장접수처", "99Z");
+
+        var report = enrichmentService.enrichAll();
+
+        assertThat(report.failedSourceCount()).isOne();
+        assertThat(supplyRowRepository.findAll()).singleElement().satisfies(row ->
+                assertThat(row.getLhSourceSupplyRowIdentifier()).isNull()
+        );
+        assertThat(supplyTargetRepository.count()).isZero();
+        assertThat(enrichmentFailureRepository.findAll()).singleElement()
+                .extracting(failure -> failure.getReason())
+                .isEqualTo(LhAnnouncementEnrichmentFailureReason.HOUSING_TYPE_NOT_FOUND);
+    }
+
     private void saveComplex() {
         Address address = Address.create(
                 "서울특별시 종로구 테스트로 1", PNU, PNU.substring(0, 10), "11", "11110",
@@ -240,6 +259,10 @@ class LhAnnouncementEnrichmentServiceTest {
     }
 
     private void saveLhSources(String deposit, String rent, String receptionGuidance) {
+        saveLhSources(deposit, rent, receptionGuidance, "46A");
+    }
+
+    private void saveLhSources(String deposit, String rent, String receptionGuidance, String housingTypeName) {
         detailSourceRepository.saveAll(List.of(
                 detail(0, "ETC_INFO", null, null, null, null, null, null, null, "정정 사유"),
                 detail(1, "SCHEDULE", "2026.08.24 10:00 ~ 2026.08.31 17:00", null, null, null, null, null, null, null),
@@ -248,7 +271,9 @@ class LhAnnouncementEnrichmentServiceTest {
                 detail(4, "COMPLEX", null, null, null, null, null, null, null, null)
         ));
         supplySourceRepository.save(new LhAnnouncementSupplySource(0, PAN_ID,
-                new LhAnnouncementSupplySourceData("동삼2", "46A", "46.8", "67.0", "100", "20", deposit, rent)));
+                new LhAnnouncementSupplySourceData(
+                        "동삼2", housingTypeName, "46.8", "67.0", "100", "20", deposit, rent
+                )));
     }
 
     private LhAnnouncementDetailSource detail(

--- a/backend/src/test/java/com/toadzip/backend/ingest/service/LhAnnouncementEnrichmentServiceTest.java
+++ b/backend/src/test/java/com/toadzip/backend/ingest/service/LhAnnouncementEnrichmentServiceTest.java
@@ -196,6 +196,26 @@ class LhAnnouncementEnrichmentServiceTest {
     }
 
     @Test
+    void 저장했던_임대료가_공고문_참조로_바뀌면_기존_공급대상을_삭제한다() {
+        saveComplex();
+        myHomeSourceRepository.save(myHomeSource());
+        mappingService.mapAll();
+        saveLhSources("10,000,000", "200,000");
+        enrichmentService.enrichAll();
+        assertThat(supplyTargetRepository.count()).isOne();
+
+        supplySourceRepository.deleteAll();
+        supplySourceRepository.save(new LhAnnouncementSupplySource(0, PAN_ID,
+                new LhAnnouncementSupplySourceData(
+                        "동삼2", "46A", "46.8", "67.0", "100", "20", "공고문 참조", "공고문 참조"
+                )));
+
+        enrichmentService.enrichAll();
+
+        assertThat(supplyTargetRepository.count()).isZero();
+    }
+
+    @Test
     void 긴_접수_안내문은_접수처명으로_저장하지_않고_기본명을_사용한다() {
         saveComplex();
         myHomeSourceRepository.save(myHomeSource());

--- a/backend/src/test/java/com/toadzip/backend/ingest/service/LhAnnouncementEnrichmentServiceTest.java
+++ b/backend/src/test/java/com/toadzip/backend/ingest/service/LhAnnouncementEnrichmentServiceTest.java
@@ -3,6 +3,7 @@ package com.toadzip.backend.ingest.service;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.toadzip.backend.announcement.domain.Announcement;
+import com.toadzip.backend.announcement.domain.SupplyRow;
 import com.toadzip.backend.announcement.domain.SupplyTarget;
 import com.toadzip.backend.announcement.repository.AnnouncementAttachmentRepository;
 import com.toadzip.backend.announcement.repository.AnnouncementRepository;
@@ -226,6 +227,63 @@ class LhAnnouncementEnrichmentServiceTest {
         assertThat(enrichmentFailureRepository.findAll()).singleElement()
                 .extracting(failure -> failure.getReason())
                 .isEqualTo(LhAnnouncementEnrichmentFailureReason.HOUSING_TYPE_NOT_FOUND);
+    }
+
+    @Test
+    void LH_공급행_순서가_바뀌어도_주택형을_다시_확인해_올바른_공급행을_보강한다() {
+        saveComplex();
+        HousingComplex complex = housingComplexRepository.findAll().getFirst();
+        HousingType secondType = housingTypeRepository.save(HousingType.createFromMyHome(
+                complex, "source-housing-type-id-59B", "59B", new BigDecimal("59.8000"), new BigDecimal("84.0000")
+        ));
+        myHomeSourceRepository.save(myHomeSource());
+        mappingService.mapAll();
+        Announcement announcement = announcementRepository.findAll().getFirst();
+        SupplyRow mappedRow = supplyRowRepository.findAll().getFirst();
+        HousingType firstType = housingTypeRepository.findAll().stream()
+                .filter(type -> type.getName().equals("46A"))
+                .findFirst()
+                .orElseThrow();
+        supplyRowRepository.deleteAll();
+        supplyRowRepository.saveAll(List.of(
+                SupplyRow.create(
+                        announcement, complex, firstType, "manual-46A", 1, "동삼2", "46A", PNU,
+                        null, mappedRow.getSupplyCategory(), null, null
+                ),
+                SupplyRow.create(
+                        announcement, complex, secondType, "manual-59B", 2, "동삼2", "59B", PNU,
+                        null, mappedRow.getSupplyCategory(), null, null
+                )
+        ));
+        saveLhSources("10,000,000", "200,000");
+        supplySourceRepository.save(new LhAnnouncementSupplySource(1, PAN_ID,
+                new LhAnnouncementSupplySourceData(
+                        "동삼2", "59B", "59.8", "84.0", "80", "10", "20,000,000", "300,000"
+                )));
+        enrichmentService.enrichAll();
+
+        supplySourceRepository.deleteAll();
+        supplySourceRepository.saveAll(List.of(
+                new LhAnnouncementSupplySource(0, PAN_ID, new LhAnnouncementSupplySourceData(
+                        "동삼2", "59B", "59.8", "84.0", "80", "10", "21,000,000", "310,000"
+                )),
+                new LhAnnouncementSupplySource(1, PAN_ID, new LhAnnouncementSupplySourceData(
+                        "동삼2", "46A", "46.8", "67.0", "100", "20", "11,000,000", "210,000"
+                ))
+        ));
+
+        enrichmentService.enrichAll();
+
+        assertThat(supplyRowRepository.findAll())
+                .filteredOn(row -> row.getSourceHousingTypeName().equals("46A"))
+                .singleElement()
+                .extracting(SupplyRow::getLhSourceSupplyRowIdentifier)
+                .isEqualTo("LH:" + PAN_ID + ":SUPPLY:1");
+        assertThat(supplyRowRepository.findAll())
+                .filteredOn(row -> row.getSourceHousingTypeName().equals("59B"))
+                .singleElement()
+                .extracting(SupplyRow::getLhSourceSupplyRowIdentifier)
+                .isEqualTo("LH:" + PAN_ID + ":SUPPLY:0");
     }
 
     private void saveComplex() {


### PR DESCRIPTION
## 관련 이슈

Closes #19

선행 작업: #13, #14, #17, #18

## 작업 목적

- 수집한 LH 공고 상세·공급 원본을 마이홈 기준으로 생성된 기존 LH 공고에 연결한다.
- 마이홈 공고에 없는 일정·접수처·첨부파일·공급 정보를 LH 원본으로 보강한다.
- 연결하거나 매칭하지 못한 원본을 누락시키지 않고 실패 사유와 함께 보존한다.

## 작업 내역

- 마이홈 공고 중 공급기관이 LH인 공고를 보강 대상으로 선정
- 마이홈 공고 URL의 `panId`를 이용해 LH 상세·공급 원본 연결
- 기존 공고에 다음 정보 보강
  - 공고 일정
  - 접수처
  - 첨부파일
  - 정정·취소 사유
- 기존 공급행에 다음 정보 보강
  - LH 공급 원본 식별자
  - 입주 예정월
  - 전체·공급 세대수
  - 임대보증금과 월 임대료

- 단지만 일치하고 주택형이 다른 경우 잘못된 공급행에 연결하지 않고
  `HOUSING_TYPE_NOT_FOUND`로 기록하도록 보완

## 리뷰 포인트

- LH 원본으로 별도 공고를 생성하지 않고 기존 마이홈 공고만 갱신한다.
- 공급행 매칭은 기존 LH 원본 식별자를 우선 사용하고, 없으면 단지명과 주택형명을 함께 비교한다.
- 단지만 일치한다는 이유로 다른 주택형 공급행에 연결하지 않는다.
- 파싱하거나 매칭하지 못한 값은 추정하지 않고 실패 데이터로 보존한다.
- 현재 개발 데이터의 `COMPLEX_NOT_FOUND` 공급 원본은 삭제하지 않아 추후 매칭 기준 개선 후 재처리할 수 있다.

## 검증 결과

- 테스트 방법:
  - `./gradlew test --tests com.toadzip.backend.ingest.service.LhAnnouncementEnrichmentServiceTest`
  - `./gradlew --rerun-tasks check`
  - `git diff --check`
  - 로컬 개발 DB에서 보강 API 실행 후 동일 원본 즉시 재실행

- 테스트 결과:
  - LH 보강 서비스 정상·중복·갱신·실패 테스트 5개 통과
  - 전체 백엔드 검사 통과
  - 첫 실행에서 기존 공고 63건과 공급행 61건 갱신
  - 재실행 결과 갱신 0건, 변경 없음 64건
  - 공고별 일정·첨부파일·공급행 중복 0건
  - 연결 실패 원본과 실패 사유가 DB에 보존되는 것을 확인