### PR TITLE
feat(logging): 공통 HTTP 요청 로깅 추가 (#83)

### DIFF
--- a/backend/src/main/java/com/toadzip/backend/announcement/controller/AnnouncementExceptionAdvice.java
+++ b/backend/src/main/java/com/toadzip/backend/announcement/controller/AnnouncementExceptionAdvice.java
@@ -5,8 +5,8 @@ import com.toadzip.backend.announcement.exception.InvalidAnnouncementCursorExcep
 import com.toadzip.backend.announcement.exception.InvalidAnnouncementRequestException;
 import com.toadzip.backend.announcement.exception.InvalidRegionCodeException;
 import com.toadzip.backend.global.exception.ErrorResponse;
+import com.toadzip.backend.global.exception.RequestTraceIdResolver;
 import jakarta.servlet.http.HttpServletRequest;
-import java.util.UUID;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
@@ -62,10 +62,6 @@ public class AnnouncementExceptionAdvice {
     }
 
     private String traceIdOf(HttpServletRequest request) {
-        String requestId = request.getRequestId();
-        if (requestId == null || requestId.isBlank()) {
-            return UUID.randomUUID().toString();
-        }
-        return requestId;
+        return RequestTraceIdResolver.resolve(request);
     }
 }

--- a/backend/src/main/java/com/toadzip/backend/global/exception/GlobalExceptionAdvice.java
+++ b/backend/src/main/java/com/toadzip/backend/global/exception/GlobalExceptionAdvice.java
@@ -146,13 +146,7 @@ public class GlobalExceptionAdvice {
             HttpServletRequest request
     ) {
         String traceId = RequestTraceIdResolver.resolve(request);
-        LOGGER.error(
-                "Unexpected server error: traceId={}, method={}, path={}",
-                traceId,
-                request.getMethod(),
-                request.getRequestURI(),
-                exception
-        );
+        logUnexpectedException(exception, request);
         ErrorResponse errorResponse = new ErrorResponse(
                 INTERNAL_SERVER_ERROR,
                 "서버 내부 오류가 발생했습니다.",
@@ -165,6 +159,7 @@ public class GlobalExceptionAdvice {
             List<ValidationError> errors,
             HttpServletRequest request
     ) {
+        logExpectedException(HttpStatus.BAD_REQUEST, VALIDATION_FAILED, request);
         ErrorResponse errorResponse = new ErrorResponse(
                 VALIDATION_FAILED,
                 "요청값이 올바르지 않습니다.",
@@ -180,8 +175,30 @@ public class GlobalExceptionAdvice {
             String message,
             HttpServletRequest request
     ) {
+        logExpectedException(status, code, request);
         ErrorResponse errorResponse = new ErrorResponse(code, message, RequestTraceIdResolver.resolve(request));
         return ResponseEntity.status(status).body(errorResponse);
+    }
+
+    private void logExpectedException(HttpStatus status, String code, HttpServletRequest request) {
+        LOGGER.warn(
+                "event=http.request.rejected result=failure errorCode={} method={} uri={} status={}",
+                code,
+                request.getMethod(),
+                request.getRequestURI(),
+                status.value()
+        );
+    }
+
+    private void logUnexpectedException(Exception exception, HttpServletRequest request) {
+        LOGGER.error(
+                "event=http.request.failed result=failure errorCode={} method={} uri={} status={}",
+                INTERNAL_SERVER_ERROR,
+                request.getMethod(),
+                request.getRequestURI(),
+                HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                exception
+        );
     }
 
     private ValidationError validationErrorOf(FieldError error) {

--- a/backend/src/main/java/com/toadzip/backend/global/exception/RequestTraceIdResolver.java
+++ b/backend/src/main/java/com/toadzip/backend/global/exception/RequestTraceIdResolver.java
@@ -5,14 +5,26 @@ import java.util.UUID;
 
 public final class RequestTraceIdResolver {
 
+    private static final String TRACE_ID_ATTRIBUTE = RequestTraceIdResolver.class.getName() + ".traceId";
+
     private RequestTraceIdResolver() {
     }
 
     public static String resolve(HttpServletRequest request) {
-        String requestId = request.getRequestId();
-        if (requestId == null || requestId.isBlank()) {
-            return UUID.randomUUID().toString();
+        Object savedTraceId = request.getAttribute(TRACE_ID_ATTRIBUTE);
+        if (savedTraceId instanceof String traceId && !traceId.isBlank()) {
+            return traceId;
         }
-        return requestId;
+        String traceId = createTraceId(request);
+        request.setAttribute(TRACE_ID_ATTRIBUTE, traceId);
+        return traceId;
+    }
+
+    private static String createTraceId(HttpServletRequest request) {
+        String requestId = request.getRequestId();
+        if (requestId != null && !requestId.isBlank()) {
+            return requestId;
+        }
+        return UUID.randomUUID().toString();
     }
 }

--- a/backend/src/main/java/com/toadzip/backend/global/logging/HttpRequestLoggingFilter.java
+++ b/backend/src/main/java/com/toadzip/backend/global/logging/HttpRequestLoggingFilter.java
@@ -1,0 +1,60 @@
+package com.toadzip.backend.global.logging;
+
+import com.toadzip.backend.global.exception.RequestTraceIdResolver;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public final class HttpRequestLoggingFilter extends OncePerRequestFilter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(HttpRequestLoggingFilter.class);
+
+    private static final String TRACE_ID = "traceId";
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        String traceId = RequestTraceIdResolver.resolve(request);
+        long startedAt = System.nanoTime();
+        MDC.put(TRACE_ID, traceId);
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            completeRequest(request, response, startedAt);
+        }
+    }
+
+    private void completeRequest(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            long startedAt
+    ) {
+        try {
+            long durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startedAt);
+            LOGGER.info(
+                    "event=http.request.completed method={} uri={} status={} durationMs={}",
+                    request.getMethod(),
+                    request.getRequestURI(),
+                    response.getStatus(),
+                    durationMs
+            );
+        } finally {
+            MDC.remove(TRACE_ID);
+        }
+    }
+}

--- a/backend/src/main/java/com/toadzip/backend/housing/controller/HousingComplexExceptionAdvice.java
+++ b/backend/src/main/java/com/toadzip/backend/housing/controller/HousingComplexExceptionAdvice.java
@@ -1,7 +1,6 @@
 package com.toadzip.backend.housing.controller;
 
 import jakarta.servlet.http.HttpServletRequest;
-import java.util.UUID;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
@@ -10,6 +9,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import com.toadzip.backend.global.exception.ErrorResponse;
+import com.toadzip.backend.global.exception.RequestTraceIdResolver;
 import com.toadzip.backend.housing.exception.AdminHousingComplexNotFoundException;
 import com.toadzip.backend.housing.exception.HousingComplexNotFoundException;
 import com.toadzip.backend.housing.exception.InvalidComplexCursorException;
@@ -92,10 +92,6 @@ public class HousingComplexExceptionAdvice {
     }
 
     private String traceIdOf(HttpServletRequest request) {
-        String requestId = request.getRequestId();
-        if (requestId == null || requestId.isBlank()) {
-            return UUID.randomUUID().toString();
-        }
-        return requestId;
+        return RequestTraceIdResolver.resolve(request);
     }
 }

--- a/backend/src/main/java/com/toadzip/backend/ingest/exception/controller/IngestExceptionAdvice.java
+++ b/backend/src/main/java/com/toadzip/backend/ingest/exception/controller/IngestExceptionAdvice.java
@@ -1,7 +1,6 @@
 package com.toadzip.backend.ingest.exception.controller;
 
 import jakarta.servlet.http.HttpServletRequest;
-import java.util.UUID;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
@@ -10,6 +9,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import com.toadzip.backend.global.exception.ErrorResponse;
+import com.toadzip.backend.global.exception.RequestTraceIdResolver;
 import com.toadzip.backend.ingest.exception.exception.IngestAlreadyRunningException;
 import com.toadzip.backend.ingest.exception.exception.InvalidIngestRequestException;
 
@@ -48,10 +48,6 @@ public class IngestExceptionAdvice {
     }
 
     private String traceIdOf(HttpServletRequest request) {
-        String requestId = request.getRequestId();
-        if (requestId == null || requestId.isBlank()) {
-            return UUID.randomUUID().toString();
-        }
-        return requestId;
+        return RequestTraceIdResolver.resolve(request);
     }
 }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,4 +1,5 @@
 spring.application.name=backend
+logging.pattern.correlation=[traceId=%X{traceId:-}]\u0020
 ingest.service-key=${DATA_GO_KR_SERVICE_KEY:}
 ingest.base-url.myhome-complex=https://apis.data.go.kr/1613000/HWSPR04
 ingest.base-url.myhome-announcement=https://apis.data.go.kr/1613000/HWSPR02

--- a/backend/src/test/java/com/toadzip/backend/announcement/controller/AnnouncementExceptionAdviceTest.java
+++ b/backend/src/test/java/com/toadzip/backend/announcement/controller/AnnouncementExceptionAdviceTest.java
@@ -1,0 +1,24 @@
+package com.toadzip.backend.announcement.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.toadzip.backend.global.exception.RequestTraceIdResolver;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+class AnnouncementExceptionAdviceTest {
+
+    private final AnnouncementExceptionAdvice advice = new AnnouncementExceptionAdvice();
+
+    @Test
+    void 공통_요청_추적_식별자를_오류_응답에_사용한다() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        String traceId = RequestTraceIdResolver.resolve(request);
+
+        var response = advice.handleInvalidRequest(request);
+
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().code()).isEqualTo("INVALID_REQUEST");
+        assertThat(response.getBody().traceId()).isEqualTo(traceId);
+    }
+}

--- a/backend/src/test/java/com/toadzip/backend/global/exception/GlobalExceptionAdviceTest.java
+++ b/backend/src/test/java/com/toadzip/backend/global/exception/GlobalExceptionAdviceTest.java
@@ -1,5 +1,6 @@
 package com.toadzip.backend.global.exception;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.matchesPattern;
 import static org.hamcrest.Matchers.not;
@@ -10,9 +11,16 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
@@ -35,6 +43,23 @@ class GlobalExceptionAdviceTest {
 
     @Autowired
     private MockMvc mockMvc;
+
+    private Logger logger;
+    private ListAppender<ILoggingEvent> appender;
+
+    @BeforeEach
+    void attachLogAppender() {
+        logger = (Logger) LoggerFactory.getLogger(GlobalExceptionAdvice.class);
+        appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+    }
+
+    @AfterEach
+    void detachLogAppender() {
+        logger.detachAppender(appender);
+        appender.stop();
+    }
 
     @Test
     void DTO의_모든_필드_검증_실패를_오류_목록으로_반환한다() throws Exception {
@@ -134,6 +159,46 @@ class GlobalExceptionAdviceTest {
                 .andExpect(jsonPath("$.message").value("서버 내부 오류가 발생했습니다."))
                 .andExpect(jsonPath("$.traceId").isNotEmpty())
                 .andExpect(content().string(not(containsString("database password"))));
+    }
+
+    @Test
+    void 예상한_요청_예외는_오류코드와_함께_WARN으로_기록한다() throws Exception {
+        mockMvc.perform(post("/test/errors")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{invalid"))
+                .andExpect(status().isBadRequest());
+
+        assertThat(appender.list).singleElement().satisfies(event -> {
+            assertThat(event.getLevel()).isEqualTo(Level.WARN);
+            assertThat(event.getFormattedMessage())
+                    .contains("event=http.request.rejected")
+                    .contains("result=failure")
+                    .contains("errorCode=INVALID_REQUEST")
+                    .contains("method=POST")
+                    .contains("uri=/test/errors")
+                    .contains("status=400");
+            assertThat(event.getThrowableProxy()).isNull();
+        });
+    }
+
+    @Test
+    void 예상하지_못한_예외는_오류코드와_스택트레이스를_ERROR로_기록한다() throws Exception {
+        mockMvc.perform(get("/test/errors/unexpected"))
+                .andExpect(status().isInternalServerError());
+
+        assertThat(appender.list).singleElement().satisfies(event -> {
+            assertThat(event.getLevel()).isEqualTo(Level.ERROR);
+            assertThat(event.getFormattedMessage())
+                    .contains("event=http.request.failed")
+                    .contains("result=failure")
+                    .contains("errorCode=INTERNAL_SERVER_ERROR")
+                    .contains("method=GET")
+                    .contains("uri=/test/errors/unexpected")
+                    .contains("status=500");
+            assertThat(event.getThrowableProxy()).isNotNull();
+            assertThat(event.getThrowableProxy().getClassName())
+                    .isEqualTo(IllegalStateException.class.getName());
+        });
     }
 
     @Test

--- a/backend/src/test/java/com/toadzip/backend/global/exception/RequestTraceIdResolverTest.java
+++ b/backend/src/test/java/com/toadzip/backend/global/exception/RequestTraceIdResolverTest.java
@@ -1,0 +1,27 @@
+package com.toadzip.backend.global.exception;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+class RequestTraceIdResolverTest {
+
+    @Test
+    void 컨테이너_requestId가_없어도_같은_요청에는_같은_traceId를_반환한다() {
+        HttpServletRequest request = new HttpServletRequestWrapper(new MockHttpServletRequest()) {
+            @Override
+            public String getRequestId() {
+                return "";
+            }
+        };
+
+        String firstTraceId = RequestTraceIdResolver.resolve(request);
+        String secondTraceId = RequestTraceIdResolver.resolve(request);
+
+        assertThat(firstTraceId).isNotBlank();
+        assertThat(secondTraceId).isEqualTo(firstTraceId);
+    }
+}

--- a/backend/src/test/java/com/toadzip/backend/global/logging/HttpRequestLoggingFilterTest.java
+++ b/backend/src/test/java/com/toadzip/backend/global/logging/HttpRequestLoggingFilterTest.java
@@ -1,0 +1,80 @@
+package com.toadzip.backend.global.logging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import jakarta.servlet.ServletException;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+class HttpRequestLoggingFilterTest {
+
+    private static final String TRACE_ID = "traceId";
+
+    private final HttpRequestLoggingFilter filter = new HttpRequestLoggingFilter();
+
+    @AfterEach
+    void clearMdc() {
+        MDC.clear();
+    }
+
+    @Test
+    void 요청을_처리하는_동안_traceId를_MDC에_등록하고_완료되면_제거한다() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/test");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        AtomicReference<String> traceIdInRequest = new AtomicReference<>();
+
+        filter.doFilter(request, response, (servletRequest, servletResponse) ->
+                traceIdInRequest.set(MDC.get(TRACE_ID)));
+
+        assertThat(traceIdInRequest.get()).isNotBlank();
+        assertThat(MDC.get(TRACE_ID)).isNull();
+    }
+
+    @Test
+    void 요청_처리에서_예외가_발생해도_MDC의_traceId를_제거한다() {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/test");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        assertThatThrownBy(() -> filter.doFilter(request, response, (servletRequest, servletResponse) -> {
+            throw new ServletException("test failure");
+        })).isInstanceOf(ServletException.class);
+        assertThat(MDC.get(TRACE_ID)).isNull();
+    }
+
+    @Test
+    void 요청이_완료되면_method_URI_status_처리시간을_traceId와_함께_기록한다() throws Exception {
+        Logger logger = (Logger) LoggerFactory.getLogger(HttpRequestLoggingFilter.class);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/test");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        try {
+            filter.doFilter(request, response, (servletRequest, servletResponse) -> response.setStatus(201));
+
+            assertThat(appender.list).singleElement().satisfies(event -> {
+                assertThat(event.getFormattedMessage())
+                        .contains("event=http.request.completed")
+                        .contains("method=POST")
+                        .contains("uri=/api/test")
+                        .contains("status=201")
+                        .contains("durationMs=");
+                assertThat(event.getMDCPropertyMap()).containsKey(TRACE_ID);
+                assertThat(event.getMDCPropertyMap().get(TRACE_ID)).isNotBlank();
+            });
+        } finally {
+            logger.detachAppender(appender);
+            appender.stop();
+        }
+    }
+}

--- a/backend/src/test/java/com/toadzip/backend/housing/controller/HousingComplexExceptionAdviceTest.java
+++ b/backend/src/test/java/com/toadzip/backend/housing/controller/HousingComplexExceptionAdviceTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.mock.web.MockHttpServletRequest;
 
+import com.toadzip.backend.global.exception.RequestTraceIdResolver;
 import com.toadzip.backend.housing.exception.HousingComplexNotFoundException;
 import com.toadzip.backend.housing.exception.InvalidComplexCursorException;
 import com.toadzip.backend.housing.exception.InvalidComplexRequestException;
@@ -51,6 +52,17 @@ class HousingComplexExceptionAdviceTest {
 
         assertError(response, BAD_REQUEST, "INVALID_REGION_CODE");
         assertThat(response.getBody().message()).isEqualTo("지역 코드를 확인해 주세요.");
+    }
+
+    @Test
+    void 공통_요청_추적_식별자를_오류_응답에_사용한다() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        String traceId = RequestTraceIdResolver.resolve(request);
+
+        var response = advice.handleInvalidMapBounds(new InvalidMapBoundsException(), request);
+
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().traceId()).isEqualTo(traceId);
     }
 
     private void assertError(

--- a/backend/src/test/java/com/toadzip/backend/ingest/exception/controller/IngestExceptionAdviceTest.java
+++ b/backend/src/test/java/com/toadzip/backend/ingest/exception/controller/IngestExceptionAdviceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 
+import com.toadzip.backend.global.exception.RequestTraceIdResolver;
 import com.toadzip.backend.ingest.exception.exception.InvalidIngestRequestException;
 
 class IngestExceptionAdviceTest {
@@ -23,5 +24,19 @@ class IngestExceptionAdviceTest {
         assertThat(response.getBody().message()).isEqualTo("수집 요청값이 올바르지 않습니다.");
         assertThat(response.getBody().traceId()).isNotBlank();
         assertThat(response.getBody().errors()).isEmpty();
+    }
+
+    @Test
+    void 공통_요청_추적_식별자를_오류_응답에_사용한다() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        String traceId = RequestTraceIdResolver.resolve(request);
+
+        var response = advice.handleInvalidIngestRequest(
+                new InvalidIngestRequestException("수집 요청값이 올바르지 않습니다."),
+                request
+        );
+
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().traceId()).isEqualTo(traceId);
     }
 }


### PR DESCRIPTION
## 관련 이슈

Closes #83

## 작업 목적

- 하나의 요청 흐름과 실패 원인을 추적할 수 있도록 공통 로깅 기반을 만든다.


## 작업 내역

- HTTP 요청의 Method, URI, Status, 처리 시간을 공통 Filter에서 기록
- 요청별 traceId를 생성하고 MDC를 통해 모든 로그에 자동 포함
- 예상 예외는 WARN, 예상하지 못한 예외는 스택 트레이스와 함께 ERROR로 기록
- 공고·단지·수집 예외 응답에서도 공통 traceId 사용
- 요청 처리가 끝나거나 예외가 발생해도 MDC가 정리되도록 처리

## 리뷰 포인트

-

## 검증 결과

<!--
실행한 테스트 명령이나 직접 확인한 시나리오와 결과를 작성해 주세요.

예시:
- 테스트 방법: ./gradlew test
- 테스트 결과: 전체 테스트 통과

검증하지 못한 항목이 있다면 그 사유를 작성해 주세요.
-->

- 테스트 방법: 로컬에서 실행시켜 로그 확인
- 테스트 결과:
    - traceId가 출력되는 것 확인
        <img width="1091" height="89" alt="image" src="https://github.com/user-attachments/assets/3d40c20c-1447-4ea3-a0c4-408ceb434c34" />
    - WARN, ERROR 로그 출력 확인
        <img width="1086" height="72" alt="image" src="https://github.com/user-attachments/assets/345de53b-b504-4f8b-aa92-8bcb2c9ab763" />
