### PR TITLE
feat(ingest): LH 단지명 유사도 기반 주택형 세대수 보강 (#79)

### DIFF
--- a/backend/src/main/java/com/toadzip/backend/housing/domain/HousingType.java
+++ b/backend/src/main/java/com/toadzip/backend/housing/domain/HousingType.java
@@ -160,6 +160,15 @@ public class HousingType {
         return true;
     }
 
+    public boolean enrichHouseholdCountFromLh(int totalHouseholdCount) {
+        validateNonNegative(totalHouseholdCount, "LH 주택형 세대수");
+        if (java.util.Objects.equals(this.totalHouseholdCount, totalHouseholdCount)) {
+            return false;
+        }
+        this.totalHouseholdCount = totalHouseholdCount;
+        return true;
+    }
+
     public boolean isDuplex() {
         return Boolean.TRUE.equals(duplex);
     }

--- a/backend/src/main/java/com/toadzip/backend/ingest/controller/LhHousingTypeHouseholdEnrichmentController.java
+++ b/backend/src/main/java/com/toadzip/backend/ingest/controller/LhHousingTypeHouseholdEnrichmentController.java
@@ -1,0 +1,26 @@
+package com.toadzip.backend.ingest.controller;
+
+import com.toadzip.backend.ingest.dto.LhHousingTypeHouseholdEnrichmentReport;
+import com.toadzip.backend.ingest.service.LhHousingTypeHouseholdEnrichmentService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/admin/ingest/lh/housing-type-households")
+public class LhHousingTypeHouseholdEnrichmentController {
+
+    private final LhHousingTypeHouseholdEnrichmentService enrichmentService;
+
+    public LhHousingTypeHouseholdEnrichmentController(
+            LhHousingTypeHouseholdEnrichmentService enrichmentService
+    ) {
+        this.enrichmentService = enrichmentService;
+    }
+
+    @PostMapping
+    public ResponseEntity<LhHousingTypeHouseholdEnrichmentReport> enrichAll() {
+        return ResponseEntity.ok(enrichmentService.enrichAll());
+    }
+}

--- a/backend/src/main/java/com/toadzip/backend/ingest/dto/LhHousingTypeHouseholdEnrichmentReport.java
+++ b/backend/src/main/java/com/toadzip/backend/ingest/dto/LhHousingTypeHouseholdEnrichmentReport.java
@@ -1,0 +1,55 @@
+package com.toadzip.backend.ingest.dto;
+
+public record LhHousingTypeHouseholdEnrichmentReport(
+        int sourceComplexCount,
+        int matchedComplexCount,
+        int updatedHousingTypeCount,
+        int unchangedHousingTypeCount,
+        int failedSourceComplexCount,
+        int unmatchedHousingTypeCount
+) {
+
+    public LhHousingTypeHouseholdEnrichmentReport {
+        if (sourceComplexCount < 0
+                || matchedComplexCount < 0
+                || updatedHousingTypeCount < 0
+                || unchangedHousingTypeCount < 0
+                || failedSourceComplexCount < 0
+                || unmatchedHousingTypeCount < 0) {
+            throw new IllegalArgumentException(
+                    "LH 주택형 세대수 보강 결과 개수는 음수일 수 없습니다."
+            );
+        }
+    }
+
+    public static LhHousingTypeHouseholdEnrichmentReport empty(int sourceComplexCount) {
+        return new LhHousingTypeHouseholdEnrichmentReport(sourceComplexCount, 0, 0, 0, 0, 0);
+    }
+
+    public static LhHousingTypeHouseholdEnrichmentReport failed() {
+        return new LhHousingTypeHouseholdEnrichmentReport(0, 0, 0, 0, 1, 0);
+    }
+
+    public static LhHousingTypeHouseholdEnrichmentReport matched(
+            int updatedHousingTypeCount,
+            int unchangedHousingTypeCount,
+            int unmatchedHousingTypeCount
+    ) {
+        return new LhHousingTypeHouseholdEnrichmentReport(
+                0, 1, updatedHousingTypeCount, unchangedHousingTypeCount, 0, unmatchedHousingTypeCount
+        );
+    }
+
+    public LhHousingTypeHouseholdEnrichmentReport plus(
+            LhHousingTypeHouseholdEnrichmentReport other
+    ) {
+        return new LhHousingTypeHouseholdEnrichmentReport(
+                sourceComplexCount + other.sourceComplexCount,
+                matchedComplexCount + other.matchedComplexCount,
+                updatedHousingTypeCount + other.updatedHousingTypeCount,
+                unchangedHousingTypeCount + other.unchangedHousingTypeCount,
+                failedSourceComplexCount + other.failedSourceComplexCount,
+                unmatchedHousingTypeCount + other.unmatchedHousingTypeCount
+        );
+    }
+}

--- a/backend/src/main/java/com/toadzip/backend/ingest/repository/LhCatalogSourceRepository.java
+++ b/backend/src/main/java/com/toadzip/backend/ingest/repository/LhCatalogSourceRepository.java
@@ -1,8 +1,10 @@
 package com.toadzip.backend.ingest.repository;
 
+import com.toadzip.backend.ingest.domain.LhCatalogSource;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import com.toadzip.backend.ingest.domain.LhCatalogSource;
-
 public interface LhCatalogSourceRepository extends JpaRepository<LhCatalogSource, Long> {
+
+    List<LhCatalogSource> findAllByOrderBySourceOrderAsc();
 }

--- a/backend/src/main/java/com/toadzip/backend/ingest/service/LhHousingTypeHouseholdEnrichmentService.java
+++ b/backend/src/main/java/com/toadzip/backend/ingest/service/LhHousingTypeHouseholdEnrichmentService.java
@@ -1,0 +1,134 @@
+package com.toadzip.backend.ingest.service;
+
+import com.toadzip.backend.housing.domain.HousingComplex;
+import com.toadzip.backend.housing.repository.HousingComplexRepository;
+import com.toadzip.backend.ingest.domain.LhCatalogSource;
+import com.toadzip.backend.ingest.dto.LhHousingTypeHouseholdEnrichmentReport;
+import com.toadzip.backend.ingest.repository.LhCatalogSourceRepository;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Slf4j
+public class LhHousingTypeHouseholdEnrichmentService {
+
+    private final LhCatalogSourceRepository sourceRepository;
+    private final HousingComplexRepository complexRepository;
+    private final LhHousingTypeHouseholdSourceMapper sourceMapper;
+    private final LhHousingTypeHouseholdMatcher matcher;
+    private final LhHousingTypeHouseholdWriter writer;
+
+    public LhHousingTypeHouseholdEnrichmentService(
+            LhCatalogSourceRepository sourceRepository,
+            HousingComplexRepository complexRepository,
+            LhHousingTypeHouseholdSourceMapper sourceMapper,
+            LhHousingTypeHouseholdMatcher matcher,
+            LhHousingTypeHouseholdWriter writer
+    ) {
+        this.sourceRepository = sourceRepository;
+        this.complexRepository = complexRepository;
+        this.sourceMapper = sourceMapper;
+        this.matcher = matcher;
+        this.writer = writer;
+    }
+
+    @Transactional
+    public LhHousingTypeHouseholdEnrichmentReport enrichAll() {
+        Map<LhHousingTypeHouseholdSourceKey, List<LhCatalogSource>> sourceGroups =
+                sourceMapper.group(sourceRepository.findAllByOrderBySourceOrderAsc());
+        List<HousingComplex> complexes = complexRepository.findAll();
+        LhHousingTypeHouseholdEnrichmentReport report =
+                LhHousingTypeHouseholdEnrichmentReport.empty(sourceGroups.size());
+        List<MatchedSource> matchedSources = new ArrayList<>();
+        for (List<LhCatalogSource> sources : sourceGroups.values()) {
+            Optional<MatchedSource> matchedSource = match(sources, complexes);
+            if (matchedSource.isEmpty()) {
+                report = report.plus(LhHousingTypeHouseholdEnrichmentReport.failed());
+                continue;
+            }
+            matchedSources.add(matchedSource.get());
+        }
+        return report.plus(writeUniqueMatches(matchedSources));
+    }
+
+    private Optional<MatchedSource> match(
+            List<LhCatalogSource> sources,
+            List<HousingComplex> complexes
+    ) {
+        try {
+            LhHousingTypeHouseholdSource source = sourceMapper.map(sources);
+            List<HousingComplex> matches = matcher.findMatches(complexes, source);
+            if (matches.size() != 1) {
+                log.warn(
+                        "LH 주택형 세대수 보강 단지를 확정하지 못했습니다: "
+                                + "areaName={}, complexName={}, candidateCount={}",
+                        source.areaName(),
+                        source.complexName(),
+                        matches.size()
+                );
+                return Optional.empty();
+            }
+            return Optional.of(new MatchedSource(matches.getFirst(), source));
+        }
+        catch (IllegalArgumentException exception) {
+            LhCatalogSource first = sources.getFirst();
+            log.warn(
+                    "LH 주택형 세대수 원천을 해석하지 못했습니다: sourceOrder={}, detail={}",
+                    first.getSourceOrder(),
+                    exception.getMessage()
+            );
+            return Optional.empty();
+        }
+    }
+
+    private LhHousingTypeHouseholdEnrichmentReport writeUniqueMatches(
+            List<MatchedSource> matchedSources
+    ) {
+        Map<Long, Integer> sourceGroupCounts = sourceGroupCounts(matchedSources);
+        LhHousingTypeHouseholdEnrichmentReport report =
+                LhHousingTypeHouseholdEnrichmentReport.empty(0);
+        for (MatchedSource matchedSource : matchedSources) {
+            int sourceGroupCount = sourceGroupCounts.get(matchedSource.complex().getId());
+            if (sourceGroupCount > 1) {
+                logDuplicateMatch(matchedSource, sourceGroupCount);
+                report = report.plus(LhHousingTypeHouseholdEnrichmentReport.failed());
+                continue;
+            }
+            report = report.plus(writer.write(
+                    matchedSource.complex(),
+                    matchedSource.source().housingTypes()
+            ));
+        }
+        return report;
+    }
+
+    private Map<Long, Integer> sourceGroupCounts(List<MatchedSource> matchedSources) {
+        Map<Long, Integer> result = new HashMap<>();
+        for (MatchedSource matchedSource : matchedSources) {
+            result.merge(matchedSource.complex().getId(), 1, Integer::sum);
+        }
+        return result;
+    }
+
+    private void logDuplicateMatch(MatchedSource matchedSource, int sourceGroupCount) {
+        log.warn(
+                "여러 LH 주택형 세대수 원천 그룹이 같은 단지에 매칭되어 보강하지 않았습니다: "
+                        + "sourceComplexName={}, targetComplexIdentifier={}, sourceGroupCount={}",
+                matchedSource.source().complexName(),
+                matchedSource.complex().getSourceComplexIdentifier(),
+                sourceGroupCount
+        );
+    }
+
+    private record MatchedSource(
+            HousingComplex complex,
+            LhHousingTypeHouseholdSource source
+    ) {
+    }
+}

--- a/backend/src/main/java/com/toadzip/backend/ingest/service/LhHousingTypeHouseholdEnrichmentService.java
+++ b/backend/src/main/java/com/toadzip/backend/ingest/service/LhHousingTypeHouseholdEnrichmentService.java
@@ -54,7 +54,9 @@ public class LhHousingTypeHouseholdEnrichmentService {
             }
             matchedSources.add(matchedSource.get());
         }
-        return report.plus(writeUniqueMatches(matchedSources));
+        report = report.plus(writeUniqueMatches(matchedSources));
+        logCompleted(report);
+        return report;
     }
 
     private Optional<MatchedSource> match(
@@ -66,8 +68,8 @@ public class LhHousingTypeHouseholdEnrichmentService {
             List<HousingComplex> matches = matcher.findMatches(complexes, source);
             if (matches.size() != 1) {
                 log.warn(
-                        "LH 주택형 세대수 보강 단지를 확정하지 못했습니다: "
-                                + "areaName={}, complexName={}, candidateCount={}",
+                        "event=lh_household.match.unresolved result=skipped source=lh_catalog "
+                                + "area={} sourceName={} candidates={}",
                         source.areaName(),
                         source.complexName(),
                         matches.size()
@@ -79,7 +81,8 @@ public class LhHousingTypeHouseholdEnrichmentService {
         catch (IllegalArgumentException exception) {
             LhCatalogSource first = sources.getFirst();
             log.warn(
-                    "LH 주택형 세대수 원천을 해석하지 못했습니다: sourceOrder={}, detail={}",
+                    "event=lh_household.map.failed result=skipped source=lh_catalog "
+                            + "sourceOrder={} detail={}",
                     first.getSourceOrder(),
                     exception.getMessage()
             );
@@ -118,11 +121,22 @@ public class LhHousingTypeHouseholdEnrichmentService {
 
     private void logDuplicateMatch(MatchedSource matchedSource, int sourceGroupCount) {
         log.warn(
-                "여러 LH 주택형 세대수 원천 그룹이 같은 단지에 매칭되어 보강하지 않았습니다: "
-                        + "sourceComplexName={}, targetComplexIdentifier={}, sourceGroupCount={}",
+                "event=lh_household.match.duplicate result=skipped source=lh_catalog "
+                        + "sourceName={} targetId={} groups={}",
                 matchedSource.source().complexName(),
                 matchedSource.complex().getSourceComplexIdentifier(),
                 sourceGroupCount
+        );
+    }
+
+    private void logCompleted(LhHousingTypeHouseholdEnrichmentReport report) {
+        log.info(
+                "event=lh_household.enrich.completed result=success source=lh_catalog "
+                        + "sources={} matched={} failed={} updatedTypes={}",
+                report.sourceComplexCount(),
+                report.matchedComplexCount(),
+                report.failedSourceComplexCount(),
+                report.updatedHousingTypeCount()
         );
     }
 

--- a/backend/src/main/java/com/toadzip/backend/ingest/service/LhHousingTypeHouseholdMatcher.java
+++ b/backend/src/main/java/com/toadzip/backend/ingest/service/LhHousingTypeHouseholdMatcher.java
@@ -1,0 +1,225 @@
+package com.toadzip.backend.ingest.service;
+
+import com.toadzip.backend.housing.domain.HousingComplex;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.springframework.stereotype.Component;
+
+@Component
+public class LhHousingTypeHouseholdMatcher {
+
+    private static final Map<String, String> SUPPLY_TYPES = Map.ofEntries(
+            Map.entry("행복주택", "HAPPY_HOUSING"),
+            Map.entry("국민임대", "NATIONAL_RENTAL"),
+            Map.entry("국민임대주택", "NATIONAL_RENTAL"),
+            Map.entry("영구임대", "PERMANENT_RENTAL"),
+            Map.entry("영구임대주택", "PERMANENT_RENTAL"),
+            Map.entry("5년임대", "PUBLIC_RENTAL_5Y"),
+            Map.entry("공공임대5년", "PUBLIC_RENTAL_5Y"),
+            Map.entry("10년임대", "PUBLIC_RENTAL_10Y"),
+            Map.entry("공공임대10년", "PUBLIC_RENTAL_10Y"),
+            Map.entry("50년임대", "PUBLIC_RENTAL_50Y"),
+            Map.entry("공공임대50년", "PUBLIC_RENTAL_50Y"),
+            Map.entry("장기전세", "LONG_TERM_JEONSE"),
+            Map.entry("통합공공임대", "INTEGRATED_PUBLIC_RENTAL"),
+            Map.entry("재개발임대", "REDEVELOPMENT_RENTAL")
+    );
+    private static final Set<String> PUBLIC_RENTAL_TYPES = Set.of(
+            "PUBLIC_RENTAL_5Y", "PUBLIC_RENTAL_10Y", "PUBLIC_RENTAL_50Y"
+    );
+    private static final List<String> NAME_DECORATIONS = List.of(
+            "통합공공임대주택",
+            "국민임대주택",
+            "영구임대주택",
+            "공공임대주택",
+            "행복주택",
+            "주공아파트",
+            "공공임대",
+            "국민임대",
+            "영구임대",
+            "임대주택",
+            "휴먼시아",
+            "아파트",
+            "공임리츠",
+            "마을",
+            "단지",
+            "블록",
+            "블럭",
+            "지구",
+            "리츠",
+            "주공",
+            "lh"
+    );
+    private static final Pattern NUMBER = Pattern.compile("[0-9]+");
+
+    public List<HousingComplex> findMatches(
+            List<HousingComplex> complexes,
+            LhHousingTypeHouseholdSource source
+    ) {
+        List<HousingComplex> structuralMatches = complexes.stream()
+                .filter(complex -> "LH".equals(complex.getProvider()))
+                .filter(complex -> regionMatches(complex, source.areaName()))
+                .filter(complex -> supplyTypeMatches(complex.getSupplyType(), source.supplyTypeName()))
+                .filter(complex -> complex.getTotalHouseholdCount() == source.totalHouseholdCount())
+                .toList();
+        return bestNameMatches(structuralMatches, source.complexName());
+    }
+
+    private List<HousingComplex> bestNameMatches(
+            List<HousingComplex> complexes,
+            String sourceName
+    ) {
+        int bestScore = 0;
+        List<HousingComplex> bestMatches = new ArrayList<>();
+        for (HousingComplex complex : complexes) {
+            int score = nameScore(sourceName, complex.getName());
+            if (score == 0 || score < bestScore) {
+                continue;
+            }
+            if (score > bestScore) {
+                bestMatches.clear();
+                bestScore = score;
+            }
+            bestMatches.add(complex);
+        }
+        return bestMatches;
+    }
+
+    private int nameScore(String sourceName, String candidateName) {
+        String normalizedSource = normalized(sourceName);
+        String normalizedCandidate = normalized(candidateName);
+        if (normalizedSource.equals(normalizedCandidate)) {
+            return 10_000;
+        }
+
+        String source = comparableName(normalizedSource);
+        String candidate = comparableName(normalizedCandidate);
+        if (source.isEmpty() || candidate.isEmpty()) {
+            return 0;
+        }
+        if (source.equals(candidate)) {
+            return 9_000;
+        }
+
+        int shorterLength = Math.min(source.length(), candidate.length());
+        int longerLength = Math.max(source.length(), candidate.length());
+        if (shorterLength >= 3 && (source.contains(candidate) || candidate.contains(source))) {
+            return 8_000 + shorterLength * 100 / longerLength;
+        }
+
+        int commonLength = longestCommonSubstringLength(source, candidate);
+        int diceScore = bigramDiceScore(source, candidate);
+        boolean sharesNumber = sharesNumber(source, candidate);
+        if (commonLength < 4 && diceScore < 450 && !(commonLength >= 2 && sharesNumber)) {
+            return 0;
+        }
+        return 1_000 + commonLength * 100 + diceScore + (sharesNumber ? 200 : 0);
+    }
+
+    private String comparableName(String normalizedName) {
+        String result = normalizedName.replaceAll("nhf제?[0-9]*호?", "");
+        for (String decoration : NAME_DECORATIONS) {
+            result = result.replace(decoration, "");
+        }
+        return result;
+    }
+
+    private int longestCommonSubstringLength(String left, String right) {
+        int[] previous = new int[right.length() + 1];
+        int longest = 0;
+        for (int leftIndex = 1; leftIndex <= left.length(); leftIndex++) {
+            int[] current = new int[right.length() + 1];
+            for (int rightIndex = 1; rightIndex <= right.length(); rightIndex++) {
+                if (left.charAt(leftIndex - 1) != right.charAt(rightIndex - 1)) {
+                    continue;
+                }
+                current[rightIndex] = previous[rightIndex - 1] + 1;
+                longest = Math.max(longest, current[rightIndex]);
+            }
+            previous = current;
+        }
+        return longest;
+    }
+
+    private int bigramDiceScore(String left, String right) {
+        if (left.length() < 2 || right.length() < 2) {
+            return 0;
+        }
+        Set<String> leftBigrams = bigrams(left);
+        Set<String> rightBigrams = bigrams(right);
+        long intersection = leftBigrams.stream().filter(rightBigrams::contains).count();
+        return (int) (2_000L * intersection / (leftBigrams.size() + rightBigrams.size()));
+    }
+
+    private Set<String> bigrams(String value) {
+        Set<String> result = new HashSet<>();
+        for (int index = 0; index < value.length() - 1; index++) {
+            result.add(value.substring(index, index + 2));
+        }
+        return result;
+    }
+
+    private boolean sharesNumber(String left, String right) {
+        Set<String> leftNumbers = new HashSet<>();
+        Matcher leftMatcher = NUMBER.matcher(left);
+        while (leftMatcher.find()) {
+            leftNumbers.add(leftMatcher.group());
+        }
+        Matcher rightMatcher = NUMBER.matcher(right);
+        while (rightMatcher.find()) {
+            if (leftNumbers.contains(rightMatcher.group())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean regionMatches(HousingComplex complex, String areaName) {
+        String address = canonicalRegion(complex.getAddress().getRoadAddress());
+        String sourceRegion = canonicalRegion(areaName);
+        return !sourceRegion.isEmpty() && address.startsWith(sourceRegion);
+    }
+
+    private boolean supplyTypeMatches(String myHomeSupplyType, String lhSupplyType) {
+        String normalized = normalized(lhSupplyType);
+        if ("공공임대".equals(normalized)) {
+            return PUBLIC_RENTAL_TYPES.contains(myHomeSupplyType);
+        }
+        return myHomeSupplyType.equals(SUPPLY_TYPES.get(normalized));
+    }
+
+    private String canonicalRegion(String value) {
+        return normalized(value)
+                .replace("서울특별시", "서울")
+                .replace("부산광역시", "부산")
+                .replace("대구광역시", "대구")
+                .replace("인천광역시", "인천")
+                .replace("광주광역시", "광주")
+                .replace("대전광역시", "대전")
+                .replace("울산광역시", "울산")
+                .replace("세종특별자치시", "세종")
+                .replace("강원특별자치도", "강원")
+                .replace("강원도", "강원")
+                .replace("전북특별자치도", "전북")
+                .replace("전라북도", "전북")
+                .replace("제주특별자치도", "제주")
+                .replace("경기도", "경기")
+                .replace("충청북도", "충북")
+                .replace("충청남도", "충남")
+                .replace("전라남도", "전남")
+                .replace("경상북도", "경북")
+                .replace("경상남도", "경남");
+    }
+
+    private String normalized(String value) {
+        if (value == null) {
+            return "";
+        }
+        return value.replaceAll("[\\s\\-·,()]", "").strip().toLowerCase();
+    }
+}

--- a/backend/src/main/java/com/toadzip/backend/ingest/service/LhHousingTypeHouseholdMatcher.java
+++ b/backend/src/main/java/com/toadzip/backend/ingest/service/LhHousingTypeHouseholdMatcher.java
@@ -105,6 +105,9 @@ public class LhHousingTypeHouseholdMatcher {
         if (source.equals(candidate)) {
             return 9_000;
         }
+        if (hasConflictingNumbers(source, candidate)) {
+            return 0;
+        }
 
         int shorterLength = Math.min(source.length(), candidate.length());
         int longerLength = Math.max(source.length(), candidate.length());
@@ -165,18 +168,31 @@ public class LhHousingTypeHouseholdMatcher {
     }
 
     private boolean sharesNumber(String left, String right) {
-        Set<String> leftNumbers = new HashSet<>();
-        Matcher leftMatcher = NUMBER.matcher(left);
-        while (leftMatcher.find()) {
-            leftNumbers.add(leftMatcher.group());
+        Set<String> leftNumbers = numbers(left);
+        return numbers(right).stream().anyMatch(leftNumbers::contains);
+    }
+
+    private boolean hasConflictingNumbers(String left, String right) {
+        Set<String> leftNumbers = numbers(left);
+        Set<String> rightNumbers = numbers(right);
+        return !leftNumbers.isEmpty() && !rightNumbers.isEmpty() && !leftNumbers.equals(rightNumbers);
+    }
+
+    private Set<String> numbers(String value) {
+        Set<String> result = new HashSet<>();
+        Matcher matcher = NUMBER.matcher(value);
+        while (matcher.find()) {
+            result.add(withoutLeadingZeros(matcher.group()));
         }
-        Matcher rightMatcher = NUMBER.matcher(right);
-        while (rightMatcher.find()) {
-            if (leftNumbers.contains(rightMatcher.group())) {
-                return true;
-            }
+        return result;
+    }
+
+    private String withoutLeadingZeros(String number) {
+        int firstDigit = 0;
+        while (firstDigit < number.length() - 1 && number.charAt(firstDigit) == '0') {
+            firstDigit++;
         }
-        return false;
+        return number.substring(firstDigit);
     }
 
     private boolean regionMatches(HousingComplex complex, String areaName) {

--- a/backend/src/main/java/com/toadzip/backend/ingest/service/LhHousingTypeHouseholdSourceMapper.java
+++ b/backend/src/main/java/com/toadzip/backend/ingest/service/LhHousingTypeHouseholdSourceMapper.java
@@ -1,0 +1,151 @@
+package com.toadzip.backend.ingest.service;
+
+import com.toadzip.backend.ingest.domain.LhCatalogSource;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+
+@Component
+public class LhHousingTypeHouseholdSourceMapper {
+
+    public Map<LhHousingTypeHouseholdSourceKey, List<LhCatalogSource>> group(
+            List<LhCatalogSource> sources
+    ) {
+        Map<LhHousingTypeHouseholdSourceKey, List<LhCatalogSource>> grouped = new LinkedHashMap<>();
+        for (LhCatalogSource source : sources) {
+            LhHousingTypeHouseholdSourceKey key = new LhHousingTypeHouseholdSourceKey(
+                    canonicalRegion(source.getAreaName()),
+                    normalized(source.getSupplyTypeName()),
+                    normalized(source.getComplexLabel())
+            );
+            grouped.computeIfAbsent(key, ignored -> new ArrayList<>()).add(source);
+        }
+        return grouped;
+    }
+
+    public LhHousingTypeHouseholdSource map(List<LhCatalogSource> sources) {
+        LhCatalogSource first = sources.getFirst();
+        String areaName = required(first.getAreaName(), "지역명");
+        String supplyTypeName = required(first.getSupplyTypeName(), "공급유형");
+        String complexName = required(first.getComplexLabel(), "단지명");
+        int totalHouseholdCount = sameComplexHouseholdCount(sources);
+        return new LhHousingTypeHouseholdSource(
+                areaName,
+                supplyTypeName,
+                complexName,
+                totalHouseholdCount,
+                housingTypes(sources)
+        );
+    }
+
+    private int sameComplexHouseholdCount(List<LhCatalogSource> sources) {
+        Integer totalHouseholdCount = null;
+        for (LhCatalogSource source : sources) {
+            int current = nonNegativeInteger(source.getComplexTotalUnitCount(), "단지 전체 세대수");
+            if (totalHouseholdCount != null && totalHouseholdCount != current) {
+                throw new IllegalArgumentException("단지 전체 세대수가 서로 다릅니다.");
+            }
+            totalHouseholdCount = current;
+        }
+        return totalHouseholdCount;
+    }
+
+    private List<LhHousingTypeHousehold> housingTypes(List<LhCatalogSource> sources) {
+        Map<BigDecimal, Integer> householdCountsByArea = new LinkedHashMap<>();
+        for (LhCatalogSource source : sources) {
+            BigDecimal area = area(source.getExclusiveArea());
+            int householdCount = nonNegativeInteger(source.getTotalUnitCount(), "주택형 세대수");
+            Integer previous = householdCountsByArea.putIfAbsent(area, householdCount);
+            if (previous != null && previous != householdCount) {
+                throw new IllegalArgumentException(
+                        "같은 전용면적의 주택형 세대수가 서로 다릅니다."
+                );
+            }
+        }
+        return householdCountsByArea.entrySet().stream()
+                .map(entry -> new LhHousingTypeHousehold(entry.getKey(), entry.getValue()))
+                .toList();
+    }
+
+    private BigDecimal area(String raw) {
+        try {
+            BigDecimal value = new BigDecimal(required(raw, "전용면적"));
+            if (value.signum() < 0) {
+                throw new IllegalArgumentException("전용면적은 음수일 수 없습니다.");
+            }
+            return value.setScale(4, RoundingMode.HALF_UP);
+        }
+        catch (NumberFormatException exception) {
+            throw new IllegalArgumentException("전용면적이 숫자가 아닙니다.");
+        }
+    }
+
+    private int nonNegativeInteger(String raw, String fieldName) {
+        try {
+            int value = Integer.parseInt(required(raw, fieldName).replace(",", ""));
+            if (value < 0) {
+                throw new IllegalArgumentException(fieldName + "는 음수일 수 없습니다.");
+            }
+            return value;
+        }
+        catch (NumberFormatException exception) {
+            throw new IllegalArgumentException(fieldName + "가 정수가 아닙니다.");
+        }
+    }
+
+    private String required(String value, String fieldName) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(fieldName + "이 없습니다.");
+        }
+        return value.strip();
+    }
+
+    private String normalized(String value) {
+        if (value == null) {
+            return "";
+        }
+        return value.replaceAll("[\\s\\-·,()]", "").strip().toLowerCase();
+    }
+
+    private String canonicalRegion(String value) {
+        return normalized(value)
+                .replace("서울특별시", "서울")
+                .replace("부산광역시", "부산")
+                .replace("대구광역시", "대구")
+                .replace("인천광역시", "인천")
+                .replace("광주광역시", "광주")
+                .replace("대전광역시", "대전")
+                .replace("울산광역시", "울산")
+                .replace("세종특별자치시", "세종")
+                .replace("강원특별자치도", "강원")
+                .replace("강원도", "강원")
+                .replace("전북특별자치도", "전북")
+                .replace("전라북도", "전북")
+                .replace("제주특별자치도", "제주")
+                .replace("경기도", "경기")
+                .replace("충청북도", "충북")
+                .replace("충청남도", "충남")
+                .replace("전라남도", "전남")
+                .replace("경상북도", "경북")
+                .replace("경상남도", "경남");
+    }
+}
+
+record LhHousingTypeHouseholdSourceKey(String areaName, String supplyTypeName, String complexName) {
+}
+
+record LhHousingTypeHouseholdSource(
+        String areaName,
+        String supplyTypeName,
+        String complexName,
+        int totalHouseholdCount,
+        List<LhHousingTypeHousehold> housingTypes
+) {
+}
+
+record LhHousingTypeHousehold(BigDecimal exclusiveArea, int totalHouseholdCount) {
+}

--- a/backend/src/main/java/com/toadzip/backend/ingest/service/LhHousingTypeHouseholdWriter.java
+++ b/backend/src/main/java/com/toadzip/backend/ingest/service/LhHousingTypeHouseholdWriter.java
@@ -1,0 +1,45 @@
+package com.toadzip.backend.ingest.service;
+
+import com.toadzip.backend.housing.domain.HousingComplex;
+import com.toadzip.backend.housing.domain.HousingType;
+import com.toadzip.backend.housing.repository.HousingTypeRepository;
+import com.toadzip.backend.ingest.dto.LhHousingTypeHouseholdEnrichmentReport;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+@Component
+public class LhHousingTypeHouseholdWriter {
+
+    private final HousingTypeRepository housingTypeRepository;
+
+    public LhHousingTypeHouseholdWriter(HousingTypeRepository housingTypeRepository) {
+        this.housingTypeRepository = housingTypeRepository;
+    }
+
+    public LhHousingTypeHouseholdEnrichmentReport write(
+            HousingComplex complex,
+            List<LhHousingTypeHousehold> sources
+    ) {
+        List<HousingType> housingTypes = housingTypeRepository.findAllByHousingComplex(complex);
+        int updatedCount = 0;
+        int unchangedCount = 0;
+        int unmatchedCount = 0;
+        for (LhHousingTypeHousehold source : sources) {
+            List<HousingType> matches = housingTypes.stream()
+                    .filter(type -> type.getExclusiveArea().compareTo(source.exclusiveArea()) == 0)
+                    .toList();
+            if (matches.size() != 1) {
+                unmatchedCount++;
+                continue;
+            }
+            if (matches.getFirst().enrichHouseholdCountFromLh(source.totalHouseholdCount())) {
+                updatedCount++;
+                continue;
+            }
+            unchangedCount++;
+        }
+        return LhHousingTypeHouseholdEnrichmentReport.matched(
+                updatedCount, unchangedCount, unmatchedCount
+        );
+    }
+}

--- a/backend/src/main/java/com/toadzip/backend/ingest/service/LhHousingTypeHouseholdWriter.java
+++ b/backend/src/main/java/com/toadzip/backend/ingest/service/LhHousingTypeHouseholdWriter.java
@@ -20,7 +20,9 @@ public class LhHousingTypeHouseholdWriter {
             HousingComplex complex,
             List<LhHousingTypeHousehold> sources
     ) {
-        List<HousingType> housingTypes = housingTypeRepository.findAllByHousingComplex(complex);
+        List<HousingType> housingTypes = housingTypeRepository.findAllByHousingComplex(complex).stream()
+                .filter(type -> type.getSourceHousingTypeIdentifier() != null)
+                .toList();
         int updatedCount = 0;
         int unchangedCount = 0;
         int unmatchedCount = 0;

--- a/backend/src/test/java/com/toadzip/backend/housing/domain/HousingTypeTest.java
+++ b/backend/src/test/java/com/toadzip/backend/housing/domain/HousingTypeTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.Method;
 import java.math.BigDecimal;
@@ -13,6 +14,37 @@ import java.time.LocalDate;
 import org.junit.jupiter.api.Test;
 
 class HousingTypeTest {
+
+    @Test
+    void LH_주택형_세대수만_보강하고_같은_값은_변경하지_않는다() {
+        HousingType housingType = HousingType.createFromMyHome(
+                createHousingComplex(),
+                "source-housing-type-id",
+                "46A",
+                new BigDecimal("46.8000"),
+                null
+        );
+
+        assertTrue(housingType.enrichHouseholdCountFromLh(125));
+        assertEquals(125, housingType.getTotalHouseholdCount());
+        assertFalse(housingType.enrichHouseholdCountFromLh(125));
+    }
+
+    @Test
+    void LH_주택형_세대수는_음수로_보강할_수_없다() {
+        HousingType housingType = HousingType.createFromMyHome(
+                createHousingComplex(),
+                "source-housing-type-id",
+                "46A",
+                new BigDecimal("46.8000"),
+                null
+        );
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> housingType.enrichHouseholdCountFromLh(-1)
+        );
+    }
 
     @Test
     void 마이홈에_없는_주택형_정보는_미확정으로_생성한다() {

--- a/backend/src/test/java/com/toadzip/backend/ingest/controller/LhHousingTypeHouseholdEnrichmentControllerTest.java
+++ b/backend/src/test/java/com/toadzip/backend/ingest/controller/LhHousingTypeHouseholdEnrichmentControllerTest.java
@@ -1,0 +1,40 @@
+package com.toadzip.backend.ingest.controller;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.toadzip.backend.ingest.dto.LhHousingTypeHouseholdEnrichmentReport;
+import com.toadzip.backend.ingest.service.LhHousingTypeHouseholdEnrichmentService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(LhHousingTypeHouseholdEnrichmentController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class LhHousingTypeHouseholdEnrichmentControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private LhHousingTypeHouseholdEnrichmentService enrichmentService;
+
+    @Test
+    void LH_카탈로그로_마이홈_주택형별_세대수_보강을_실행한다() throws Exception {
+        when(enrichmentService.enrichAll()).thenReturn(
+                new LhHousingTypeHouseholdEnrichmentReport(1, 1, 2, 0, 0, 0)
+        );
+
+        mockMvc.perform(post("/api/admin/ingest/lh/housing-type-households"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.sourceComplexCount").value(1))
+                .andExpect(jsonPath("$.matchedComplexCount").value(1))
+                .andExpect(jsonPath("$.updatedHousingTypeCount").value(2))
+                .andExpect(jsonPath("$.failedSourceComplexCount").value(0));
+    }
+}

--- a/backend/src/test/java/com/toadzip/backend/ingest/service/LhHousingTypeHouseholdEnrichmentServiceTest.java
+++ b/backend/src/test/java/com/toadzip/backend/ingest/service/LhHousingTypeHouseholdEnrichmentServiceTest.java
@@ -1,0 +1,219 @@
+package com.toadzip.backend.ingest.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.toadzip.backend.housing.domain.Address;
+import com.toadzip.backend.housing.domain.HousingComplex;
+import com.toadzip.backend.housing.domain.HousingType;
+import com.toadzip.backend.housing.repository.HousingComplexRepository;
+import com.toadzip.backend.housing.repository.HousingTypeRepository;
+import com.toadzip.backend.ingest.domain.LhCatalogSource;
+import com.toadzip.backend.ingest.domain.LhCatalogSourceData;
+import com.toadzip.backend.ingest.repository.LhCatalogSourceRepository;
+import java.math.BigDecimal;
+import java.time.Instant;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class LhHousingTypeHouseholdEnrichmentServiceTest {
+
+    @Autowired
+    private LhHousingTypeHouseholdEnrichmentService service;
+
+    @Autowired
+    private LhCatalogSourceRepository sourceRepository;
+
+    @Autowired
+    private HousingComplexRepository complexRepository;
+
+    @Autowired
+    private HousingTypeRepository housingTypeRepository;
+
+    @BeforeEach
+    void setUp() {
+        cleanUp();
+    }
+
+    @AfterEach
+    void tearDown() {
+        cleanUp();
+    }
+
+    @Test
+    void 마이홈_단지의_주택형별_세대수만_LH_카탈로그로_보강한다() {
+        HousingComplex complex = saveComplex("동삼2", "NATIONAL_RENTAL", 120);
+        HousingType small = saveType(complex, "46A", "46.8000");
+        HousingType large = saveType(complex, "59B", "59.8000");
+        saveCatalog(0, "국민임대", "46.8", 120, 70);
+        saveCatalog(1, "국민임대", "59.8", 120, 50);
+
+        var report = service.enrichAll();
+
+        assertThat(report.sourceComplexCount()).isOne();
+        assertThat(report.matchedComplexCount()).isOne();
+        assertThat(report.updatedHousingTypeCount()).isEqualTo(2);
+        assertThat(housingTypeRepository.findById(small.getId()).orElseThrow().getTotalHouseholdCount())
+                .isEqualTo(70);
+        assertThat(housingTypeRepository.findById(large.getId()).orElseThrow().getTotalHouseholdCount())
+                .isEqualTo(50);
+        assertThat(complexRepository.findById(complex.getId()).orElseThrow()).satisfies(stored -> {
+            assertThat(stored.getName()).isEqualTo("동삼2");
+            assertThat(stored.getSupplyType()).isEqualTo("NATIONAL_RENTAL");
+            assertThat(stored.getTotalHouseholdCount()).isEqualTo(120);
+            assertThat(stored.getSourceComplexIdentifier()).isEqualTo("100:NATIONAL_RENTAL");
+        });
+    }
+
+    @Test
+    void 일반_공공임대도_CSV_없이_마이홈의_세부_공급유형을_유지하며_보강한다() {
+        HousingComplex complex = saveComplex("공공임대단지", "PUBLIC_RENTAL_10Y", 100);
+        HousingType type = saveType(complex, "46A", "46.8000");
+        saveCatalog(0, "공공임대", "46.8", 100, 100, "공공임대단지");
+
+        var report = service.enrichAll();
+
+        assertThat(report.updatedHousingTypeCount()).isOne();
+        assertThat(housingTypeRepository.findById(type.getId()).orElseThrow().getTotalHouseholdCount())
+                .isEqualTo(100);
+        assertThat(complexRepository.findById(complex.getId()).orElseThrow().getSupplyType())
+                .isEqualTo("PUBLIC_RENTAL_10Y");
+    }
+
+    @Test
+    void LH와_마이홈의_단지명이_부분적으로_같아도_주택형_세대수를_보강한다() {
+        HousingComplex complex = saveComplex("강릉송정주공아파트", "NATIONAL_RENTAL", 623);
+        HousingType type = saveType(complex, "46A", "46.8000");
+        saveCatalog(0, "국민임대", "46.8", 623, 100, "강릉송정");
+
+        var report = service.enrichAll();
+
+        assertThat(report.matchedComplexCount()).isOne();
+        assertThat(housingTypeRepository.findById(type.getId()).orElseThrow().getTotalHouseholdCount())
+                .isEqualTo(100);
+    }
+
+    @Test
+    void 같은_단지_후보가_여러_개면_어느_주택형도_보강하지_않는다() {
+        HousingComplex first = saveComplex("동삼2", "NATIONAL_RENTAL", 120);
+        HousingComplex second = saveComplex("동삼2", "NATIONAL_RENTAL", 120);
+        HousingType firstType = saveType(first, "46A", "46.8000");
+        HousingType secondType = saveType(second, "46A", "46.8000");
+        saveCatalog(0, "국민임대", "46.8", 120, 120);
+
+        var report = service.enrichAll();
+
+        assertThat(report.failedSourceComplexCount()).isOne();
+        assertThat(housingTypeRepository.findAllById(java.util.List.of(firstType.getId(), secondType.getId())))
+                .allSatisfy(type -> assertThat(type.getTotalHouseholdCount()).isNull());
+    }
+
+    @Test
+    void 여러_LH_원천_그룹이_같은_단지에_매칭되면_어느_값도_보강하지_않는다() {
+        HousingComplex complex = saveComplex("동삼2주공아파트", "NATIONAL_RENTAL", 120);
+        HousingType type = saveType(complex, "46A", "46.8000");
+        saveCatalog(0, "국민임대", "46.8", 120, 70, "동삼2");
+        saveCatalog(1, "국민임대", "46.8", 120, 80, "동삼2단지");
+
+        var report = service.enrichAll();
+
+        assertThat(report.sourceComplexCount()).isEqualTo(2);
+        assertThat(report.matchedComplexCount()).isZero();
+        assertThat(report.updatedHousingTypeCount()).isZero();
+        assertThat(report.failedSourceComplexCount()).isEqualTo(2);
+        assertThat(housingTypeRepository.findById(type.getId()).orElseThrow().getTotalHouseholdCount())
+                .isNull();
+    }
+
+    @Test
+    void 일치하지_않는_LH_주택형은_건너뛰고_일치하는_주택형만_보강한다() {
+        HousingComplex complex = saveComplex("동삼2", "NATIONAL_RENTAL", 120);
+        HousingType matched = saveType(complex, "46A", "46.8000");
+        saveCatalog(0, "국민임대", "46.8", 120, 70);
+        saveCatalog(1, "국민임대", "59.8", 120, 50);
+
+        var report = service.enrichAll();
+
+        assertThat(report.updatedHousingTypeCount()).isOne();
+        assertThat(report.unmatchedHousingTypeCount()).isOne();
+        assertThat(housingTypeRepository.findById(matched.getId()).orElseThrow().getTotalHouseholdCount())
+                .isEqualTo(70);
+    }
+
+    @Test
+    void 같은_LH_값으로_다시_보강하면_변경하지_않는다() {
+        HousingComplex complex = saveComplex("동삼2", "NATIONAL_RENTAL", 120);
+        saveType(complex, "46A", "46.8000");
+        saveCatalog(0, "국민임대", "46.8", 120, 120);
+        service.enrichAll();
+
+        var report = service.enrichAll();
+
+        assertThat(report.updatedHousingTypeCount()).isZero();
+        assertThat(report.unchangedHousingTypeCount()).isOne();
+    }
+
+    private HousingComplex saveComplex(String name, String supplyType, int totalHouseholdCount) {
+        String identifier = (100 + complexRepository.count()) + ":" + supplyType;
+        Address address = Address.create(
+                "서울특별시 종로구 테스트로 1",
+                "1111010100100010000",
+                "1111010100",
+                "11",
+                "11110",
+                new BigDecimal("37.566206"),
+                new BigDecimal("126.977706")
+        );
+        return complexRepository.save(HousingComplex.createFromMyHome(
+                name, identifier, supplyType, address, totalHouseholdCount, "LH", null,
+                "DISTRICT", "APARTMENT", "CORRIDOR", true, 80
+        ));
+    }
+
+    private HousingType saveType(HousingComplex complex, String name, String area) {
+        return housingTypeRepository.save(HousingType.createFromMyHome(
+                complex,
+                complex.getSourceComplexIdentifier() + ":" + name,
+                name,
+                new BigDecimal(area),
+                null
+        ));
+    }
+
+    private void saveCatalog(
+            int order,
+            String supplyType,
+            String area,
+            int complexCount,
+            int typeCount
+    ) {
+        saveCatalog(order, supplyType, area, complexCount, typeCount, "동삼2");
+    }
+
+    private void saveCatalog(
+            int order,
+            String supplyType,
+            String area,
+            int complexCount,
+            int typeCount,
+            String complexName
+    ) {
+        LhCatalogSource source = new LhCatalogSource(order, new LhCatalogSourceData(
+                "서울", supplyType, complexName, String.valueOf(complexCount), area,
+                String.valueOf(typeCount), null, null
+        ));
+        source.markCollectedAt(Instant.parse("2026-09-01T00:00:00Z"));
+        sourceRepository.save(source);
+    }
+
+    private void cleanUp() {
+        sourceRepository.deleteAll();
+        housingTypeRepository.deleteAll();
+        complexRepository.deleteAll();
+    }
+}

--- a/backend/src/test/java/com/toadzip/backend/ingest/service/LhHousingTypeHouseholdEnrichmentServiceTest.java
+++ b/backend/src/test/java/com/toadzip/backend/ingest/service/LhHousingTypeHouseholdEnrichmentServiceTest.java
@@ -146,6 +146,37 @@ class LhHousingTypeHouseholdEnrichmentServiceTest {
     }
 
     @Test
+    void 수기_등록한_주택형만_일치하면_LH_값으로_덮어쓰지_않는다() {
+        HousingComplex complex = saveComplex("동삼2", "NATIONAL_RENTAL", 120);
+        HousingType manualType = saveManualType(complex, "46A", "46.8000", 20);
+        saveCatalog(0, "국민임대", "46.8", 120, 70);
+
+        var report = service.enrichAll();
+
+        assertThat(report.updatedHousingTypeCount()).isZero();
+        assertThat(report.unmatchedHousingTypeCount()).isOne();
+        assertThat(housingTypeRepository.findById(manualType.getId()).orElseThrow().getTotalHouseholdCount())
+                .isEqualTo(20);
+    }
+
+    @Test
+    void 같은_면적의_수기_주택형이_있어도_마이홈_주택형은_보강한다() {
+        HousingComplex complex = saveComplex("동삼2", "NATIONAL_RENTAL", 120);
+        HousingType myHomeType = saveType(complex, "46A", "46.8000");
+        HousingType manualType = saveManualType(complex, "46A 수기", "46.8000", 20);
+        saveCatalog(0, "국민임대", "46.8", 120, 70);
+
+        var report = service.enrichAll();
+
+        assertThat(report.updatedHousingTypeCount()).isOne();
+        assertThat(report.unmatchedHousingTypeCount()).isZero();
+        assertThat(housingTypeRepository.findById(myHomeType.getId()).orElseThrow().getTotalHouseholdCount())
+                .isEqualTo(70);
+        assertThat(housingTypeRepository.findById(manualType.getId()).orElseThrow().getTotalHouseholdCount())
+                .isEqualTo(20);
+    }
+
+    @Test
     void 같은_LH_값으로_다시_보강하면_변경하지_않는다() {
         HousingComplex complex = saveComplex("동삼2", "NATIONAL_RENTAL", 120);
         saveType(complex, "46A", "46.8000");
@@ -181,6 +212,24 @@ class LhHousingTypeHouseholdEnrichmentServiceTest {
                 complex.getSourceComplexIdentifier() + ":" + name,
                 name,
                 new BigDecimal(area),
+                null
+        ));
+    }
+
+    private HousingType saveManualType(
+            HousingComplex complex,
+            String name,
+            String area,
+            int totalHouseholdCount
+    ) {
+        return housingTypeRepository.save(HousingType.create(
+                complex,
+                name,
+                new BigDecimal(area),
+                null,
+                totalHouseholdCount,
+                "https://example.com/floor-plan.png",
+                false,
                 null
         ));
     }

--- a/backend/src/test/java/com/toadzip/backend/ingest/service/LhHousingTypeHouseholdMatcherTest.java
+++ b/backend/src/test/java/com/toadzip/backend/ingest/service/LhHousingTypeHouseholdMatcherTest.java
@@ -39,6 +39,14 @@ class LhHousingTypeHouseholdMatcherTest {
     }
 
     @Test
+    void 단지_번호가_다르면_이름이_유사해도_매칭하지_않는다() {
+        HousingComplex complex = complex("문산선유2단지", "NATIONAL_RENTAL", 504);
+        LhHousingTypeHouseholdSource source = source("문산선유3단지", "국민임대", 504);
+
+        assertThat(matcher.findMatches(List.of(complex), source)).isEmpty();
+    }
+
+    @Test
     void 부분_일치_후보가_여러_개이면_이름_유사도가_가장_높은_후보만_선택한다() {
         HousingComplex expected = complex("강릉송정주공아파트", "NATIONAL_RENTAL", 623);
         HousingComplex other = complex("강릉송정타운아파트", "NATIONAL_RENTAL", 623);

--- a/backend/src/test/java/com/toadzip/backend/ingest/service/LhHousingTypeHouseholdMatcherTest.java
+++ b/backend/src/test/java/com/toadzip/backend/ingest/service/LhHousingTypeHouseholdMatcherTest.java
@@ -1,0 +1,89 @@
+package com.toadzip.backend.ingest.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.toadzip.backend.housing.domain.Address;
+import com.toadzip.backend.housing.domain.HousingComplex;
+import java.math.BigDecimal;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class LhHousingTypeHouseholdMatcherTest {
+
+    private final LhHousingTypeHouseholdMatcher matcher = new LhHousingTypeHouseholdMatcher();
+
+    @Test
+    void LH_이름이_마이홈_이름의_일부이면_매칭한다() {
+        HousingComplex complex = complex("강릉송정주공아파트", "NATIONAL_RENTAL", 623);
+        LhHousingTypeHouseholdSource source = source("강릉송정", "국민임대", 623);
+
+        assertThat(matcher.findMatches(List.of(complex), source)).containsExactly(complex);
+    }
+
+    @Test
+    void 출처별_장식어를_제외한_이름과_동일한_동호수이면_매칭한다() {
+        HousingComplex complex = complex("샘터마을2단지", "NATIONAL_RENTAL", 504);
+        LhHousingTypeHouseholdSource source = source("능곡샘터2", "국민임대", 504);
+
+        assertThat(matcher.findMatches(List.of(complex), source)).containsExactly(complex);
+    }
+
+    @Test
+    void 구조_조건이_하나여도_이름이_무관하면_매칭하지_않는다() {
+        HousingComplex complex = complex("운암주공6단지아파트", "PUBLIC_RENTAL_50Y", 571);
+        LhHousingTypeHouseholdSource source = source(
+                "공공임대50년 수도권 테스트 단지", "공공임대", 571
+        );
+
+        assertThat(matcher.findMatches(List.of(complex), source)).isEmpty();
+    }
+
+    @Test
+    void 부분_일치_후보가_여러_개이면_이름_유사도가_가장_높은_후보만_선택한다() {
+        HousingComplex expected = complex("강릉송정주공아파트", "NATIONAL_RENTAL", 623);
+        HousingComplex other = complex("강릉송정타운아파트", "NATIONAL_RENTAL", 623);
+        LhHousingTypeHouseholdSource source = source("강릉송정주공", "국민임대", 623);
+
+        assertThat(matcher.findMatches(List.of(other, expected), source)).containsExactly(expected);
+    }
+
+    private LhHousingTypeHouseholdSource source(
+            String name,
+            String supplyType,
+            int householdCount
+    ) {
+        return new LhHousingTypeHouseholdSource(
+                "강원특별자치도 강릉시",
+                supplyType,
+                name,
+                householdCount,
+                List.of()
+        );
+    }
+
+    private HousingComplex complex(String name, String supplyType, int householdCount) {
+        Address address = Address.create(
+                "강원특별자치도 강릉시 테스트로 1",
+                "4215010100100010000",
+                "4215010100",
+                "42",
+                "42150",
+                new BigDecimal("37.751853"),
+                new BigDecimal("128.876057")
+        );
+        return HousingComplex.createFromMyHome(
+                name,
+                name + ":" + supplyType,
+                supplyType,
+                address,
+                householdCount,
+                "LH",
+                null,
+                "DISTRICT",
+                "APARTMENT",
+                "CORRIDOR",
+                true,
+                100
+        );
+    }
+}


### PR DESCRIPTION
## 관련 이슈

Closes #79

## 작업 목적

- CSV 파일 없이 수집된 LH 임대 카탈로그를 기존 마이홈 단지와 연결합니다.
- 마이홈 단지 정보는 유지하면서 비어 있는 **주택형별 세대수**를 LH 원천 값으로 보강합니다.

## 작업 내역

- 지역, 공급유형, 단지 전체 세대수를 필수 조건으로 적용하고 **단지 이름**의 장식어를 제거(주공, 아파트, 단지)·부분·유사도 점수를 조합해 최적 후보를 선택했습니다.
- 동점 후보와 무관한 이름은 매칭하지 않으며, **여러 LH 원천 그룹이 같은 마이홈 단지에 연결되면 실패**합니다.
- 전용면적이 정확히 일치하는 마이홈 원천 주택형만 갱신하였습니다.

## 리뷰 포인트

- LH 카탈로그와 마이홈 사이에 공통 원천 식별자가 없어 **지역·공급유형·전체 세대수**를 선행 조건으로 두고 **단지 이름 매칭**은 최종 후보 선택에만 사용했습니다.
- 하나의 마이홈 단지에 여러 원천 그룹이 매칭되면 원천 순서로 값을 선택하지 않고 해당 그룹을 모두 실패 처리합니다.
- 이번 변경은 주택형별 세대수만 보강하며 마이홈 단지의 이름, 공급유형, 전체 세대수와 원천 식별자는 변경하지 않습니다.
- 매칭 방식·점수와 실패 사유의 영속화는 이번 범위에 포함하지 않았으며 현재는 구조화 로그와 응답 집계로 확인합니다.

## 검증 결과

- 테스트 방법: `./gradlew test --tests com.toadzip.backend.ingest.service.LhHousingTypeHouseholdEnrichmentServiceTest`
- 테스트 결과: 서비스 통합 테스트 9개 통과
- 테스트 방법: `./gradlew check --rerun-tasks`
- 테스트 결과: 전체 검사 통과 (`BUILD SUCCESSFUL`, 38초)
- 테스트 방법: `sh tests/harness/validate-harness-test.sh`, `sh tests/harness/validate-commit-message-test.sh`, `sh tests/harness/validate-pr-test.sh`, `sh scripts/validate-harness.sh`
- 테스트 결과: 저장소 하네스 검사 모두 통과
