### PR TITLE
feat(housing): 단지·공고 검색 필터 추가 (#81)

### DIFF
--- a/backend/src/main/java/com/toadzip/backend/housing/service/HousingComplexQueryService.java
+++ b/backend/src/main/java/com/toadzip/backend/housing/service/HousingComplexQueryService.java
@@ -266,24 +266,14 @@ public class HousingComplexQueryService {
         if (regionCode.isBlank()) {
             throw new InvalidRegionCodeException();
         }
-        if (regionCode.matches("[0-9]{2}")) {
-            return provinceSelection(regionCode);
-        }
-        if (regionCode.matches("[0-9]{5}")) {
-            return districtSelection(regionCode);
+        if (regionCode.matches("[0-9]{2}") || regionCode.matches("[0-9]{5}")) {
+            return filterSelection(regionCode);
         }
         throw new InvalidRegionCodeException();
     }
 
-    private RegionSelection provinceSelection(String provinceCode) {
-        if (!regionCodeResolver.isRegisteredProvinceCode(provinceCode)) {
-            throw new InvalidRegionCodeException();
-        }
-        return new RegionSelection(provinceCode, Set.of());
-    }
-
-    private RegionSelection districtSelection(String regionCode) {
-        Set<String> districtCodes = regionCodeResolver.equivalentCodes(regionCode)
+    private RegionSelection filterSelection(String regionCode) {
+        Set<String> districtCodes = regionCodeResolver.filterCodes(regionCode)
                 .orElseThrow(InvalidRegionCodeException::new);
         return new RegionSelection(null, districtCodes);
     }

--- a/backend/src/test/java/com/toadzip/backend/housing/service/HousingComplexListQueryTest.java
+++ b/backend/src/test/java/com/toadzip/backend/housing/service/HousingComplexListQueryTest.java
@@ -79,11 +79,17 @@ class HousingComplexListQueryTest {
         repository = mock(ComplexSummaryQueryRepository.class);
         regionCodeResolver = mock(RegionCodeResolver.class);
         when(regionCodeResolver.resolve("11", "11140")).thenReturn(Optional.of("서울특별시 중구"));
-        when(regionCodeResolver.isRegisteredProvinceCode("11")).thenReturn(true);
-        when(regionCodeResolver.equivalentCodes("12210"))
+        when(regionCodeResolver.filterCodes("11"))
+                .thenReturn(Optional.of(Set.of("11110", "11140")));
+        when(regionCodeResolver.filterCodes("12"))
+                .thenReturn(Optional.of(Set.of("12110", "12210", "29110", "46110")));
+        when(regionCodeResolver.filterCodes("12210"))
                 .thenReturn(Optional.of(Set.of("12210", "29110")));
-        when(regionCodeResolver.equivalentCodes("29110"))
-                .thenReturn(Optional.of(Set.of("12210", "29110")));
+        when(regionCodeResolver.equivalentCodes("41110"))
+                .thenReturn(Optional.of(Set.of("41110")));
+        when(regionCodeResolver.filterCodes("41110"))
+                .thenReturn(Optional.of(Set.of("41110", "41111", "41113")));
+        when(regionCodeResolver.filterCodes("99")).thenReturn(Optional.empty());
         HousingComplexSummaryMapper summaryMapper = new HousingComplexSummaryMapper(
                 new HousingComplexCodeMapper(),
                 regionCodeResolver
@@ -114,8 +120,8 @@ class HousingComplexListQueryTest {
         assertAll(
                 () -> assertEquals(BOUNDS, condition.bounds()),
                 () -> assertEquals("행복 단지", condition.keyword()),
-                () -> assertEquals("11", condition.provinceCode()),
-                () -> assertEquals(Set.of(), condition.cityCountyDistrictCodes()),
+                () -> assertNull(condition.provinceCode()),
+                () -> assertEquals(Set.of("11110", "11140"), condition.cityCountyDistrictCodes()),
                 () -> assertEquals(Set.of(RentalType.HAPPY_HOUSING, RentalType.NATIONAL_RENTAL),
                         condition.rentalTypes()),
                 () -> assertEquals(Set.of(ApplicationStatus.APPLYING, ApplicationStatus.CLOSED),
@@ -139,6 +145,29 @@ class HousingComplexListQueryTest {
     }
 
     @Test
+    void 통합_시도_지역은_현행과_과거_시군구_코드_집합으로_정규화한다() {
+        when(repository.findPage(any(), any(), any(), eq(21))).thenReturn(List.of());
+
+        service.getComplexes(fullSearchRequest("12"), null, null, 20);
+
+        ArgumentCaptor<HousingComplexSearchCondition> conditionCaptor =
+                ArgumentCaptor.forClass(HousingComplexSearchCondition.class);
+        verify(repository).findPage(
+                conditionCaptor.capture(),
+                eq(ComplexSort.LATEST_ANNOUNCEMENT),
+                isNull(),
+                eq(21)
+        );
+        assertAll(
+                () -> assertNull(conditionCaptor.getValue().provinceCode()),
+                () -> assertEquals(
+                        Set.of("12110", "12210", "29110", "46110"),
+                        conditionCaptor.getValue().cityCountyDistrictCodes()
+                )
+        );
+    }
+
+    @Test
     void 다섯자리_지역은_동등한_시군구_코드_집합으로_정규화한다() {
         when(repository.findPage(any(), any(), any(), eq(21))).thenReturn(List.of());
 
@@ -155,6 +184,27 @@ class HousingComplexListQueryTest {
         assertAll(
                 () -> assertNull(conditionCaptor.getValue().provinceCode()),
                 () -> assertEquals(Set.of("12210", "29110"),
+                        conditionCaptor.getValue().cityCountyDistrictCodes())
+        );
+    }
+
+    @Test
+    void 상위_시_지역은_하위_구를_포함하고_다른_시는_제외한다() {
+        when(repository.findPage(any(), any(), any(), eq(21))).thenReturn(List.of());
+
+        service.getComplexes(fullSearchRequest("41110"), null, null, 20);
+
+        ArgumentCaptor<HousingComplexSearchCondition> conditionCaptor =
+                ArgumentCaptor.forClass(HousingComplexSearchCondition.class);
+        verify(repository).findPage(
+                conditionCaptor.capture(),
+                eq(ComplexSort.LATEST_ANNOUNCEMENT),
+                isNull(),
+                eq(21)
+        );
+        assertAll(
+                () -> assertNull(conditionCaptor.getValue().provinceCode()),
+                () -> assertEquals(Set.of("41110", "41111", "41113"),
                         conditionCaptor.getValue().cityCountyDistrictCodes())
         );
     }

--- a/backend/src/test/java/com/toadzip/backend/housing/service/HousingComplexMapQueryTest.java
+++ b/backend/src/test/java/com/toadzip/backend/housing/service/HousingComplexMapQueryTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.toadzip.backend.announcement.domain.ApplicationStatus;
@@ -17,6 +18,7 @@ import com.toadzip.backend.housing.domain.RentalType;
 import com.toadzip.backend.housing.dto.request.HousingComplexSearchRequest;
 import com.toadzip.backend.housing.dto.response.HousingComplexMapItemResponse;
 import com.toadzip.backend.housing.dto.response.HousingComplexMapResponse;
+import com.toadzip.backend.housing.exception.InvalidRegionCodeException;
 import com.toadzip.backend.housing.repository.ComplexSummaryQueryRepository;
 import com.toadzip.backend.housing.repository.ComplexSummaryRow;
 import com.toadzip.backend.housing.repository.HousingComplexSearchCondition;
@@ -61,8 +63,15 @@ class HousingComplexMapQueryTest {
         repository = mock(ComplexSummaryQueryRepository.class);
         regionCodeResolver = mock(RegionCodeResolver.class);
         when(regionCodeResolver.resolve("11", "11140")).thenReturn(Optional.of("서울특별시 중구"));
-        when(regionCodeResolver.equivalentCodes("12210"))
+        when(regionCodeResolver.filterCodes("12"))
+                .thenReturn(Optional.of(Set.of("12110", "12210", "29110", "46110")));
+        when(regionCodeResolver.filterCodes("12210"))
                 .thenReturn(Optional.of(Set.of("12210", "29110")));
+        when(regionCodeResolver.equivalentCodes("41110"))
+                .thenReturn(Optional.of(Set.of("41110")));
+        when(regionCodeResolver.filterCodes("41110"))
+                .thenReturn(Optional.of(Set.of("41110", "41111", "41113")));
+        when(regionCodeResolver.filterCodes("99")).thenReturn(Optional.empty());
         HousingComplexCodeMapper codeMapper = new HousingComplexCodeMapper();
         HousingComplexSummaryMapper summaryMapper = new HousingComplexSummaryMapper(codeMapper);
         service = new HousingComplexQueryService(repository, summaryMapper, regionCodeResolver, CLOCK);
@@ -72,7 +81,7 @@ class HousingComplexMapQueryTest {
     void 목록과_같은_정규화로_지도_검색조건을_조립해_repository에_전달한다() {
         when(repository.findAll(any(HousingComplexSearchCondition.class))).thenReturn(List.of());
 
-        service.getComplexesForMap(fullSearchRequest());
+        service.getComplexesForMap(fullSearchRequest("12210"));
 
         ArgumentCaptor<HousingComplexSearchCondition> conditionCaptor =
                 ArgumentCaptor.forClass(HousingComplexSearchCondition.class);
@@ -100,6 +109,51 @@ class HousingComplexMapQueryTest {
                 () -> assertEquals(2026, condition.builtYearTo()),
                 () -> assertEquals(true, condition.hasElevator()),
                 () -> assertEquals(LocalDate.of(2026, 8, 27), condition.today())
+        );
+    }
+
+    @Test
+    void 통합_시도_지역은_현행과_과거_시군구_코드_집합으로_지도_검색조건에_전달한다() {
+        when(repository.findAll(any(HousingComplexSearchCondition.class))).thenReturn(List.of());
+
+        service.getComplexesForMap(fullSearchRequest("12"));
+
+        ArgumentCaptor<HousingComplexSearchCondition> conditionCaptor =
+                ArgumentCaptor.forClass(HousingComplexSearchCondition.class);
+        verify(repository).findAll(conditionCaptor.capture());
+        HousingComplexSearchCondition condition = conditionCaptor.getValue();
+        assertAll(
+                () -> assertNull(condition.provinceCode()),
+                () -> assertEquals(
+                        Set.of("12110", "12210", "29110", "46110"),
+                        condition.cityCountyDistrictCodes()
+                )
+        );
+    }
+
+    @Test
+    void 등록되지_않은_시도_지역은_repository_호출_전에_거부한다() {
+        assertThrows(
+                InvalidRegionCodeException.class,
+                () -> service.getComplexesForMap(fullSearchRequest("99"))
+        );
+
+        verifyNoInteractions(repository);
+    }
+
+    @Test
+    void 상위_시_지역은_하위_구를_포함하고_다른_시는_제외해_지도_검색조건으로_전달한다() {
+        when(repository.findAll(any(HousingComplexSearchCondition.class))).thenReturn(List.of());
+
+        service.getComplexesForMap(fullSearchRequest("41110"));
+
+        ArgumentCaptor<HousingComplexSearchCondition> conditionCaptor =
+                ArgumentCaptor.forClass(HousingComplexSearchCondition.class);
+        verify(repository).findAll(conditionCaptor.capture());
+        HousingComplexSearchCondition condition = conditionCaptor.getValue();
+        assertAll(
+                () -> assertNull(condition.provinceCode()),
+                () -> assertEquals(Set.of("41110", "41111", "41113"), condition.cityCountyDistrictCodes())
         );
     }
 
@@ -289,10 +343,10 @@ class HousingComplexMapQueryTest {
         assertThrows(ArithmeticException.class, () -> service.getComplexesForMap(baseSearchRequest()));
     }
 
-    private HousingComplexSearchRequest fullSearchRequest() {
+    private HousingComplexSearchRequest fullSearchRequest(String regionCode) {
         return new HousingComplexSearchRequest(
                 " 행복 단지 ",
-                "12210",
+                regionCode,
                 List.of(RentalType.HAPPY_HOUSING, RentalType.NATIONAL_RENTAL),
                 List.of(ApplicationStatus.APPLYING, ApplicationStatus.CLOSED),
                 List.of(AgencyCode.LH, AgencyCode.SH),

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -371,6 +371,29 @@ a {
   min-height: 0;
 }
 
+.housing-map-filter {
+  position: absolute;
+  z-index: 200;
+  top: 16px;
+  right: 16px;
+  bottom: 16px;
+  left: 16px;
+  pointer-events: none;
+}
+
+.housing-map-filter > section {
+  height: 100%;
+}
+
+.housing-map-filter > section > * {
+  pointer-events: auto;
+}
+
+.housing-explorer.has-detail .housing-map-filter {
+  visibility: hidden;
+  pointer-events: none;
+}
+
 .housing-map-notice {
   position: absolute;
   z-index: 4;
@@ -394,7 +417,7 @@ a {
 
 .housing-detail-layer {
   position: absolute;
-  z-index: 6;
+  z-index: 300;
   top: 14px;
   bottom: 14px;
   left: 14px;
@@ -839,6 +862,13 @@ a {
     border-bottom: 1px solid var(--border);
   }
 
+  .housing-map-filter {
+    top: 12px;
+    right: 12px;
+    bottom: 12px;
+    left: 12px;
+  }
+
   .housing-results__header {
     padding: 12px 16px 8px;
   }
@@ -857,7 +887,7 @@ a {
 
   .housing-detail-layer {
     position: fixed;
-    z-index: 20;
+    z-index: 300;
     top: 64px;
     right: 8px;
     bottom: 8px;

--- a/frontend/src/public-housing/DefaultPublicHousingExplorer.test.tsx
+++ b/frontend/src/public-housing/DefaultPublicHousingExplorer.test.tsx
@@ -1,4 +1,10 @@
-import { act, fireEvent, render, screen } from '@testing-library/react'
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from '@testing-library/react'
 import { MemoryRouter } from 'react-router'
 import { describe, expect, it, vi } from 'vitest'
 import type { PublicHousingRepository } from './api/publicHousingRepository.ts'
@@ -61,6 +67,23 @@ describe('LocalPublicHousingExplorer', () => {
       '로컬 mock 데이터를 불러오지 못했습니다.',
     )
     expect(screen.queryByRole('heading', { name: '공공임대주택' }))
+      .not.toBeInTheDocument()
+  })
+
+  it('로컬 snapshot의 지역 정보로 2단계 지역 선택을 제공한다', async () => {
+    const loadSnapshot = vi.fn().mockResolvedValue(SNAPSHOT)
+    renderLocalExplorer(loadSnapshot)
+
+    await screen.findByRole('heading', { name: '공공임대주택' })
+    fireEvent.click(screen.getByRole('button', { name: '지역 필터 열기' }))
+    fireEvent.change(screen.getByLabelText('시·도'), {
+      target: { value: '11' },
+    })
+
+    const districtSelect = await screen.findByLabelText('시·군·구')
+    expect(await within(districtSelect).findByRole('option', { name: '중구' }))
+      .toHaveValue('11140')
+    expect(screen.queryByText('세부 지역을 불러오지 못했습니다.'))
       .not.toBeInTheDocument()
   })
 })

--- a/frontend/src/public-housing/DefaultPublicHousingExplorer.tsx
+++ b/frontend/src/public-housing/DefaultPublicHousingExplorer.tsx
@@ -5,12 +5,17 @@ import {
   localPublicHousingMockEnabled,
 } from './api/defaultPublicHousingRepository.ts'
 import type { PublicHousingRepository } from './api/publicHousingRepository.ts'
+import type { PublicHousingRegionRepository } from './api/publicHousingRegionRepository.ts'
 import { decodePublicHousingSnapshot } from './api/snapshotPublicHousingRepository.ts'
+import { createSnapshotPublicHousingRegionRepository } from './api/snapshotPublicHousingRegionRepository.ts'
 import { PublicHousingExplorer } from './PublicHousingExplorer.tsx'
 
 type LocalSnapshotState =
   | { readonly status: 'loading' }
-  | { readonly status: 'ready' }
+  | {
+    readonly regionRepository: PublicHousingRegionRepository
+    readonly status: 'ready'
+  }
   | { readonly status: 'error' }
 
 interface LocalPublicHousingExplorerProps {
@@ -39,9 +44,13 @@ export function LocalPublicHousingExplorer({
     setState({ status: 'loading' })
     loadSnapshot()
       .then(decodePublicHousingSnapshot)
-      .then(() => {
+      .then((snapshot) => {
         if (active) {
-          setState({ status: 'ready' })
+          setState({
+            regionRepository:
+              createSnapshotPublicHousingRegionRepository(snapshot),
+            status: 'ready',
+          })
         }
       })
       .catch(() => {
@@ -58,6 +67,7 @@ export function LocalPublicHousingExplorer({
     return (
       <PublicHousingExplorer
         localMockEnabled
+        regionRepository={state.regionRepository}
         repository={repository}
       />
     )

--- a/frontend/src/public-housing/PublicHousingExplorer.layout.test.ts
+++ b/frontend/src/public-housing/PublicHousingExplorer.layout.test.ts
@@ -1,0 +1,61 @@
+/// <reference types="node" />
+
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+describe('public housing explorer layer order', () => {
+  it('지도 필터를 지도 컨트롤 위에, 상세 패널을 필터 위에 둔다', () => {
+    const stylesheet = readFileSync(
+      resolve(process.cwd(), 'src/index.css'),
+      'utf8',
+    )
+
+    expect(stylesheet).toMatch(
+      /\.housing-map-filter\s*\{[\s\S]*?z-index:\s*200;/,
+    )
+    expect(stylesheet).toMatch(
+      /\.housing-detail-layer\s*\{[\s\S]*?z-index:\s*300;/,
+    )
+    expect(stylesheet).not.toMatch(
+      /@media \(max-width: 767px\)[\s\S]*?\.housing-detail-layer\s*\{[\s\S]*?z-index:\s*(?:[0-9]|[1-9][0-9]|1[0-9]{2}|2[0-9]{2});/,
+    )
+  })
+
+  it('필터 form의 독립적인 높이 한도를 유지해 하단 적용 버튼을 클립하지 않는다', () => {
+    const stylesheet = readFileSync(
+      resolve(process.cwd(), 'src/index.css'),
+      'utf8',
+    )
+
+    expect(stylesheet).not.toMatch(
+      /\.housing-map-filter form\s*\{\s*max-height:\s*inherit;/,
+    )
+  })
+
+  it('필터 제목과 액션을 상단 한 줄에 두고 입력과 오류는 전체 폭을 쓴다', () => {
+    const stylesheet = readFileSync(
+      resolve(
+        process.cwd(),
+        'src/public-housing/filters/ComplexFilterToolbar.module.css',
+      ),
+      'utf8',
+    )
+
+    expect(stylesheet).toMatch(
+      /\.form\s*\{[\s\S]*?display:\s*grid;[\s\S]*?grid-template-areas:\s*'heading actions'\s*'fields fields'\s*'error error';/,
+    )
+    expect(stylesheet).toMatch(
+      /\.popoverHeading\s*\{[\s\S]*?grid-area:\s*heading;/,
+    )
+    expect(stylesheet).toMatch(
+      /\.fields\s*\{[\s\S]*?grid-area:\s*fields;/,
+    )
+    expect(stylesheet).toMatch(
+      /\.actions\s*\{[\s\S]*?grid-area:\s*actions;/,
+    )
+    expect(stylesheet).toMatch(
+      /\.error\s*\{[\s\S]*?grid-area:\s*error;/,
+    )
+  })
+})

--- a/frontend/src/public-housing/PublicHousingExplorer.test.tsx
+++ b/frontend/src/public-housing/PublicHousingExplorer.test.tsx
@@ -14,6 +14,7 @@ import {
   PublicHousingHttpError,
   type PublicHousingRepository,
 } from './api/publicHousingRepository.ts'
+import type { PublicHousingRegionRepository } from './api/publicHousingRegionRepository.ts'
 import type {
   AnnouncementDetail,
   AnnouncementListItem,
@@ -71,6 +72,39 @@ const SEOUL_CITY_HALL_CENTER = {
   longitude: 126.9783882,
 }
 
+const TEST_REGIONS = [
+  {
+    regionCode: '11',
+    provinceName: '서울특별시',
+    districtName: null,
+    displayName: '서울특별시 전체',
+  },
+  {
+    regionCode: '11140',
+    provinceName: '서울특별시',
+    districtName: '중구',
+    displayName: '서울특별시 중구',
+  },
+  {
+    regionCode: '41',
+    provinceName: '경기도',
+    districtName: null,
+    displayName: '경기도 전체',
+  },
+  {
+    regionCode: '41130',
+    provinceName: '경기도',
+    districtName: '성남시',
+    displayName: '경기도 성남시',
+  },
+  {
+    regionCode: '41135',
+    provinceName: '경기도',
+    districtName: '성남시 분당구',
+    displayName: '경기도 성남시 분당구',
+  },
+] as const
+
 afterEach(() => {
   vi.restoreAllMocks()
 })
@@ -117,6 +151,460 @@ describe('PublicHousingExplorer', () => {
       await screen.findByRole('heading', { name: '서울가람 행복주택' }),
     ).toBeVisible()
     expect(screen.getByText('1곳')).toBeVisible()
+  })
+
+  it('단지 필터는 지도 우상단의 토픽별 도구모음으로 공고 탭에서도 유지한다', () => {
+    const repository = createRepository()
+    renderExplorer(repository)
+
+    const complexFilter = screen.getByRole('toolbar', {
+      name: '단지 검색 필터',
+    })
+    expect(complexFilter.closest('main')).toHaveClass(
+      'housing-map-workspace',
+    )
+    expect(within(complexFilter).getAllByRole('button').map(
+      (button) => button.getAttribute('aria-label'),
+    )).toEqual([
+      '지역 필터 열기',
+      '임대유형 필터 열기',
+      '모집상태 필터 열기',
+      '공급기관 필터 열기',
+      '모집유형 필터 열기',
+      '가격 필터 열기',
+      '전용면적 필터 열기',
+      '준공년도 필터 열기',
+    ])
+    expect(within(screen.getByRole('complementary', {
+      name: '공공임대주택 검색 결과',
+    })).queryByRole('toolbar', {
+      name: '단지 검색 필터',
+    })).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('tab', { name: '공고 목록' }))
+
+    expect(complexFilter).toBeVisible()
+    expect(within(screen.getByRole('tabpanel', {
+      name: '공고 목록',
+    })).getByRole('region', {
+      name: '공고 검색 필터',
+    })).toBeVisible()
+  })
+
+  it('가격 토픽만 적용해도 기존 지역·임대유형 조건을 보존한다', async () => {
+    const repository = createRepository()
+    renderExplorer(
+      repository,
+      '/?complexRegionCode=11&complexRentalTypes=NATIONAL_RENTAL',
+    )
+    fireEvent.click(screen.getByRole('button', { name: '초기 영역 알림' }))
+    await screen.findByRole('heading', { name: '서울가람 행복주택' })
+
+    fireEvent.click(screen.getByRole('button', { name: '가격 필터 열기' }))
+    fireEvent.change(screen.getByRole('slider', {
+      name: '임대보증금 최솟값',
+    }), { target: { value: '100000000' } })
+    fireEvent.change(screen.getByRole('slider', {
+      name: '임대보증금 최댓값',
+    }), { target: { value: '200000000' } })
+    fireEvent.click(screen.getByRole('button', { name: '가격 필터 적용' }))
+
+    await waitFor(() => {
+      expect(repository.findMapComplexes).toHaveBeenCalledTimes(2)
+      expect(repository.findComplexPage).toHaveBeenCalledTimes(2)
+    })
+    expect(repository.findMapComplexes).toHaveBeenLastCalledWith(
+      INITIAL_BOUNDS,
+      expect.any(AbortSignal),
+      {
+        maxDeposit: 200_000_000,
+        minDeposit: 100_000_000,
+        regionCode: '11',
+        rentalTypes: ['NATIONAL_RENTAL'],
+      },
+    )
+    const search = new URLSearchParams(
+      screen.getByTestId('location-search').textContent ?? '',
+    )
+    expect(search.get('complexRegionCode')).toBe('11')
+    expect(search.getAll('complexRentalTypes')).toEqual(['NATIONAL_RENTAL'])
+    expect(search.get('complexMinDeposit')).toBe('100000000')
+    expect(search.get('complexMaxDeposit')).toBe('200000000')
+  })
+
+  it('단지 필터는 적용한 조건을 URL에 보존하고 지도와 단지 목록에 함께 전달한다', async () => {
+    const repository = createRepository()
+    renderExplorer(repository)
+    fireEvent.click(screen.getByRole('button', { name: '초기 영역 알림' }))
+    await screen.findByRole('heading', { name: '서울가람 행복주택' })
+
+    fireEvent.click(screen.getByRole('button', { name: '지역 필터 열기' }))
+    fireEvent.change(screen.getByLabelText('시·도'), {
+      target: { value: '11' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: '지역 필터 적용' }))
+
+    fireEvent.click(screen.getByRole('button', { name: '임대유형 필터 열기' }))
+    fireEvent.click(screen.getByRole('checkbox', { name: '국민임대' }))
+    fireEvent.click(screen.getByRole('button', { name: '임대유형 필터 적용' }))
+
+    fireEvent.click(screen.getByRole('button', { name: '모집상태 필터 열기' }))
+    fireEvent.click(screen.getByRole('checkbox', { name: '접수중' }))
+    fireEvent.click(screen.getByRole('button', { name: '모집상태 필터 적용' }))
+
+    fireEvent.click(screen.getByRole('button', { name: '공급기관 필터 열기' }))
+    fireEvent.click(screen.getByRole('checkbox', { name: 'LH' }))
+    fireEvent.click(screen.getByRole('button', { name: '공급기관 필터 적용' }))
+
+    fireEvent.click(screen.getByRole('button', { name: '모집유형 필터 열기' }))
+    fireEvent.click(screen.getByRole('checkbox', { name: '신규 모집' }))
+    fireEvent.click(screen.getByRole('button', { name: '모집유형 필터 적용' }))
+
+    fireEvent.click(screen.getByRole('button', { name: '가격 필터 열기' }))
+    fireEvent.change(screen.getByRole('slider', {
+      name: '임대보증금 최솟값',
+    }), {
+      target: { value: '100000000' },
+    })
+    fireEvent.change(screen.getByRole('slider', {
+      name: '임대보증금 최댓값',
+    }), {
+      target: { value: '300000000' },
+    })
+    fireEvent.change(screen.getByRole('slider', {
+      name: '월 임대료 최솟값',
+    }), {
+      target: { value: '100000' },
+    })
+    fireEvent.change(screen.getByRole('slider', {
+      name: '월 임대료 최댓값',
+    }), {
+      target: { value: '500000' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: '가격 필터 적용' }))
+
+    fireEvent.click(screen.getByRole('button', { name: '전용면적 필터 열기' }))
+    fireEvent.change(screen.getByRole('slider', {
+      name: '전용면적 최솟값',
+    }), {
+      target: { value: '33' },
+    })
+    fireEvent.change(screen.getByRole('slider', {
+      name: '전용면적 최댓값',
+    }), {
+      target: { value: '66' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: '전용면적 필터 적용' }))
+
+    await waitFor(() => {
+      expect(repository.findMapComplexes).toHaveBeenCalledTimes(8)
+      expect(repository.findComplexPage).toHaveBeenCalledTimes(8)
+    })
+    repository.findComplexPage
+      .mockResolvedValueOnce(complexPageWithNext())
+      .mockResolvedValueOnce(complexPageFor(18, '서울마루 국민임대'))
+
+    fireEvent.click(screen.getByRole('button', { name: '준공년도 필터 열기' }))
+    fireEvent.change(screen.getByLabelText('최소 준공년도'), {
+      target: { value: '2015' },
+    })
+    fireEvent.change(screen.getByLabelText('최대 준공년도'), {
+      target: { value: '2026' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: '준공년도 필터 적용' }))
+
+    const expectedFilters = {
+      agencyCodes: ['LH'],
+      applicationStatuses: ['APPLYING'],
+      builtYearFrom: 2015,
+      builtYearTo: 2026,
+      maxDeposit: 300_000_000,
+      maxExclusiveArea: 66,
+      maxMonthlyRent: 500_000,
+      minDeposit: 100_000_000,
+      minExclusiveArea: 33,
+      minMonthlyRent: 100_000,
+      recruitmentTypes: ['NEW'],
+      regionCode: '11',
+      rentalTypes: ['NATIONAL_RENTAL'],
+    }
+    await waitFor(() => {
+      expect(repository.findMapComplexes).toHaveBeenCalledTimes(9)
+      expect(repository.findComplexPage).toHaveBeenCalledTimes(9)
+    })
+    expect(repository.findMapComplexes).toHaveBeenLastCalledWith(
+      INITIAL_BOUNDS,
+      expect.any(AbortSignal),
+      expectedFilters,
+    )
+    expect(repository.findComplexPage).toHaveBeenLastCalledWith(
+      INITIAL_BOUNDS,
+      null,
+      20,
+      expect.any(AbortSignal),
+      expectedFilters,
+    )
+    const search = new URLSearchParams(
+      screen.getByTestId('location-search').textContent ?? '',
+    )
+    expect(search.get('complexRegionCode')).toBe('11')
+    expect(search.getAll('complexRentalTypes')).toEqual(['NATIONAL_RENTAL'])
+    expect(search.get('complexMinDeposit')).toBe('100000000')
+    expect(search.get('complexBuiltYearTo')).toBe('2026')
+
+    fireEvent.click(screen.getByRole('button', { name: '단지 더 보기' }))
+    expect(await screen.findByRole('heading', {
+      name: '서울마루 국민임대',
+    })).toBeVisible()
+    expect(repository.findComplexPage).toHaveBeenLastCalledWith(
+      INITIAL_BOUNDS,
+      'cursor-2',
+      20,
+      expect.any(AbortSignal),
+      expectedFilters,
+    )
+
+    fireEvent.click(screen.getByRole('tab', { name: '공고 목록' }))
+    fireEvent.click(screen.getByRole('tab', { name: '단지 목록' }))
+    fireEvent.click(screen.getByRole('button', { name: '지역 필터 열기' }))
+    expect(within(screen.getByRole('region', {
+      name: '지역 필터',
+    })).getByLabelText('시·도')).toHaveValue('11')
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    fireEvent.click(screen.getByRole('button', { name: '임대유형 필터 열기' }))
+    const rentalFilter = screen.getByRole('region', {
+      name: '임대유형 필터',
+    })
+    expect(within(rentalFilter).getByRole('checkbox', { name: '국민임대' }))
+      .toBeChecked()
+    fireEvent.click(within(rentalFilter).getByRole('button', {
+      name: '임대유형 필터 초기화',
+    }))
+    await waitFor(() => {
+      expect(repository.findMapComplexes).toHaveBeenCalledTimes(10)
+      expect(repository.findComplexPage).toHaveBeenCalledTimes(11)
+    })
+    const resetSearch = new URLSearchParams(
+      screen.getByTestId('location-search').textContent ?? '',
+    )
+    expect(resetSearch.get('complexRegionCode')).toBe('11')
+    expect(resetSearch.getAll('complexRentalTypes')).toEqual([])
+    expect(repository.findMapComplexes).toHaveBeenLastCalledWith(
+      INITIAL_BOUNDS,
+      expect.any(AbortSignal),
+      {
+        agencyCodes: ['LH'],
+        applicationStatuses: ['APPLYING'],
+        builtYearFrom: 2015,
+        builtYearTo: 2026,
+        maxDeposit: 300_000_000,
+        maxExclusiveArea: 66,
+        maxMonthlyRent: 500_000,
+        minDeposit: 100_000_000,
+        minExclusiveArea: 33,
+        minMonthlyRent: 100_000,
+        recruitmentTypes: ['NEW'],
+        regionCode: '11',
+      },
+    )
+  })
+
+  it('공유 URL의 시군구와 복수 조건을 폼에서 다시 적용해도 보존한다', async () => {
+    const repository = createRepository()
+    renderExplorer(
+      repository,
+      '/?complexRegionCode=41135'
+        + '&complexRentalTypes=NATIONAL_RENTAL'
+        + '&complexRentalTypes=HAPPY_HOUSING'
+        + '&complexAgencyCodes=LH'
+        + '&complexAgencyCodes=GH',
+    )
+    fireEvent.click(screen.getByRole('button', { name: '초기 영역 알림' }))
+    await screen.findByRole('heading', { name: '서울가람 행복주택' })
+
+    fireEvent.click(screen.getByRole('button', { name: '지역 필터 열기' }))
+    const regionFilter = screen.getByRole('region', {
+      name: '지역 필터',
+    })
+    expect(within(regionFilter).getByLabelText('시·도')).toHaveValue('41')
+    await waitFor(() => {
+      expect(within(regionFilter).getByLabelText('시·군·구'))
+        .toHaveValue('41135')
+    })
+    fireEvent.click(within(regionFilter).getByRole('button', {
+      name: '지역 필터 적용',
+    }))
+
+    fireEvent.click(screen.getByRole('button', { name: '임대유형 필터 열기' }))
+    const rentalFilter = screen.getByRole('region', {
+      name: '임대유형 필터',
+    })
+    expect(within(rentalFilter).getByRole('checkbox', {
+      name: '국민임대',
+    })).toBeChecked()
+    expect(within(rentalFilter).getByRole('checkbox', {
+      name: '행복주택',
+    })).toBeChecked()
+    fireEvent.click(within(rentalFilter).getByRole('button', {
+      name: '임대유형 필터 적용',
+    }))
+
+    fireEvent.click(screen.getByRole('button', { name: '공급기관 필터 열기' }))
+    const agencyFilter = screen.getByRole('region', {
+      name: '공급기관 필터',
+    })
+    expect(within(agencyFilter).getByRole('checkbox', { name: 'LH' }))
+      .toBeChecked()
+    expect(within(agencyFilter).getByRole('checkbox', { name: 'GH' }))
+      .toBeChecked()
+    fireEvent.click(within(agencyFilter).getByRole('button', {
+      name: '공급기관 필터 적용',
+    }))
+
+    const search = new URLSearchParams(
+      screen.getByTestId('location-search').textContent ?? '',
+    )
+    expect(search.get('complexRegionCode')).toBe('41135')
+    expect(new Set(search.getAll('complexRentalTypes'))).toEqual(new Set([
+      'NATIONAL_RENTAL',
+      'HAPPY_HOUSING',
+    ]))
+    expect(search.getAll('complexAgencyCodes')).toEqual(['LH', 'GH'])
+  })
+
+  it('지도 idle 대기 중 단지 필터를 바꿔도 이전 조건 요청이 덮어쓰지 않는다', async () => {
+    const repository = createRepository()
+    renderExplorer(repository)
+    fireEvent.click(screen.getByRole('button', { name: '초기 영역 알림' }))
+    await screen.findByRole('heading', { name: '서울가람 행복주택' })
+
+    fireEvent.click(screen.getByRole('button', { name: '다음 영역 알림' }))
+    fireEvent.click(screen.getByRole('button', { name: '임대유형 필터 열기' }))
+    fireEvent.click(screen.getByRole('checkbox', { name: '국민임대' }))
+    fireEvent.click(screen.getByRole('button', { name: '임대유형 필터 적용' }))
+
+    await waitFor(() => {
+      expect(repository.findMapComplexes).toHaveBeenCalledTimes(2)
+      expect(repository.findComplexPage).toHaveBeenCalledTimes(2)
+    })
+    await act(async () => new Promise((resolve) => {
+      window.setTimeout(resolve, 350)
+    }))
+
+    const filters = { rentalTypes: ['NATIONAL_RENTAL'] }
+    expect(repository.findMapComplexes).toHaveBeenCalledTimes(2)
+    expect(repository.findMapComplexes).toHaveBeenLastCalledWith(
+      NEXT_BOUNDS,
+      expect.any(AbortSignal),
+      filters,
+    )
+    expect(repository.findComplexPage).toHaveBeenCalledTimes(2)
+    expect(repository.findComplexPage).toHaveBeenLastCalledWith(
+      NEXT_BOUNDS,
+      null,
+      20,
+      expect.any(AbortSignal),
+      filters,
+    )
+  })
+
+  it('단지 범위 손잡이는 서로 교차하지 않도록 상대 값에 맞춘다', async () => {
+    const repository = createRepository()
+    renderExplorer(repository)
+    fireEvent.click(screen.getByRole('button', { name: '초기 영역 알림' }))
+    await screen.findByRole('heading', { name: '서울가람 행복주택' })
+    fireEvent.click(screen.getByRole('button', { name: '가격 필터 열기' }))
+    const minimum = screen.getByRole('slider', {
+      name: '임대보증금 최솟값',
+    })
+    const maximum = screen.getByRole('slider', {
+      name: '임대보증금 최댓값',
+    })
+    fireEvent.change(maximum, { target: { value: '100000000' } })
+    fireEvent.change(minimum, { target: { value: '300000000' } })
+
+    expect(minimum).toHaveValue('100000000')
+    expect(screen.getByRole('status', {
+      name: '임대보증금 선택 범위',
+    })).toHaveTextContent('1억 ~ 1억')
+
+    fireEvent.click(screen.getByRole('button', { name: '가격 필터 적용' }))
+    await waitFor(() => {
+      expect(repository.findMapComplexes).toHaveBeenCalledTimes(2)
+      expect(repository.findComplexPage).toHaveBeenCalledTimes(2)
+    })
+    expect(repository.findMapComplexes).toHaveBeenLastCalledWith(
+      INITIAL_BOUNDS,
+      expect.any(AbortSignal),
+      { maxDeposit: 100_000_000, minDeposit: 100_000_000 },
+    )
+    const search = new URLSearchParams(
+      screen.getByTestId('location-search').textContent ?? '',
+    )
+    expect(search.get('complexMinDeposit')).toBe('100000000')
+    expect(search.get('complexMaxDeposit')).toBe('100000000')
+  })
+
+  it('공고 필터는 단지 필터와 독립적으로 공고 목록에만 적용한다', async () => {
+    const repository = createRepository()
+    renderExplorer(repository)
+    fireEvent.click(screen.getByRole('button', { name: '초기 영역 알림' }))
+    await screen.findByRole('heading', { name: '서울가람 행복주택' })
+    fireEvent.click(screen.getByRole('tab', { name: '공고 목록' }))
+    await screen.findByRole('heading', {
+      name: '성남 청년 행복주택 입주자 모집 공고',
+    })
+    const complexRequestCount = repository.findComplexPage.mock.calls.length
+    const mapRequestCount = repository.findMapComplexes.mock.calls.length
+
+    fireEvent.click(screen.getByRole('button', { name: '공고 필터 열기' }))
+    const announcementFilter = screen.getByRole('region', {
+      name: '공고 검색 필터',
+    })
+    fireEvent.change(within(announcementFilter).getByLabelText('시·도'), {
+      target: { value: '41' },
+    })
+    fireEvent.click(screen.getByRole('checkbox', { name: '행복주택' }))
+    fireEvent.click(screen.getByRole('checkbox', { name: '접수예정' }))
+    fireEvent.click(screen.getByRole('checkbox', { name: 'GH' }))
+    fireEvent.click(screen.getByRole('checkbox', {
+      name: '예비입주자 모집',
+    }))
+    fireEvent.click(screen.getByRole('button', { name: '공고 필터 적용' }))
+
+    await waitFor(() => {
+      expect(repository.findAnnouncementPage).toHaveBeenCalledTimes(2)
+    })
+    expect(repository.findAnnouncementPage).toHaveBeenLastCalledWith(
+      null,
+      20,
+      expect.any(AbortSignal),
+      {
+        agencyCodes: ['GH'],
+        applicationStatuses: ['BEFORE_APPLICATION'],
+        recruitmentTypes: ['WAITLIST'],
+        regionCode: '41',
+        rentalTypes: ['HAPPY_HOUSING'],
+      },
+    )
+    expect(repository.findComplexPage).toHaveBeenCalledTimes(complexRequestCount)
+    expect(repository.findMapComplexes).toHaveBeenCalledTimes(mapRequestCount)
+    const search = new URLSearchParams(
+      screen.getByTestId('location-search').textContent ?? '',
+    )
+    expect(search.get('announcementRegionCode')).toBe('41')
+    expect(search.get('complexRegionCode')).toBeNull()
+
+    fireEvent.click(screen.getByRole('tab', { name: '단지 목록' }))
+    fireEvent.click(screen.getByRole('button', { name: '지역 필터 열기' }))
+    expect(within(screen.getByRole('region', {
+      name: '지역 필터',
+    })).getByLabelText('시·도')).toHaveValue('')
+    fireEvent.keyDown(document, { key: 'Escape' })
+    fireEvent.click(screen.getByRole('tab', { name: '공고 목록' }))
+    expect(within(announcementFilter).getByLabelText('시·도'))
+      .toHaveValue('41')
   })
 
   it('지도 응답의 임대 조건을 정보형 마커 표시값으로 변환한다', async () => {
@@ -1353,16 +1841,26 @@ function renderExplorer(
   repository: PublicHousingRepository,
   initialEntry = '/',
   localMockEnabled = false,
+  regionRepository = createRegionRepository(),
 ) {
   return render(
     <MemoryRouter initialEntries={[initialEntry]}>
       <PublicHousingExplorer
         localMockEnabled={localMockEnabled}
+        regionRepository={regionRepository}
         repository={repository}
       />
       <LocationSearch />
     </MemoryRouter>,
   )
+}
+
+function createRegionRepository(): PublicHousingRegionRepository {
+  return {
+    search: vi.fn().mockImplementation((keyword: string) => Promise.resolve(
+      TEST_REGIONS.filter(({ provinceName }) => provinceName === keyword),
+    )),
+  }
 }
 
 function LocationSearch() {

--- a/frontend/src/public-housing/PublicHousingExplorer.test.tsx
+++ b/frontend/src/public-housing/PublicHousingExplorer.test.tsx
@@ -527,7 +527,7 @@ describe('PublicHousingExplorer', () => {
     expect(minimum).toHaveValue('100000000')
     expect(screen.getByRole('status', {
       name: '임대보증금 선택 범위',
-    })).toHaveTextContent('1억 ~ 1억')
+    })).toHaveTextContent('1억~1억')
 
     fireEvent.click(screen.getByRole('button', { name: '가격 필터 적용' }))
     await waitFor(() => {
@@ -899,6 +899,11 @@ describe('PublicHousingExplorer', () => {
     expect(await screen.findByLabelText(
       '현재 불러온 단지 1곳 이상',
     )).toHaveTextContent('1곳 이상')
+    fireEvent.click(within(screen.getByRole('toolbar', {
+      name: '모바일 단지 검색 필터',
+    })).getByRole('button', { name: /^전체 단지 필터 열기/ }))
+    expect(screen.getByRole('button', { name: '단지 1곳 보기' }))
+      .toBeInTheDocument()
     expect(
       screen.getByRole('region', { name: '공공임대주택 지도' }),
     ).toHaveAttribute('aria-busy', 'false')

--- a/frontend/src/public-housing/PublicHousingExplorer.tsx
+++ b/frontend/src/public-housing/PublicHousingExplorer.tsx
@@ -14,8 +14,16 @@ import NaverMap, {
   type NaverMapMarker,
 } from '../maps/naver/NaverMap.tsx'
 import { defaultPublicHousingRepository } from './api/defaultPublicHousingRepository.ts'
-import { PublicHousingHttpError } from './api/publicHousingRepository.ts'
-import type { PublicHousingRepository } from './api/publicHousingRepository.ts'
+import {
+  type PublicHousingRegionRepository,
+  publicHousingRegionRepository,
+} from './api/publicHousingRegionRepository.ts'
+import {
+  type AnnouncementSearchFilters,
+  type ComplexSearchFilters,
+  PublicHousingHttpError,
+  type PublicHousingRepository,
+} from './api/publicHousingRepository.ts'
 import {
   type AnnouncementResultsState,
   useAnnouncementResults,
@@ -27,6 +35,16 @@ import {
   type HousingComplexCardData,
 } from './components/HousingComplexCard.tsx'
 import { HousingComplexDetailPanel } from './components/HousingComplexDetailPanel.tsx'
+import { ComplexFilterToolbar } from './filters/ComplexFilterToolbar.tsx'
+import { SearchFilterPanel } from './filters/SearchFilterPanel.tsx'
+import {
+  hasSearchFilters,
+  parseAnnouncementSearchFilters,
+  parseComplexSearchFilters,
+  searchFiltersSignature,
+  setAnnouncementSearchFilters,
+  setComplexSearchFilters,
+} from './filters/searchFilterLocation.ts'
 import {
   evaluateViewportRequest,
   type ViewportBlockReason,
@@ -132,6 +150,7 @@ interface PendingListFocus {
 
 export interface PublicHousingExplorerProps {
   localMockEnabled?: boolean
+  regionRepository?: PublicHousingRegionRepository
   repository?: PublicHousingRepository
 }
 
@@ -165,6 +184,7 @@ const INITIAL_ANNOUNCEMENT_DETAIL: AnnouncementDetailState = {
 
 export function PublicHousingExplorer({
   localMockEnabled = false,
+  regionRepository = publicHousingRegionRepository,
   repository = defaultPublicHousingRepository,
 }: PublicHousingExplorerProps) {
   const location = useLocation()
@@ -237,11 +257,29 @@ export function PublicHousingExplorer({
     () => parseMapLocation(new URLSearchParams(location.search)),
     [location.search],
   )
+  const complexFilters = useMemo(
+    () => parseComplexSearchFilters(new URLSearchParams(location.search)),
+    [location.search],
+  )
+  const announcementFilters = useMemo(
+    () => parseAnnouncementSearchFilters(new URLSearchParams(location.search)),
+    [location.search],
+  )
+  const complexFiltersKey = useMemo(
+    () => searchFiltersSignature(complexFilters),
+    [complexFilters],
+  )
+  const announcementFiltersKey = useMemo(
+    () => searchFiltersSignature(announcementFilters),
+    [announcementFilters],
+  )
   const announcementResults = useAnnouncementResults(
     repository,
     announcementListRequested
       && activeResultTab === 'announcements'
       && detailLocation.kind !== 'announcement',
+    announcementFilters,
+    announcementFiltersKey,
   )
 
   useEffect(() => {
@@ -556,6 +594,46 @@ export function PublicHousingExplorer({
     setActiveResultTab(tab)
   }, [detailLocation])
 
+  const applyComplexFilters = useCallback((filters: ComplexSearchFilters) => {
+    const currentSearch = new URLSearchParams(location.search)
+    const nextSearch = setComplexSearchFilters(currentSearch, filters)
+    if (nextSearch.toString() === currentSearch.toString()) {
+      return
+    }
+    navigate({
+      hash: location.hash,
+      pathname: location.pathname,
+      search: toSearchString(nextSearch),
+    }, { state: location.state })
+  }, [
+    location.hash,
+    location.pathname,
+    location.search,
+    location.state,
+    navigate,
+  ])
+
+  const applyAnnouncementFilters = useCallback((
+    filters: AnnouncementSearchFilters,
+  ) => {
+    const currentSearch = new URLSearchParams(location.search)
+    const nextSearch = setAnnouncementSearchFilters(currentSearch, filters)
+    if (nextSearch.toString() === currentSearch.toString()) {
+      return
+    }
+    navigate({
+      hash: location.hash,
+      pathname: location.pathname,
+      search: toSearchString(nextSearch),
+    }, { state: location.state })
+  }, [
+    location.hash,
+    location.pathname,
+    location.search,
+    location.state,
+    navigate,
+  ])
+
   const openComplexDetail = useCallback(
     (complexId: string) => openDetail('complexes', complexId),
     [openDetail],
@@ -644,7 +722,7 @@ export function PublicHousingExplorer({
       if (!decision.allowed) {
         return
       }
-      const signature = decision.boundsSignature
+      const signature = `${decision.boundsSignature}|${complexFiltersKey}`
       if (!force && pendingViewportSignatureRef.current === signature) {
         return
       }
@@ -676,15 +754,29 @@ export function PublicHousingExplorer({
         status: 'loading',
       }))
 
-      Promise.all([
-        repository.findMapComplexes(nextViewport.bounds, controller.signal),
-        repository.findComplexPage(
-          nextViewport.bounds,
-          null,
-          PAGE_SIZE,
-          controller.signal,
-        ),
-      ])
+      const mapRequest = hasSearchFilters(complexFilters)
+        ? repository.findMapComplexes(
+            nextViewport.bounds,
+            controller.signal,
+            complexFilters,
+          )
+        : repository.findMapComplexes(nextViewport.bounds, controller.signal)
+      const complexRequest = hasSearchFilters(complexFilters)
+        ? repository.findComplexPage(
+            nextViewport.bounds,
+            null,
+            PAGE_SIZE,
+            controller.signal,
+            complexFilters,
+          )
+        : repository.findComplexPage(
+            nextViewport.bounds,
+            null,
+            PAGE_SIZE,
+            controller.signal,
+          )
+
+      Promise.all([mapRequest, complexRequest])
         .then(([mapItems, page]) => {
           if (requestRevisionRef.current !== revision) {
             return
@@ -732,8 +824,24 @@ export function PublicHousingExplorer({
           }))
         })
     },
-    [repository],
+    [complexFilters, complexFiltersKey, repository],
   )
+
+  const previousComplexFiltersKeyRef = useRef(complexFiltersKey)
+
+  useEffect(() => {
+    if (previousComplexFiltersKeyRef.current === complexFiltersKey) {
+      return
+    }
+    previousComplexFiltersKeyRef.current = complexFiltersKey
+    if (viewportDebounceRef.current !== null) {
+      window.clearTimeout(viewportDebounceRef.current)
+      viewportDebounceRef.current = null
+    }
+    if (viewport !== null) {
+      applyViewport(viewport, true)
+    }
+  }, [applyViewport, complexFiltersKey, viewport])
 
   const handleViewportChange = useCallback(
     (nextViewport: ViewportSnapshot) => {
@@ -821,13 +929,22 @@ export function PublicHousingExplorer({
       status: 'loading-more',
     }))
 
-    repository
-      .findComplexPage(
-        appliedViewport.bounds,
-        cursor,
-        PAGE_SIZE,
-        controller.signal,
-      )
+    const request = hasSearchFilters(complexFilters)
+      ? repository.findComplexPage(
+          appliedViewport.bounds,
+          cursor,
+          PAGE_SIZE,
+          controller.signal,
+          complexFilters,
+        )
+      : repository.findComplexPage(
+          appliedViewport.bounds,
+          cursor,
+          PAGE_SIZE,
+          controller.signal,
+        )
+
+    request
       .then((page) => {
         if (requestRevisionRef.current !== revision) {
           return
@@ -852,7 +969,7 @@ export function PublicHousingExplorer({
           status: 'error',
         }))
       })
-  }, [appliedViewport, complexResults, repository])
+  }, [appliedViewport, complexFilters, complexResults, repository])
 
   const retryComplexResults = useCallback(() => {
     if (failedPaginationCursorRef.current) {
@@ -997,6 +1114,12 @@ export function PublicHousingExplorer({
           aria-labelledby="announcement-results-tab"
           hidden={activeResultTab !== 'announcements'}
         >
+            <SearchFilterPanel
+              filters={announcementFilters}
+              kind="announcement"
+              onApply={applyAnnouncementFilters}
+              regionRepository={regionRepository}
+            />
             <AnnouncementResultContent
               state={announcementResults.state}
               selectedAnnouncementId={selectedAnnouncementId}
@@ -1026,6 +1149,13 @@ export function PublicHousingExplorer({
       </aside>
 
       <main className="housing-map-workspace">
+        <div className="housing-map-filter">
+          <ComplexFilterToolbar
+            filters={complexFilters}
+            onApply={applyComplexFilters}
+            regionRepository={regionRepository}
+          />
+        </div>
         <NaverMap
           cameraTarget={activeMapTarget}
           dataBusy={!requestBlocked && mapResults.status === 'loading'}

--- a/frontend/src/public-housing/PublicHousingExplorer.tsx
+++ b/frontend/src/public-housing/PublicHousingExplorer.tsx
@@ -1029,6 +1029,10 @@ export function PublicHousingExplorer({
     announcementResults.state,
     requestBlocked,
   )
+  const complexFilterResultCountLabel = !requestBlocked
+    && mapResults.status === 'ready'
+    ? `${mapResults.items.length}곳`
+    : undefined
   const hasDetail = complexDetail.status !== 'closed'
     || announcementDetail.status !== 'closed'
   const selectedAnnouncementId = detailLocation.kind === 'announcement'
@@ -1154,6 +1158,7 @@ export function PublicHousingExplorer({
             filters={complexFilters}
             onApply={applyComplexFilters}
             regionRepository={regionRepository}
+            resultCountLabel={complexFilterResultCountLabel}
           />
         </div>
         <NaverMap

--- a/frontend/src/public-housing/announcements/useAnnouncementResults.test.tsx
+++ b/frontend/src/public-housing/announcements/useAnnouncementResults.test.tsx
@@ -1,6 +1,9 @@
 import { fireEvent, render, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
-import type { PublicHousingRepository } from '../api/publicHousingRepository.ts'
+import type {
+  AnnouncementSearchFilters,
+  PublicHousingRepository,
+} from '../api/publicHousingRepository.ts'
 import type {
   AnnouncementListItem,
   AnnouncementPage,
@@ -33,6 +36,26 @@ describe('useAnnouncementResults', () => {
     expect(screen.getByText('101')).toBeVisible()
   })
 
+  it('진행 중인 첫 페이지 요청을 탭을 닫을 때 취소하고 다시 열면 다시 요청한다', async () => {
+    const firstPage = deferred<AnnouncementPage>()
+    const repeatedFirstPage = deferred<AnnouncementPage>()
+    const repository = createRepository()
+    repository.findAnnouncementPage
+      .mockReturnValueOnce(firstPage.promise)
+      .mockReturnValueOnce(repeatedFirstPage.promise)
+    const { rerender } = render(<Harness enabled repository={repository} />)
+    const firstSignal = repository.findAnnouncementPage.mock.calls[0][2]
+
+    rerender(<Harness enabled={false} repository={repository} />)
+
+    expect(firstSignal.aborted).toBe(true)
+    rerender(<Harness enabled repository={repository} />)
+    expect(repository.findAnnouncementPage).toHaveBeenCalledTimes(2)
+
+    repeatedFirstPage.resolve(announcementPage(['201'], null, false))
+    expect(await screen.findByText('201')).toBeVisible()
+  })
+
   it('공고 전용 cursor로 다음 페이지를 이어 붙이고 중복 ID는 제거한다', async () => {
     const repository = createRepository()
     repository.findAnnouncementPage
@@ -50,6 +73,108 @@ describe('useAnnouncementResults', () => {
       20,
       expect.any(AbortSignal),
     )
+  })
+
+  it('진행 중인 다음 페이지 요청을 탭을 닫을 때 취소하고 기존 첫 페이지를 유지한다', async () => {
+    const nextPage = deferred<AnnouncementPage>()
+    const repository = createRepository()
+    repository.findAnnouncementPage
+      .mockResolvedValueOnce(announcementPage(['101'], 'next', true))
+      .mockReturnValueOnce(nextPage.promise)
+    const { rerender } = render(<Harness enabled repository={repository} />)
+    await screen.findByText('101')
+
+    fireEvent.click(screen.getByRole('button', { name: '더 보기' }))
+    const paginationSignal = repository.findAnnouncementPage.mock.calls[1][2]
+    rerender(<Harness enabled={false} repository={repository} />)
+
+    expect(paginationSignal.aborted).toBe(true)
+    expect(screen.getByText('ready')).toBeVisible()
+    rerender(<Harness enabled repository={repository} />)
+    expect(repository.findAnnouncementPage).toHaveBeenCalledTimes(2)
+    expect(screen.getByText('101')).toBeVisible()
+  })
+
+  it('필터를 다음 페이지에도 유지하고 변경 시 cursor 없이 다시 시작한다', async () => {
+    const repository = createRepository()
+    repository.findAnnouncementPage
+      .mockResolvedValueOnce(announcementPage(['101'], 'next', true))
+      .mockResolvedValueOnce(announcementPage(['102'], null, false))
+      .mockResolvedValueOnce(announcementPage(['201'], null, false))
+    const seoulFilters: AnnouncementSearchFilters = {
+      regionCode: '11',
+      rentalTypes: ['HAPPY_HOUSING'],
+    }
+    const gyeonggiFilters: AnnouncementSearchFilters = {
+      regionCode: '41',
+      rentalTypes: ['NATIONAL_RENTAL'],
+    }
+    const { rerender } = render(
+      <Harness
+        enabled
+        filters={seoulFilters}
+        repository={repository}
+      />,
+    )
+    await screen.findByText('101')
+
+    fireEvent.click(screen.getByRole('button', { name: '더 보기' }))
+
+    expect(await screen.findByText('102')).toBeVisible()
+    expect(repository.findAnnouncementPage).toHaveBeenLastCalledWith(
+      'next',
+      20,
+      expect.any(AbortSignal),
+      seoulFilters,
+    )
+
+    rerender(
+      <Harness
+        enabled
+        filters={gyeonggiFilters}
+        repository={repository}
+      />,
+    )
+
+    expect(await screen.findByText('201')).toBeVisible()
+    expect(screen.queryByText('101')).not.toBeInTheDocument()
+    expect(repository.findAnnouncementPage).toHaveBeenLastCalledWith(
+      null,
+      20,
+      expect.any(AbortSignal),
+      gyeonggiFilters,
+    )
+  })
+
+  it('필터 변경 뒤 첫 페이지가 실패해도 이전 필터의 공고를 표시하지 않는다', async () => {
+    const nextFiltersPage = deferred<AnnouncementPage>()
+    const repository = createRepository()
+    repository.findAnnouncementPage
+      .mockResolvedValueOnce(announcementPage(['101'], null, false))
+      .mockReturnValueOnce(nextFiltersPage.promise)
+    const { rerender } = render(
+      <Harness
+        enabled
+        filters={{ regionCode: '11' }}
+        repository={repository}
+      />,
+    )
+    await screen.findByText('101')
+
+    rerender(
+      <Harness
+        enabled
+        filters={{ regionCode: '41' }}
+        repository={repository}
+      />,
+    )
+
+    expect(screen.getByText('loading')).toBeVisible()
+    expect(screen.queryByText('101')).not.toBeInTheDocument()
+    nextFiltersPage.reject(new Error('새 공고 연결 실패'))
+
+    expect(await screen.findByText('새 공고 연결 실패')).toBeVisible()
+    expect(screen.queryByText('101')).not.toBeInTheDocument()
   })
 
   it('첫 페이지 오류는 다시 시도하고 성공한 결과로 교체한다', async () => {
@@ -91,14 +216,17 @@ describe('useAnnouncementResults', () => {
 
 function Harness({
   enabled,
+  filters = {},
   repository,
 }: {
   enabled: boolean
+  filters?: AnnouncementSearchFilters
   repository: PublicHousingRepository
 }) {
   const { loadMore, retry, state } = useAnnouncementResults(
     repository,
     enabled,
+    filters,
   )
   return (
     <section>
@@ -161,4 +289,14 @@ function announcementListItem(announcementId: string): AnnouncementListItem {
     viewCount: 0,
   }
   return { ...raw, announcementId, raw }
+}
+
+function deferred<T>() {
+  let reject: (reason?: unknown) => void = () => undefined
+  let resolve: (value: T) => void = () => undefined
+  const promise = new Promise<T>((nextResolve, nextReject) => {
+    resolve = nextResolve
+    reject = nextReject
+  })
+  return { promise, reject, resolve }
 }

--- a/frontend/src/public-housing/announcements/useAnnouncementResults.ts
+++ b/frontend/src/public-housing/announcements/useAnnouncementResults.ts
@@ -1,5 +1,12 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import type { PublicHousingRepository } from '../api/publicHousingRepository.ts'
+import type {
+  AnnouncementSearchFilters,
+  PublicHousingRepository,
+} from '../api/publicHousingRepository.ts'
+import {
+  hasSearchFilters,
+  searchFiltersSignature,
+} from '../filters/searchFilterLocation.ts'
 import type { AnnouncementListItem } from '../model/publicHousing.ts'
 
 const PAGE_SIZE = 20
@@ -30,31 +37,65 @@ const INITIAL_STATE: AnnouncementResultsState = {
 export function useAnnouncementResults(
   repository: PublicHousingRepository,
   enabled: boolean,
+  filters: AnnouncementSearchFilters = {},
+  filtersKey = searchFiltersSignature(filters),
 ) {
   const [state, setState] = useState<AnnouncementResultsState>(INITIAL_STATE)
-  const initialRequestStartedRef = useRef(false)
+  const requestedFiltersKeyRef = useRef<string | null>(null)
   const requestRevisionRef = useRef(0)
   const firstPageAbortRef = useRef<AbortController | null>(null)
   const paginationAbortRef = useRef<AbortController | null>(null)
 
+  const cancelInFlightRequests = useCallback((restorePaginationStatus = false) => {
+    const firstPageController = firstPageAbortRef.current
+    const paginationController = paginationAbortRef.current
+    if (firstPageController === null && paginationController === null) {
+      return false
+    }
+
+    requestRevisionRef.current += 1
+    firstPageController?.abort()
+    paginationController?.abort()
+    firstPageAbortRef.current = null
+    paginationAbortRef.current = null
+    if (restorePaginationStatus && paginationController !== null) {
+      setState((current) => current.status === 'loading-more'
+        ? { ...current, status: 'ready' }
+        : current)
+    }
+    return firstPageController !== null
+  }, [])
+
   const loadFirstPage = useCallback(() => {
-    firstPageAbortRef.current?.abort()
-    paginationAbortRef.current?.abort()
+    cancelInFlightRequests()
     const controller = new AbortController()
     const revision = requestRevisionRef.current + 1
     requestRevisionRef.current = revision
     firstPageAbortRef.current = controller
+    requestedFiltersKeyRef.current = filtersKey
     setState((current) => ({
       ...current,
       errorMessage: null,
       hasNext: false,
+      items: [],
       nextCursor: null,
       status: 'loading',
     }))
 
-    repository
-      .findAnnouncementPage(null, PAGE_SIZE, controller.signal)
+    const request = hasSearchFilters(filters)
+      ? repository.findAnnouncementPage(
+          null,
+          PAGE_SIZE,
+          controller.signal,
+          filters,
+        )
+      : repository.findAnnouncementPage(null, PAGE_SIZE, controller.signal)
+
+    request
       .then((page) => {
+        if (firstPageAbortRef.current === controller) {
+          firstPageAbortRef.current = null
+        }
         if (requestRevisionRef.current !== revision) {
           return
         }
@@ -67,6 +108,9 @@ export function useAnnouncementResults(
         })
       })
       .catch((error: unknown) => {
+        if (firstPageAbortRef.current === controller) {
+          firstPageAbortRef.current = null
+        }
         if (isAbortError(error) || requestRevisionRef.current !== revision) {
           return
         }
@@ -76,13 +120,14 @@ export function useAnnouncementResults(
           status: 'error',
         }))
       })
-  }, [repository])
+  }, [cancelInFlightRequests, filters, filtersKey, repository])
 
   const loadMore = useCallback(() => {
     if (
-      !state.hasNext ||
-      !state.nextCursor ||
-      state.status === 'loading-more'
+      !enabled
+      || !state.hasNext
+      || !state.nextCursor
+      || state.status === 'loading-more'
     ) {
       return
     }
@@ -97,9 +142,24 @@ export function useAnnouncementResults(
       status: 'loading-more',
     }))
 
-    repository
-      .findAnnouncementPage(state.nextCursor, PAGE_SIZE, controller.signal)
+    const request = hasSearchFilters(filters)
+      ? repository.findAnnouncementPage(
+          state.nextCursor,
+          PAGE_SIZE,
+          controller.signal,
+          filters,
+        )
+      : repository.findAnnouncementPage(
+          state.nextCursor,
+          PAGE_SIZE,
+          controller.signal,
+        )
+
+    request
       .then((page) => {
+        if (paginationAbortRef.current === controller) {
+          paginationAbortRef.current = null
+        }
         if (requestRevisionRef.current !== revision) {
           return
         }
@@ -112,6 +172,9 @@ export function useAnnouncementResults(
         }))
       })
       .catch((error: unknown) => {
+        if (paginationAbortRef.current === controller) {
+          paginationAbortRef.current = null
+        }
         if (isAbortError(error) || requestRevisionRef.current !== revision) {
           return
         }
@@ -121,22 +184,27 @@ export function useAnnouncementResults(
           status: 'error',
         }))
       })
-  }, [repository, state])
+  }, [enabled, filters, repository, state])
 
   useEffect(() => {
-    if (!enabled || initialRequestStartedRef.current) {
+    if (!enabled) {
+      const firstPageWasInFlight = cancelInFlightRequests(true)
+      if (firstPageWasInFlight) {
+        requestedFiltersKeyRef.current = null
+      }
       return
     }
-    initialRequestStartedRef.current = true
+    if (requestedFiltersKeyRef.current === filtersKey) {
+      return
+    }
     loadFirstPage()
-  }, [enabled, loadFirstPage])
+  }, [cancelInFlightRequests, enabled, filtersKey, loadFirstPage])
 
   useEffect(() => {
     return () => {
-      firstPageAbortRef.current?.abort()
-      paginationAbortRef.current?.abort()
+      cancelInFlightRequests()
     }
-  }, [])
+  }, [cancelInFlightRequests])
 
   const retry = state.items.length > 0 && state.nextCursor
     ? loadMore

--- a/frontend/src/public-housing/api/publicHousingRegionRepository.test.ts
+++ b/frontend/src/public-housing/api/publicHousingRegionRepository.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  districtRegionOptionsForProvince,
+  type PublicHousingRegion,
+} from '../model/publicHousingRegion.ts'
+import { createHttpPublicHousingRegionRepository } from './publicHousingRegionRepository.ts'
+
+describe('public housing region HTTP repository', () => {
+  it('encodes the keyword, forwards the signal, and decodes region items', async () => {
+    const fetcher = vi.fn().mockResolvedValue(jsonResponse({
+      data: {
+        items: [
+          {
+            regionCode: '41',
+            provinceName: '경기도',
+            districtName: null,
+            displayName: '경기도 전체',
+          },
+          {
+            regionCode: '41110',
+            provinceName: '경기도',
+            districtName: '수원시',
+            displayName: '경기도 수원시',
+          },
+        ],
+      },
+    }))
+    const repository = createHttpPublicHousingRegionRepository({
+      apiBaseUrl: 'https://api.example.test',
+      fetcher,
+    })
+    const controller = new AbortController()
+
+    await expect(repository.search('수원 +/구', controller.signal)).resolves.toEqual([
+      {
+        regionCode: '41',
+        provinceName: '경기도',
+        districtName: null,
+        displayName: '경기도 전체',
+      },
+      {
+        regionCode: '41110',
+        provinceName: '경기도',
+        districtName: '수원시',
+        displayName: '경기도 수원시',
+      },
+    ])
+    expect(fetcher).toHaveBeenCalledWith(
+      'https://api.example.test/api/v1/regions?keyword=%EC%88%98%EC%9B%90+%2B%2F%EA%B5%AC',
+      {
+        headers: { Accept: 'application/json' },
+        signal: controller.signal,
+      },
+    )
+  })
+
+  it('reports an HTTP failure separately from a response contract failure', async () => {
+    const fetcher = vi.fn().mockResolvedValue(jsonResponse({
+      code: 'INVALID_REQUEST',
+      message: '검색어를 확인해 주세요.',
+      traceId: 'region-trace-id',
+    }, 400))
+    const repository = createHttpPublicHousingRegionRepository({ fetcher })
+
+    await expect(repository.search(
+      ' ',
+      new AbortController().signal,
+    )).rejects.toMatchObject({
+      name: 'PublicHousingRegionHttpError',
+      message: '검색어를 확인해 주세요.',
+      status: 400,
+      code: 'INVALID_REQUEST',
+      traceId: 'region-trace-id',
+    })
+  })
+
+  it('keeps the HTTP status when the failure body is not JSON', async () => {
+    const repository = createHttpPublicHousingRegionRepository({
+      fetcher: vi.fn().mockResolvedValue(new Response('unavailable', {
+        status: 503,
+      })),
+    })
+
+    await expect(repository.search(
+      '수원',
+      new AbortController().signal,
+    )).rejects.toMatchObject({
+      name: 'PublicHousingRegionHttpError',
+      message: '지역 정보를 불러오지 못했습니다.',
+      status: 503,
+      code: null,
+      traceId: null,
+    })
+  })
+
+  it('does not trust fields in an HTTP failure body', async () => {
+    const repository = createHttpPublicHousingRegionRepository({
+      fetcher: vi.fn().mockResolvedValue(jsonResponse({
+        code: 7,
+        message: { text: 'wrong shape' },
+        traceId: false,
+      }, 422)),
+    })
+
+    await expect(repository.search(
+      '수원',
+      new AbortController().signal,
+    )).rejects.toMatchObject({
+      name: 'PublicHousingRegionHttpError',
+      message: '지역 정보를 불러오지 못했습니다.',
+      status: 422,
+      code: null,
+      traceId: null,
+    })
+  })
+
+  it.each([
+    ['missing data', {}, '$.data'],
+    ['non-object data', { data: null }, '$.data'],
+    ['missing items', { data: {} }, '$.data.items'],
+    ['non-array items', { data: { items: null } }, '$.data.items'],
+    [
+      'malformed region code',
+      { data: { items: [regionItem({ regionCode: '4111' })] } },
+      '$.data.items[0].regionCode',
+    ],
+    [
+      'non-string province name',
+      { data: { items: [regionItem({ provinceName: null })] } },
+      '$.data.items[0].provinceName',
+    ],
+    [
+      'non-nullable district name',
+      { data: { items: [regionItem({ districtName: 7 })] } },
+      '$.data.items[0].districtName',
+    ],
+    [
+      'empty display name',
+      { data: { items: [regionItem({ displayName: '' })] } },
+      '$.data.items[0].displayName',
+    ],
+  ])('rejects %s at its response path', async (_caseName, body, path) => {
+    const repository = createHttpPublicHousingRegionRepository({
+      fetcher: vi.fn().mockResolvedValue(jsonResponse(body)),
+    })
+
+    await expect(repository.search(
+      '수원',
+      new AbortController().signal,
+    )).rejects.toMatchObject({
+      name: 'PublicHousingRegionContractError',
+      path,
+    })
+  })
+
+  it('turns invalid success JSON into a response contract error', async () => {
+    const repository = createHttpPublicHousingRegionRepository({
+      fetcher: vi.fn().mockResolvedValue(new Response('not-json')),
+    })
+
+    await expect(repository.search(
+      '수원',
+      new AbortController().signal,
+    )).rejects.toMatchObject({
+      name: 'PublicHousingRegionContractError',
+      path: '$ (invalid JSON)',
+    })
+  })
+})
+
+describe('district region options for a province', () => {
+  it('removes aggregate and other-province rows without changing response order', () => {
+    const regions = [
+      region('41', '경기도', null),
+      region('41130', '경기도', '성남시'),
+      region('11140', '서울특별시', '중구'),
+      region('41110', '경기도', '수원시'),
+    ]
+
+    expect(districtRegionOptionsForProvince(regions, '41').map(
+      ({ regionCode }) => regionCode,
+    )).toEqual(['41130', '41110'])
+  })
+
+  it('keeps all 25 Seoul autonomous districts in response order', () => {
+    const seoulDistrictCodes = [
+      '11110', '11140', '11170', '11200', '11215',
+      '11230', '11260', '11290', '11305', '11320',
+      '11350', '11380', '11410', '11440', '11470',
+      '11500', '11530', '11545', '11560', '11590',
+      '11620', '11650', '11680', '11710', '11740',
+    ]
+    const regions = [
+      region('11', '서울특별시', null),
+      ...seoulDistrictCodes.map((code) =>
+        region(code, '서울특별시', `자치구-${code}`),
+      ),
+    ]
+
+    const options = districtRegionOptionsForProvince(regions, '11')
+
+    expect(options).toHaveLength(25)
+    expect(options.map(({ regionCode }) => regionCode)).toEqual([
+      '11110', '11140', '11170', '11200', '11215',
+      '11230', '11260', '11290', '11305', '11320',
+      '11350', '11380', '11410', '11440', '11470',
+      '11500', '11530', '11545', '11560', '11590',
+      '11620', '11650', '11680', '11710', '11740',
+    ])
+  })
+
+  it('keeps a parent city and hides only its matching child districts', () => {
+    const regions = [
+      region('41111', '경기도', '수원시 장안구'),
+      region('41110', '경기도', '수원시'),
+      region('41112', '경기도', '이름이 다른 구'),
+      region('41281', '경기도', '수원시 코드가 다른 구'),
+      region('41371', '경기도', '화성시'),
+      region('41372', '경기도', '화성시 동부구'),
+      region('41461', '경기도', '용인시 처인구'),
+    ]
+
+    expect(districtRegionOptionsForProvince(regions, '41').map(
+      ({ regionCode }) => regionCode,
+    )).toEqual(['41110', '41112', '41281', '41371', '41372', '41461'])
+  })
+})
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    headers: { 'Content-Type': 'application/json' },
+    status,
+  })
+}
+
+function regionItem(overrides: Record<string, unknown>) {
+  return {
+    regionCode: '41110',
+    provinceName: '경기도',
+    districtName: '수원시',
+    displayName: '경기도 수원시',
+    ...overrides,
+  }
+}
+
+function region(
+  regionCode: string,
+  provinceName: string,
+  districtName: string | null,
+): PublicHousingRegion {
+  return {
+    regionCode,
+    provinceName,
+    districtName,
+    displayName: districtName === null
+      ? `${provinceName} 전체`
+      : `${provinceName} ${districtName}`,
+  }
+}

--- a/frontend/src/public-housing/api/publicHousingRegionRepository.ts
+++ b/frontend/src/public-housing/api/publicHousingRegionRepository.ts
@@ -1,0 +1,217 @@
+import type { PublicHousingRegion } from '../model/publicHousingRegion.ts'
+
+const REGIONS_PATH = '/api/v1/regions'
+
+interface RepositoryOptions {
+  readonly apiBaseUrl?: string
+  readonly fetcher?: typeof globalThis.fetch
+}
+
+interface ErrorBody {
+  readonly code: string | null
+  readonly message: string | null
+  readonly traceId: string | null
+}
+
+export interface PublicHousingRegionRepository {
+  search(
+    keyword: string,
+    signal: AbortSignal,
+  ): Promise<readonly PublicHousingRegion[]>
+}
+
+export class PublicHousingRegionHttpError extends Error {
+  readonly status: number
+  readonly code: string | null
+  readonly traceId: string | null
+
+  constructor(status: number, body: ErrorBody) {
+    super(body.message ?? '지역 정보를 불러오지 못했습니다.')
+    this.name = 'PublicHousingRegionHttpError'
+    this.status = status
+    this.code = body.code
+    this.traceId = body.traceId
+  }
+}
+
+export class PublicHousingRegionContractError extends Error {
+  readonly path: string
+
+  constructor(path: string) {
+    super(`지역 API 응답 형식이 올바르지 않습니다: ${path}`)
+    this.name = 'PublicHousingRegionContractError'
+    this.path = path
+  }
+}
+
+export function createHttpPublicHousingRegionRepository(
+  options: RepositoryOptions = {},
+): PublicHousingRegionRepository {
+  const apiBaseUrl = options.apiBaseUrl ?? resolveApiBaseUrl()
+  const fetcher = options.fetcher ?? globalThis.fetch
+
+  return {
+    async search(keyword, signal) {
+      const search = new URLSearchParams({ keyword })
+      const response = await fetcher(
+        `${apiBaseUrl}${REGIONS_PATH}?${search.toString()}`,
+        {
+          headers: { Accept: 'application/json' },
+          signal,
+        },
+      )
+      if (!response.ok) {
+        throw new PublicHousingRegionHttpError(
+          response.status,
+          await decodeErrorBody(response),
+        )
+      }
+      try {
+        return decodePublicHousingRegionEnvelope(await response.json())
+      } catch (error) {
+        if (
+          error instanceof PublicHousingRegionContractError
+          || isAbortError(error)
+        ) {
+          throw error
+        }
+        throw new PublicHousingRegionContractError('$ (invalid JSON)')
+      }
+    },
+  }
+}
+
+export const publicHousingRegionRepository =
+  createHttpPublicHousingRegionRepository()
+
+async function decodeErrorBody(response: Response): Promise<ErrorBody> {
+  let value: unknown
+  try {
+    value = (await response.json()) as unknown
+  } catch (error) {
+    if (isAbortError(error)) {
+      throw error
+    }
+    return { code: null, message: null, traceId: null }
+  }
+
+  if (!isRecord(value)) {
+    return { code: null, message: null, traceId: null }
+  }
+  return {
+    code: nullableString(value.code),
+    message: nullableString(value.message),
+    traceId: nullableString(value.traceId),
+  }
+}
+
+export function decodePublicHousingRegionEnvelope(
+  value: unknown,
+): readonly PublicHousingRegion[] {
+  const envelope = recordAt(value, '$')
+  const data = recordAt(fieldAt(envelope, 'data', '$'), '$.data')
+  const items = arrayAt(fieldAt(data, 'items', '$.data'), '$.data.items')
+
+  return items.map((item, index) => decodeRegion(
+    item,
+    `$.data.items[${index}]`,
+  ))
+}
+
+function decodeRegion(value: unknown, path: string): PublicHousingRegion {
+  const region = recordAt(value, path)
+  return {
+    regionCode: regionCodeAt(
+      fieldAt(region, 'regionCode', path),
+      `${path}.regionCode`,
+    ),
+    provinceName: nonEmptyStringAt(
+      fieldAt(region, 'provinceName', path),
+      `${path}.provinceName`,
+    ),
+    districtName: nullableNonEmptyStringAt(
+      fieldAt(region, 'districtName', path),
+      `${path}.districtName`,
+    ),
+    displayName: nonEmptyStringAt(
+      fieldAt(region, 'displayName', path),
+      `${path}.displayName`,
+    ),
+  }
+}
+
+function recordAt(value: unknown, path: string): Record<string, unknown> {
+  if (!isRecord(value)) {
+    throw new PublicHousingRegionContractError(path)
+  }
+  return value
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function fieldAt(
+  value: Record<string, unknown>,
+  field: string,
+  path: string,
+): unknown {
+  if (!Object.hasOwn(value, field)) {
+    throw new PublicHousingRegionContractError(`${path}.${field}`)
+  }
+  return value[field]
+}
+
+function arrayAt(value: unknown, path: string): readonly unknown[] {
+  if (!Array.isArray(value)) {
+    throw new PublicHousingRegionContractError(path)
+  }
+  return value
+}
+
+function nonEmptyStringAt(value: unknown, path: string): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new PublicHousingRegionContractError(path)
+  }
+  return value
+}
+
+function nullableString(value: unknown): string | null {
+  return typeof value === 'string' ? value : null
+}
+
+function nullableNonEmptyStringAt(
+  value: unknown,
+  path: string,
+): string | null {
+  if (value === null) {
+    return null
+  }
+  return nonEmptyStringAt(value, path)
+}
+
+function regionCodeAt(value: unknown, path: string): string {
+  const regionCode = nonEmptyStringAt(value, path)
+  if (!/^(?:\d{2}|\d{5})$/.test(regionCode)) {
+    throw new PublicHousingRegionContractError(path)
+  }
+  return regionCode
+}
+
+function isAbortError(error: unknown) {
+  return typeof error === 'object'
+    && error !== null
+    && 'name' in error
+    && error.name === 'AbortError'
+}
+
+function resolveApiBaseUrl(): string {
+  const configuredApiBaseUrl = import.meta.env.VITE_API_BASE_URL
+  if (configuredApiBaseUrl) {
+    return configuredApiBaseUrl
+  }
+  if (import.meta.env.DEV) {
+    return 'http://localhost:8080'
+  }
+  return ''
+}

--- a/frontend/src/public-housing/api/publicHousingRepository.test.ts
+++ b/frontend/src/public-housing/api/publicHousingRepository.test.ts
@@ -19,6 +19,30 @@ const BOUNDS: MapBounds = {
   northEastLng: 127.1,
 }
 
+const COMPLEX_FILTERS = {
+  agencyCodes: ['LH'],
+  applicationStatuses: ['APPLYING'],
+  builtYearFrom: 2015,
+  builtYearTo: 2026,
+  maxDeposit: 30_000_000,
+  maxExclusiveArea: 60,
+  maxMonthlyRent: 500_000,
+  minDeposit: 1_000_000,
+  minExclusiveArea: 20,
+  minMonthlyRent: 100_000,
+  recruitmentTypes: ['NEW', 'WAITLIST'],
+  regionCode: '11',
+  rentalTypes: ['NATIONAL_RENTAL', 'HAPPY_HOUSING'],
+} as const
+
+const ANNOUNCEMENT_FILTERS = {
+  agencyCodes: ['SH'],
+  applicationStatuses: ['BEFORE_APPLICATION'],
+  recruitmentTypes: ['WAITLIST'],
+  regionCode: '11110',
+  rentalTypes: ['NATIONAL_RENTAL'],
+} as const
+
 const LIST_ITEM = {
   complexId: 17,
   thumbnailImageUrl: null,
@@ -222,6 +246,30 @@ afterEach(() => {
 })
 
 describe('공공주택 HTTP repository', () => {
+  it('공고 목록은 공고 전용 필터를 반복 query key로 직렬화한다', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse({ data: { items: [], nextCursor: null, hasNext: false } }),
+    )
+    const repository = createRepository(fetchMock, 'https://api.example.test')
+
+    await repository.findAnnouncementPage(
+      null,
+      20,
+      new AbortController().signal,
+      ANNOUNCEMENT_FILTERS,
+    )
+
+    const [requestUrl] = fetchMock.mock.calls[0] ?? []
+    const search = new URL(String(requestUrl)).searchParams
+    expect(search.get('regionCode')).toBe('11110')
+    expect(search.getAll('rentalTypes')).toEqual(['NATIONAL_RENTAL'])
+    expect(search.getAll('applicationStatuses')).toEqual([
+      'BEFORE_APPLICATION',
+    ])
+    expect(search.getAll('agencyCodes')).toEqual(['SH'])
+    expect(search.getAll('recruitmentTypes')).toEqual(['WAITLIST'])
+  })
+
   it('공고 목록은 지도 bounds 없이 opaque cursor, size와 AbortSignal로 조회한다', async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       jsonResponse({
@@ -585,6 +633,45 @@ describe('공공주택 HTTP repository', () => {
       },
     })
     expect(page.raw.items[0]).toEqual(LIST_ITEM)
+  })
+
+  it('단지 목록과 지도는 같은 단지 필터를 query로 직렬화한다', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(
+        jsonResponse({ data: { items: [], nextCursor: null, hasNext: false } }),
+      )
+      .mockResolvedValueOnce(jsonResponse({ data: { items: [] } }))
+    const repository = createRepository(fetchMock, 'https://api.example.test')
+    const signal = new AbortController().signal
+
+    await repository.findComplexPage(
+      BOUNDS,
+      null,
+      20,
+      signal,
+      COMPLEX_FILTERS,
+    )
+    await repository.findMapComplexes(BOUNDS, signal, COMPLEX_FILTERS)
+
+    for (const [requestUrl] of fetchMock.mock.calls) {
+      const search = new URL(String(requestUrl)).searchParams
+      expect(search.get('regionCode')).toBe('11')
+      expect(search.getAll('rentalTypes')).toEqual([
+        'NATIONAL_RENTAL',
+        'HAPPY_HOUSING',
+      ])
+      expect(search.getAll('applicationStatuses')).toEqual(['APPLYING'])
+      expect(search.getAll('agencyCodes')).toEqual(['LH'])
+      expect(search.getAll('recruitmentTypes')).toEqual(['NEW', 'WAITLIST'])
+      expect(search.get('minDeposit')).toBe('1000000')
+      expect(search.get('maxDeposit')).toBe('30000000')
+      expect(search.get('minMonthlyRent')).toBe('100000')
+      expect(search.get('maxMonthlyRent')).toBe('500000')
+      expect(search.get('minExclusiveArea')).toBe('20')
+      expect(search.get('maxExclusiveArea')).toBe('60')
+      expect(search.get('builtYearFrom')).toBe('2015')
+      expect(search.get('builtYearTo')).toBe('2026')
+    }
   })
 
   it('지도 응답 순서를 보존하되 범위를 벗어난 개별 좌표만 제외한다', async () => {

--- a/frontend/src/public-housing/api/publicHousingRepository.ts
+++ b/frontend/src/public-housing/api/publicHousingRepository.ts
@@ -37,16 +37,57 @@ interface ErrorBody {
   readonly traceId: string | null
 }
 
+export type RentalTypeFilter =
+  | 'HAPPY_HOUSING'
+  | 'NATIONAL_RENTAL'
+  | 'PERMANENT_RENTAL'
+  | 'PUBLIC_RENTAL_50Y'
+  | 'INTEGRATED_PUBLIC_RENTAL'
+  | 'REDEVELOPMENT_RENTAL'
+  | 'ETC'
+
+export type ApplicationStatusFilter =
+  | 'BEFORE_APPLICATION'
+  | 'APPLYING'
+  | 'CLOSED'
+
+export type AgencyCodeFilter = 'LH' | 'SH' | 'GH' | 'ETC'
+
+export type RecruitmentTypeFilter = 'NEW' | 'WAITLIST' | 'ETC'
+
+export interface SharedSearchFilters {
+  readonly agencyCodes?: readonly AgencyCodeFilter[]
+  readonly applicationStatuses?: readonly ApplicationStatusFilter[]
+  readonly recruitmentTypes?: readonly RecruitmentTypeFilter[]
+  readonly regionCode?: string | null
+  readonly rentalTypes?: readonly RentalTypeFilter[]
+}
+
+export interface ComplexSearchFilters extends SharedSearchFilters {
+  readonly builtYearFrom?: number | null
+  readonly builtYearTo?: number | null
+  readonly maxDeposit?: number | null
+  readonly maxExclusiveArea?: number | null
+  readonly maxMonthlyRent?: number | null
+  readonly minDeposit?: number | null
+  readonly minExclusiveArea?: number | null
+  readonly minMonthlyRent?: number | null
+}
+
+export type AnnouncementSearchFilters = SharedSearchFilters
+
 export interface PublicHousingRepository {
   findComplexPage(
     bounds: MapBounds,
     cursor: string | null,
     size: number,
     signal: AbortSignal,
+    filters?: ComplexSearchFilters,
   ): Promise<ComplexPage>
   findMapComplexes(
     bounds: MapBounds,
     signal: AbortSignal,
+    filters?: ComplexSearchFilters,
   ): Promise<readonly MapComplex[]>
   findComplexDetail(
     complexId: string,
@@ -56,6 +97,7 @@ export interface PublicHousingRepository {
     cursor: string | null,
     size: number,
     signal: AbortSignal,
+    filters?: AnnouncementSearchFilters,
   ): Promise<AnnouncementPage>
   findAnnouncementDetail(
     announcementId: string,
@@ -84,9 +126,10 @@ export function createHttpPublicHousingRepository(
   const fetcher = options.fetcher ?? globalThis.fetch
 
   return {
-    async findComplexPage(bounds, cursor, size, signal) {
+    async findComplexPage(bounds, cursor, size, signal, filters = {}) {
       validatePageSize(size)
       const search = boundsSearchParams(bounds)
+      appendComplexFilters(search, filters)
       if (cursor !== null) {
         search.set('cursor', cursor)
       }
@@ -100,8 +143,9 @@ export function createHttpPublicHousingRepository(
       return toComplexPage(decodeComplexPageEnvelope(payload))
     },
 
-    async findMapComplexes(bounds, signal) {
+    async findMapComplexes(bounds, signal, filters = {}) {
       const search = boundsSearchParams(bounds)
+      appendComplexFilters(search, filters)
       const payload = await requestJson(
         fetcher,
         `${apiBaseUrl}${COMPLEXES_PATH}/map?${search.toString()}`,
@@ -120,9 +164,10 @@ export function createHttpPublicHousingRepository(
       return toComplexDetail(decodeComplexDetailEnvelope(payload))
     },
 
-    async findAnnouncementPage(cursor, size, signal) {
+    async findAnnouncementPage(cursor, size, signal, filters = {}) {
       validatePageSize(size)
       const search = new URLSearchParams({ size: String(size) })
+      appendSharedFilters(search, filters)
       if (cursor !== null) {
         search.set('cursor', cursor)
       }
@@ -210,6 +255,56 @@ function boundsSearchParams(bounds: MapBounds): URLSearchParams {
     northEastLat: String(bounds.northEastLat),
     northEastLng: String(bounds.northEastLng),
   })
+}
+
+function appendComplexFilters(
+  search: URLSearchParams,
+  filters: ComplexSearchFilters,
+) {
+  appendSharedFilters(search, filters)
+  appendOptionalNumber(search, 'minDeposit', filters.minDeposit)
+  appendOptionalNumber(search, 'maxDeposit', filters.maxDeposit)
+  appendOptionalNumber(search, 'minMonthlyRent', filters.minMonthlyRent)
+  appendOptionalNumber(search, 'maxMonthlyRent', filters.maxMonthlyRent)
+  appendOptionalNumber(search, 'minExclusiveArea', filters.minExclusiveArea)
+  appendOptionalNumber(search, 'maxExclusiveArea', filters.maxExclusiveArea)
+  appendOptionalNumber(search, 'builtYearFrom', filters.builtYearFrom)
+  appendOptionalNumber(search, 'builtYearTo', filters.builtYearTo)
+}
+
+function appendSharedFilters(
+  search: URLSearchParams,
+  filters: SharedSearchFilters,
+) {
+  if (filters.regionCode) {
+    search.set('regionCode', filters.regionCode)
+  }
+  appendRepeated(search, 'rentalTypes', filters.rentalTypes)
+  appendRepeated(
+    search,
+    'applicationStatuses',
+    filters.applicationStatuses,
+  )
+  appendRepeated(search, 'agencyCodes', filters.agencyCodes)
+  appendRepeated(search, 'recruitmentTypes', filters.recruitmentTypes)
+}
+
+function appendRepeated(
+  search: URLSearchParams,
+  key: string,
+  values: readonly string[] | undefined,
+) {
+  values?.forEach((value) => search.append(key, value))
+}
+
+function appendOptionalNumber(
+  search: URLSearchParams,
+  key: string,
+  value: number | null | undefined,
+) {
+  if (value !== null && value !== undefined) {
+    search.set(key, String(value))
+  }
 }
 
 function validateBounds(bounds: MapBounds) {

--- a/frontend/src/public-housing/api/snapshotPublicHousingRegionRepository.test.ts
+++ b/frontend/src/public-housing/api/snapshotPublicHousingRegionRepository.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { districtRegionOptionsForProvince } from '../model/publicHousingRegion.ts'
+import { MINIMAL_PUBLIC_HOUSING_SNAPSHOT } from '../testing/minimalPublicHousingSnapshot.ts'
+import { createSnapshotPublicHousingRegionRepository } from './snapshotPublicHousingRegionRepository.ts'
+
+describe('snapshot public housing region repository', () => {
+  it('snapshot 표시명과 하위 코드로 도·상위 시 선택지를 복원한다', async () => {
+    const snapshot = {
+      ...MINIMAL_PUBLIC_HOUSING_SNAPSHOT,
+      complexRegionCodes: { 17: '41135' },
+      regionCodeDescendants: {
+        41130: ['41131', '41133', '41135', '41137', '41139'],
+      },
+      complexListItems: [{
+        ...MINIMAL_PUBLIC_HOUSING_SNAPSHOT.complexListItems[0],
+        regionName: '경기도 성남시 분당구',
+      }],
+    }
+    const repository = createSnapshotPublicHousingRegionRepository(snapshot)
+
+    const regions = await repository.search(
+      '경기도',
+      new AbortController().signal,
+    )
+
+    expect(regions).toEqual(expect.arrayContaining([
+      {
+        regionCode: '41130',
+        provinceName: '경기도',
+        districtName: '성남시',
+        displayName: '경기도 성남시',
+      },
+      {
+        regionCode: '41135',
+        provinceName: '경기도',
+        districtName: '성남시 분당구',
+        displayName: '경기도 성남시 분당구',
+      },
+    ]))
+    expect(districtRegionOptionsForProvince(regions, '41').map(
+      ({ regionCode }) => regionCode,
+    )).toEqual(['41130'])
+  })
+})

--- a/frontend/src/public-housing/api/snapshotPublicHousingRegionRepository.ts
+++ b/frontend/src/public-housing/api/snapshotPublicHousingRegionRepository.ts
@@ -1,0 +1,127 @@
+import type { PublicHousingRegion } from '../model/publicHousingRegion.ts'
+import { provinceNameForRegionCode } from '../model/publicHousingRegion.ts'
+import type { PublicHousingRegionRepository } from './publicHousingRegionRepository.ts'
+import type { PublicHousingSnapshotV1 } from './snapshotPublicHousingRepository.ts'
+
+export function createSnapshotPublicHousingRegionRepository(
+  snapshot: PublicHousingSnapshotV1,
+): PublicHousingRegionRepository {
+  const regions = collectSnapshotRegions(snapshot)
+
+  return {
+    async search(keyword, signal) {
+      throwIfAborted(signal)
+      const normalizedKeyword = keyword.trim().toLocaleLowerCase('ko-KR')
+      if (normalizedKeyword.length === 0) {
+        return regions
+      }
+      return regions.filter((region) => [
+        region.regionCode,
+        region.provinceName,
+        region.districtName ?? '',
+        region.displayName,
+      ].some((value) => value.toLocaleLowerCase('ko-KR').includes(
+        normalizedKeyword,
+      )))
+    },
+  }
+}
+
+function collectSnapshotRegions(
+  snapshot: PublicHousingSnapshotV1,
+): readonly PublicHousingRegion[] {
+  const regionsByCode = new Map<string, PublicHousingRegion>()
+  const complexNamesById = new Map(snapshot.complexListItems.map((item) => [
+    String(item.complexId),
+    item.regionName,
+  ]))
+
+  for (const [complexId, regionCode] of Object.entries(
+    snapshot.complexRegionCodes,
+  )) {
+    addNamedRegion(regionsByCode, regionCode, complexNamesById.get(complexId))
+  }
+
+  const announcementRegionsById = new Map(
+    snapshot.announcementListItems.map((item) => [
+      String(item.announcementId),
+      item.regionNames,
+    ]),
+  )
+  for (const [announcementId, regionCodes] of Object.entries(
+    snapshot.announcementRegionCodes,
+  )) {
+    const regionNames = announcementRegionsById.get(announcementId) ?? []
+    if (regionCodes.length === regionNames.length) {
+      regionCodes.forEach((regionCode, index) => {
+        addNamedRegion(regionsByCode, regionCode, regionNames[index])
+      })
+      continue
+    }
+
+    for (const regionCode of regionCodes) {
+      const provinceName = provinceNameForRegionCode(regionCode)
+      const matchingNames = regionNames.filter((regionName) =>
+        provinceName !== null && regionName.startsWith(provinceName),
+      )
+      if (matchingNames.length === 1) {
+        addNamedRegion(regionsByCode, regionCode, matchingNames[0])
+      }
+    }
+  }
+
+  for (const [parentCode, descendantCodes] of Object.entries(
+    snapshot.regionCodeDescendants,
+  )) {
+    if (regionsByCode.has(parentCode)) {
+      continue
+    }
+    const child = descendantCodes
+      .map((regionCode) => regionsByCode.get(regionCode))
+      .find((region) => region?.districtName?.includes(' '))
+    const parentDistrictName = child?.districtName?.split(' ')[0]
+    if (child !== undefined && parentDistrictName !== undefined) {
+      regionsByCode.set(parentCode, {
+        regionCode: parentCode,
+        provinceName: child.provinceName,
+        districtName: parentDistrictName,
+        displayName: `${child.provinceName} ${parentDistrictName}`,
+      })
+    }
+  }
+
+  return [...regionsByCode.values()].sort((left, right) =>
+    left.regionCode.localeCompare(right.regionCode),
+  )
+}
+
+function addNamedRegion(
+  regionsByCode: Map<string, PublicHousingRegion>,
+  regionCode: string,
+  regionName: string | null | undefined,
+) {
+  if (regionsByCode.has(regionCode) || regionName === null
+    || regionName === undefined) {
+    return
+  }
+  const provinceName = provinceNameForRegionCode(regionCode)
+  if (provinceName === null || !regionName.startsWith(provinceName)) {
+    return
+  }
+  const districtName = regionName.slice(provinceName.length).trim()
+  if (districtName.length === 0) {
+    return
+  }
+  regionsByCode.set(regionCode, {
+    regionCode,
+    provinceName,
+    districtName,
+    displayName: `${provinceName} ${districtName}`,
+  })
+}
+
+function throwIfAborted(signal: AbortSignal) {
+  if (signal.aborted) {
+    throw new DOMException('The operation was aborted.', 'AbortError')
+  }
+}

--- a/frontend/src/public-housing/api/snapshotPublicHousingRepository.test.ts
+++ b/frontend/src/public-housing/api/snapshotPublicHousingRepository.test.ts
@@ -177,6 +177,110 @@ describe('local public housing snapshot repository', () => {
     }, signal)).resolves.toEqual([])
   })
 
+  it('applies the same filters to local snapshot maps, complexes and announcements', async () => {
+    const repository = createSnapshotPublicHousingRepository(
+      snapshotWithSecondScenario(),
+    )
+    const signal = new AbortController().signal
+    const complexFilters = {
+      agencyCodes: ['GH'],
+      applicationStatuses: ['BEFORE_APPLICATION'],
+      builtYearFrom: 2018,
+      builtYearTo: 2018,
+      maxDeposit: 25_000_000,
+      maxExclusiveArea: 55,
+      maxMonthlyRent: 230_000,
+      minDeposit: 15_000_000,
+      minExclusiveArea: 45,
+      minMonthlyRent: 210_000,
+      recruitmentTypes: ['WAITLIST'],
+      regionCode: '41135',
+      rentalTypes: ['NATIONAL_RENTAL'],
+    } as const
+
+    const [mapItems, complexPage, announcementPage] = await Promise.all([
+      repository.findMapComplexes(BOUNDS, signal, complexFilters),
+      repository.findComplexPage(BOUNDS, null, 20, signal, complexFilters),
+      repository.findAnnouncementPage(null, 20, signal, {
+        agencyCodes: ['GH'],
+        applicationStatuses: ['BEFORE_APPLICATION'],
+        recruitmentTypes: ['WAITLIST'],
+        regionCode: '41135',
+        rentalTypes: ['NATIONAL_RENTAL'],
+      }),
+    ])
+
+    expect(mapItems.map((item) => item.complexId)).toEqual(['18'])
+    expect(complexPage.items.map((item) => item.complexId)).toEqual(['18'])
+    expect(announcementPage.items.map((item) => item.announcementId))
+      .toEqual(['202'])
+
+    await expect(repository.findComplexPage(BOUNDS, null, 20, signal, {
+      regionCode: '41110',
+    })).resolves.toMatchObject({ items: [] })
+    await expect(repository.findComplexPage(BOUNDS, null, 20, signal, {
+      minExclusiveArea: 52,
+      maxExclusiveArea: 55,
+    })).resolves.toMatchObject({ items: [] })
+    await expect(repository.findComplexPage(BOUNDS, null, 20, signal, {
+      minDeposit: 90_000_000,
+      minMonthlyRent: 900_000,
+    })).resolves.toMatchObject({ items: [] })
+  })
+
+  it('includes child districts when a snapshot parent city is selected', async () => {
+    const snapshot = {
+      ...snapshotWithSecondScenario(),
+      regionCodeDescendants: {
+        41130: ['41131', '41133', '41135', '41137', '41139'],
+      },
+    } as unknown as PublicHousingSnapshotV1
+    const repository = createSnapshotPublicHousingRepository(snapshot)
+    const signal = new AbortController().signal
+
+    const [mapItems, complexPage, announcementPage] = await Promise.all([
+      repository.findMapComplexes(BOUNDS, signal, { regionCode: '41130' }),
+      repository.findComplexPage(BOUNDS, null, 20, signal, {
+        regionCode: '41130',
+      }),
+      repository.findAnnouncementPage(null, 20, signal, {
+        regionCode: '41130',
+      }),
+    ])
+
+    expect(mapItems.map((item) => item.complexId)).toEqual(['18'])
+    expect(complexPage.items.map((item) => item.complexId)).toEqual(['18'])
+    expect(announcementPage.items.map((item) => item.announcementId))
+      .toEqual(['202'])
+  })
+
+  it('includes legacy district codes when a snapshot province is selected', async () => {
+    const baseSnapshot = snapshotWithSecondScenario()
+    const snapshot = {
+      ...baseSnapshot,
+      complexRegionCodes: {
+        ...baseSnapshot.complexRegionCodes,
+        18: '29110',
+      },
+      regionCodeDescendants: {
+        ...baseSnapshot.regionCodeDescendants,
+        12: ['12110', '12210', '29110', '46110'],
+      },
+    } as PublicHousingSnapshotV1
+    const repository = createSnapshotPublicHousingRepository(snapshot)
+    const signal = new AbortController().signal
+
+    const [mapItems, complexPage] = await Promise.all([
+      repository.findMapComplexes(BOUNDS, signal, { regionCode: '12' }),
+      repository.findComplexPage(BOUNDS, null, 20, signal, {
+        regionCode: '12',
+      }),
+    ])
+
+    expect(mapItems.map((item) => item.complexId)).toEqual(['18'])
+    expect(complexPage.items.map((item) => item.complexId)).toEqual(['18'])
+  })
+
   it('returns the same 404 contract as the HTTP repository', async () => {
     const repository = createSnapshotPublicHousingRepository(
       MINIMAL_PUBLIC_HOUSING_SNAPSHOT,
@@ -268,9 +372,35 @@ function snapshotWithSecondScenario(): PublicHousingSnapshotV1 {
 
   return {
     ...MINIMAL_PUBLIC_HOUSING_SNAPSHOT,
+    complexRegionCodes: {
+      17: '11140',
+      18: '41135',
+    },
+    announcementRegionCodes: {
+      201: ['11140'],
+      202: ['41135'],
+    },
     complexListItems: [
       complexListItem,
-      { ...complexListItem, complexId: 18, name: '두 번째 단지' },
+      {
+        ...complexListItem,
+        complexId: 18,
+        name: '두 번째 단지',
+        regionName: '경기도 성남시',
+        rentalType: 'NATIONAL_RENTAL',
+        agency: { code: 'GH', name: '경기주택도시공사' },
+        exclusiveAreaMin: 46,
+        exclusiveAreaMax: 59,
+        depositMin: 20_000_000,
+        depositMax: 30_000_000,
+        monthlyRentMin: 220_000,
+        monthlyRentMax: 320_000,
+        representativeAnnouncement: {
+          ...complexListItem.representativeAnnouncement,
+          announcementId: 202,
+          applicationStatus: 'BEFORE_APPLICATION',
+        },
+      },
     ] as readonly RawComplexListItem[],
     mapComplexItems: [
       mapComplexItem,
@@ -280,11 +410,39 @@ function snapshotWithSecondScenario(): PublicHousingSnapshotV1 {
         name: '두 번째 단지',
         latitude: 37.57,
         longitude: 126.99,
+        rentalType: 'NATIONAL_RENTAL',
+        agency: { code: 'GH', name: '경기주택도시공사' },
+        exclusiveAreaMin: 46,
+        exclusiveAreaMax: 59,
+        depositMin: 20_000_000,
+        depositMax: 30_000_000,
+        monthlyRentMin: 220_000,
+        monthlyRentMax: 320_000,
       },
     ] as readonly RawMapComplex[],
     complexDetails: [
       complexDetail,
-      { ...complexDetail, complexId: 18, name: '두 번째 단지' },
+      {
+        ...complexDetail,
+        complexId: 18,
+        name: '두 번째 단지',
+        rentalType: 'NATIONAL_RENTAL',
+        agency: { code: 'GH', name: '경기주택도시공사' },
+        address: {
+          ...complexDetail.address,
+          regionName: '경기도 성남시',
+        },
+        completionDate: '2018-03-01',
+        housingTypes: [{
+          ...complexDetail.housingTypes[0],
+          exclusiveArea: 50,
+          currentSupplyConditions: [{
+            ...complexDetail.housingTypes[0].currentSupplyConditions[0],
+            deposit: 90_000_000,
+            monthlyRent: 900_000,
+          }],
+        }],
+      },
     ] as readonly RawComplexDetail[],
     announcementListItems: [
       announcementListItem,
@@ -292,6 +450,11 @@ function snapshotWithSecondScenario(): PublicHousingSnapshotV1 {
         ...announcementListItem,
         announcementId: 202,
         title: '두 번째 공고',
+        applicationStatus: 'BEFORE_APPLICATION',
+        rentalType: 'NATIONAL_RENTAL',
+        recruitmentType: 'WAITLIST',
+        regionNames: ['경기도 성남시'],
+        agency: { code: 'GH', name: '경기주택도시공사' },
       },
     ] as readonly RawAnnouncementListItem[],
     announcementDetails: [
@@ -300,6 +463,28 @@ function snapshotWithSecondScenario(): PublicHousingSnapshotV1 {
         ...announcementDetail,
         announcementId: 202,
         title: '두 번째 공고',
+        supplyRows: [{
+          ...announcementDetail.supplyRows[0],
+          supplyRowId: 402,
+          complex: {
+            ...announcementDetail.supplyRows[0].complex,
+            complexId: 18,
+            name: '두 번째 단지',
+            address: '경기도 성남시 분당구 두꺼비로 1',
+          },
+          housingType: {
+            ...announcementDetail.supplyRows[0].housingType,
+            housingTypeId: 302,
+            name: '50A',
+            exclusiveArea: 50,
+          },
+          targets: [{
+            ...announcementDetail.supplyRows[0].targets[0],
+            supplyTargetId: 602,
+            deposit: 20_000_000,
+            monthlyRent: 220_000,
+          }],
+        }],
       },
     ] as readonly RawAnnouncementDetail[],
   }

--- a/frontend/src/public-housing/api/snapshotPublicHousingRepository.ts
+++ b/frontend/src/public-housing/api/snapshotPublicHousingRepository.ts
@@ -6,6 +6,7 @@ import type {
   RawComplexListItem,
   RawMapComplex,
 } from '../model/publicHousing.ts'
+import { provinceNameForRegionCode } from '../model/publicHousingRegion.ts'
 import {
   decodeAnnouncementDetailEnvelope,
   decodeAnnouncementPageEnvelope,
@@ -25,6 +26,13 @@ const ANNOUNCEMENT_CURSOR_PREFIX = 'snapshot-announcement:'
 
 export interface PublicHousingSnapshotV1 {
   readonly version: 1
+  readonly complexRegionCodes: Readonly<Record<string, string>>
+  readonly announcementRegionCodes: Readonly<
+    Record<string, readonly string[]>
+  >
+  readonly regionCodeDescendants: Readonly<
+    Record<string, readonly string[]>
+  >
   readonly complexListItems: readonly RawComplexListItem[]
   readonly mapComplexItems: readonly RawMapComplex[]
   readonly complexDetails: readonly RawComplexDetail[]
@@ -117,9 +125,12 @@ function mapResponse(snapshot: PublicHousingSnapshotV1, url: URL): Response {
     return invalidBoundsResponse()
   }
 
-  const items = snapshot.mapComplexItems.filter((item) =>
-    isInsideBounds(item, bounds),
-  )
+  const matchingIds = complexIdsMatchingFilters(snapshot, url)
+  const filterRequested = hasComplexSearchFilters(url)
+  const items = snapshot.mapComplexItems.filter((item) => (
+    isInsideBounds(item, bounds)
+    && (!filterRequested || matchingIds.has(item.complexId))
+  ))
   return successResponse({ items })
 }
 
@@ -144,9 +155,10 @@ function complexPageResponse(
       .filter((item) => isInsideBounds(item, bounds))
       .map((item) => item.complexId),
   )
-  const items = snapshot.complexListItems.filter((item) =>
-    visibleIds.has(item.complexId),
-  )
+  const items = snapshot.complexListItems.filter((item) => (
+    visibleIds.has(item.complexId)
+    && complexMatchesFilters(snapshot, item, url)
+  ))
   return successResponse(page(
     items,
     cursor.offset,
@@ -167,8 +179,11 @@ function announcementPageResponse(
     return invalidCursorResponse()
   }
 
+  const items = snapshot.announcementListItems.filter((item) => (
+    announcementMatchesFilters(snapshot, item, url)
+  ))
   return successResponse(page(
-    snapshot.announcementListItems,
+    items,
     cursor.offset,
     pageSize(url),
     ANNOUNCEMENT_CURSOR_PREFIX,
@@ -285,6 +300,255 @@ function isInsideBounds(item: RawMapComplex, bounds: MapBounds): boolean {
   )
 }
 
+const COMPLEX_SEARCH_FILTER_KEYS = [
+  'regionCode',
+  'rentalTypes',
+  'applicationStatuses',
+  'agencyCodes',
+  'recruitmentTypes',
+  'minDeposit',
+  'maxDeposit',
+  'minMonthlyRent',
+  'maxMonthlyRent',
+  'minExclusiveArea',
+  'maxExclusiveArea',
+  'builtYearFrom',
+  'builtYearTo',
+] as const
+
+function hasComplexSearchFilters(url: URL) {
+  return COMPLEX_SEARCH_FILTER_KEYS.some((key) => url.searchParams.has(key))
+}
+
+function complexIdsMatchingFilters(
+  snapshot: PublicHousingSnapshotV1,
+  url: URL,
+) {
+  return new Set(snapshot.complexListItems
+    .filter((item) => complexMatchesFilters(snapshot, item, url))
+    .map((item) => item.complexId))
+}
+
+function complexMatchesFilters(
+  snapshot: PublicHousingSnapshotV1,
+  item: RawComplexListItem,
+  url: URL,
+) {
+  const representative = item.representativeAnnouncement
+  const announcement = representative === null
+    ? undefined
+    : snapshot.announcementListItems.find(
+        (candidate) => candidate.announcementId
+          === representative.announcementId,
+      )
+  const announcementDetail = representative === null
+    ? undefined
+    : snapshot.announcementDetails.find(
+        (candidate) => candidate.announcementId
+          === representative.announcementId,
+      )
+  const detail = snapshot.complexDetails.find(
+    (candidate) => candidate.complexId === item.complexId,
+  )
+  const completionYear = detail?.completionDate === null
+    || detail?.completionDate === undefined
+    ? null
+    : Number(detail.completionDate.slice(0, 4))
+  const search = url.searchParams
+
+  const regionCode = snapshot.complexRegionCodes[String(item.complexId)]
+  return matchesRegion(
+    search.get('regionCode'),
+    [item.regionName],
+    regionCode === undefined ? [] : [regionCode],
+    snapshot.regionCodeDescendants,
+  )
+    && matchesRepeated(search, 'rentalTypes', item.rentalType)
+    && matchesRepeated(
+      search,
+      'applicationStatuses',
+      representative?.applicationStatus ?? null,
+    )
+    && matchesRepeated(search, 'agencyCodes', item.agency?.code ?? null)
+    && matchesRepeated(
+      search,
+      'recruitmentTypes',
+      announcement?.recruitmentType ?? null,
+    )
+    && matchesHousingFilters(
+      search,
+      item.complexId,
+      detail,
+      announcementDetail,
+    )
+    && matchesYearRange(search, completionYear)
+}
+
+function announcementMatchesFilters(
+  snapshot: PublicHousingSnapshotV1,
+  item: RawAnnouncementListItem,
+  url: URL,
+) {
+  const search = url.searchParams
+  return matchesRegion(
+    search.get('regionCode'),
+    item.regionNames,
+    snapshot.announcementRegionCodes[String(item.announcementId)] ?? [],
+    snapshot.regionCodeDescendants,
+  )
+    && matchesRepeated(search, 'rentalTypes', item.rentalType)
+    && matchesRepeated(
+      search,
+      'applicationStatuses',
+      item.applicationStatus,
+    )
+    && matchesRepeated(search, 'agencyCodes', item.agency?.code ?? null)
+    && matchesRepeated(search, 'recruitmentTypes', item.recruitmentType)
+}
+
+function matchesRegion(
+  regionCode: string | null,
+  regionNames: readonly (string | null)[],
+  itemRegionCodes: readonly string[],
+  regionCodeDescendants: Readonly<Record<string, readonly string[]>>,
+) {
+  if (regionCode === null) {
+    return true
+  }
+  const matchingCodes = [
+    regionCode,
+    ...(regionCodeDescendants[regionCode] ?? []),
+  ]
+  const matchesRegionCode = matchingCodes.some((matchingCode) =>
+    itemRegionCodes.some((itemRegionCode) => matchingCode.length === 2
+      ? itemRegionCode.startsWith(matchingCode)
+      : itemRegionCode === matchingCode),
+  )
+  if (matchesRegionCode || regionCode.length === 5) {
+    return matchesRegionCode
+  }
+  const provinceName = provinceNameForRegionCode(regionCode)
+  return provinceName !== null && regionNames.some(
+      (name) => name?.startsWith(provinceName) ?? false,
+    )
+}
+
+function matchesRepeated(
+  search: URLSearchParams,
+  key: string,
+  value: string | null,
+) {
+  const expected = search.getAll(key)
+  return expected.length === 0 || (value !== null && expected.includes(value))
+}
+
+function matchesHousingFilters(
+  search: URLSearchParams,
+  complexId: number,
+  detail: RawComplexDetail | undefined,
+  representativeDetail: RawAnnouncementDetail | undefined,
+) {
+  const areaRequested = rangeRequested(
+    search,
+    'minExclusiveArea',
+    'maxExclusiveArea',
+  )
+  const depositRequested = rangeRequested(
+    search,
+    'minDeposit',
+    'maxDeposit',
+  )
+  const monthlyRentRequested = rangeRequested(
+    search,
+    'minMonthlyRent',
+    'maxMonthlyRent',
+  )
+  if (!areaRequested && !depositRequested && !monthlyRentRequested) {
+    return true
+  }
+  if (!depositRequested && !monthlyRentRequested) {
+    return detail?.housingTypes.some((housingType) => matchesValueRange(
+      search,
+      'minExclusiveArea',
+      'maxExclusiveArea',
+      housingType.exclusiveArea,
+    )) ?? false
+  }
+  if (representativeDetail === undefined) {
+    return false
+  }
+  return representativeDetail.supplyRows.some((supplyRow) => (
+    supplyRow.complex?.complexId === complexId
+    && matchesValueRange(
+      search,
+      'minExclusiveArea',
+      'maxExclusiveArea',
+      supplyRow.housingType?.exclusiveArea ?? null,
+    )
+    && supplyRow.targets.some((target) => (
+      matchesValueRange(
+        search,
+        'minDeposit',
+        'maxDeposit',
+        target.deposit,
+      )
+      && matchesValueRange(
+        search,
+        'minMonthlyRent',
+        'maxMonthlyRent',
+        target.monthlyRent,
+      )
+    ))
+  ))
+}
+
+function rangeRequested(
+  search: URLSearchParams,
+  minimumKey: string,
+  maximumKey: string,
+) {
+  return search.has(minimumKey) || search.has(maximumKey)
+}
+
+function matchesValueRange(
+  search: URLSearchParams,
+  minimumKey: string,
+  maximumKey: string,
+  value: number | null,
+) {
+  const expectedMinimum = searchNumber(search, minimumKey)
+  const expectedMaximum = searchNumber(search, maximumKey)
+  if (expectedMinimum === null && expectedMaximum === null) {
+    return true
+  }
+  return value !== null
+    && (expectedMinimum === null || value >= expectedMinimum)
+    && (expectedMaximum === null || value <= expectedMaximum)
+}
+
+function matchesYearRange(
+  search: URLSearchParams,
+  completionYear: number | null,
+) {
+  const from = searchNumber(search, 'builtYearFrom')
+  const to = searchNumber(search, 'builtYearTo')
+  if (from === null && to === null) {
+    return true
+  }
+  return completionYear !== null
+    && (from === null || completionYear >= from)
+    && (to === null || completionYear <= to)
+}
+
+function searchNumber(search: URLSearchParams, key: string) {
+  const value = search.get(key)
+  if (value === null) {
+    return null
+  }
+  const number = Number(value)
+  return Number.isFinite(number) ? number : null
+}
+
 export function decodePublicHousingSnapshot(
   value: unknown,
 ): PublicHousingSnapshotV1 {
@@ -295,6 +559,18 @@ export function decodePublicHousingSnapshot(
 
   return {
     version: 1,
+    complexRegionCodes: optionalRegionCodeRecord(
+      snapshot,
+      'complexRegionCodes',
+    ),
+    announcementRegionCodes: optionalRegionCodeArrayRecord(
+      snapshot,
+      'announcementRegionCodes',
+    ),
+    regionCodeDescendants: optionalRegionCodeArrayRecord(
+      snapshot,
+      'regionCodeDescendants',
+    ),
     complexListItems: decodeComplexPageEnvelope({
       data: {
         items: arrayField(snapshot, 'complexListItems'),
@@ -337,6 +613,44 @@ function arrayField(
     throw new PublicHousingContractError(`$.${field}`)
   }
   return value
+}
+
+function optionalRegionCodeRecord(
+  record: Record<string, unknown>,
+  field: string,
+): Readonly<Record<string, string>> {
+  if (!Object.hasOwn(record, field)) {
+    return {}
+  }
+
+  const source = recordAt(record[field], `$.${field}`)
+  return Object.fromEntries(Object.entries(source).map(([key, value]) => {
+    if (!isRegionCode(value)) {
+      throw new PublicHousingContractError(`$.${field}.${key}`)
+    }
+    return [key, value]
+  }))
+}
+
+function optionalRegionCodeArrayRecord(
+  record: Record<string, unknown>,
+  field: string,
+): Readonly<Record<string, readonly string[]>> {
+  if (!Object.hasOwn(record, field)) {
+    return {}
+  }
+
+  const source = recordAt(record[field], `$.${field}`)
+  return Object.fromEntries(Object.entries(source).map(([key, value]) => {
+    if (!Array.isArray(value) || !value.every(isRegionCode)) {
+      throw new PublicHousingContractError(`$.${field}.${key}`)
+    }
+    return [key, value]
+  }))
+}
+
+function isRegionCode(value: unknown): value is string {
+  return typeof value === 'string' && /^\d{5}$/.test(value)
 }
 
 function requestSignal(

--- a/frontend/src/public-housing/filters/ComplexFilterToolbar.module.css
+++ b/frontend/src/public-housing/filters/ComplexFilterToolbar.module.css
@@ -4,6 +4,21 @@
   min-width: 0;
 }
 
+.desktopFilters {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
+.root .desktopFilters {
+  pointer-events: none;
+}
+
+.desktopFilters .scroller,
+.desktopFilters .popover {
+  pointer-events: auto;
+}
+
 .scroller {
   width: fit-content;
   max-width: 100%;
@@ -25,15 +40,16 @@
 
 .trigger {
   display: inline-flex;
-  min-height: 38px;
+  width: auto;
+  height: 36px;
   flex: 0 0 auto;
   align-items: center;
   gap: 6px;
   padding: 0 12px;
   border: 1px solid #d7dce1;
-  border-radius: 999px;
+  border-radius: 9px;
   background: rgb(255 255 255 / 97%);
-  box-shadow: 0 2px 8px rgb(18 37 47 / 14%);
+  box-shadow: 0 1px 3px rgb(18 37 47 / 10%);
   color: #343a40;
   font-size: 13px;
   font-weight: 700;
@@ -59,24 +75,11 @@
 }
 
 .triggerText {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-}
-
-.triggerSummary {
-  max-width: 100px;
+  display: block;
+  max-width: 132px;
   overflow: hidden;
-  color: var(--brand-dark);
-  font-size: 11px;
   text-overflow: ellipsis;
   white-space: nowrap;
-}
-
-.triggerSummary::before {
-  content: '·';
-  margin-right: 4px;
-  color: #87919a;
 }
 
 .visuallyHidden {
@@ -108,11 +111,11 @@
 .popover {
   position: absolute;
   z-index: 2;
-  top: 48px;
+  top: var(--popover-top);
   left: var(--popover-left);
   display: flex;
   width: var(--popover-width);
-  max-height: calc(100% - 48px);
+  max-height: calc(100% - var(--popover-top));
   overflow: hidden;
   border: 1px solid rgb(30 33 36 / 16%);
   border-radius: 14px;
@@ -192,7 +195,7 @@
   align-items: center;
   padding: 6px 10px;
   border: 1px solid #aeb5bd;
-  border-radius: 999px;
+  border-radius: 9px;
   background: #fff;
   color: #3b4148;
   font-size: 12px;
@@ -301,7 +304,7 @@
 .actions button {
   min-height: 36px;
   padding: 0 14px;
-  border-radius: 999px;
+  border-radius: 8px;
   font-size: 13px;
   font-weight: 750;
 }
@@ -318,26 +321,202 @@
   color: #fff;
 }
 
+.mobileToolbar,
+.mobileBackdrop {
+  display: none;
+}
+
+.mobileToolbar {
+  width: 100%;
+  gap: 6px;
+  padding: 2px;
+  overflow-x: auto;
+  overscroll-behavior-inline: contain;
+  scrollbar-width: none;
+}
+
+.mobileToolbar::-webkit-scrollbar {
+  display: none;
+}
+
+.mobileTrigger,
+.mobileAllTrigger {
+  display: inline-flex;
+  min-width: 0;
+  height: 44px;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  padding: 0 12px;
+  border: 1px solid #d7dce1;
+  border-radius: 10px;
+  background: rgb(255 255 255 / 97%);
+  box-shadow: 0 1px 3px rgb(18 37 47 / 12%);
+  color: #343a40;
+  font-size: 13px;
+  font-weight: 750;
+  white-space: nowrap;
+}
+
+.mobileTrigger {
+  max-width: 104px;
+}
+
+.mobileTrigger span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.mobileTrigger[data-active='true'],
+.mobileAllTrigger[data-active='true'],
+.mobileTrigger[aria-expanded='true'],
+.mobileAllTrigger[aria-expanded='true'] {
+  border-color: var(--brand);
+  background: #eff6ff;
+  color: var(--brand-dark);
+}
+
+.mobileTrigger:focus-visible,
+.mobileAllTrigger:focus-visible,
+.mobileReset:focus-visible,
+.mobileClose:focus-visible,
+.mobileApply:focus-visible {
+  outline: 3px solid rgb(37 110 244 / 24%);
+  outline-offset: 1px;
+}
+
+.mobileBackdrop {
+  position: fixed;
+  z-index: 1200;
+  inset: 0;
+  align-items: flex-end;
+  background: rgb(20 27 34 / 48%);
+}
+
+.mobileSheet {
+  width: 100%;
+  max-height: min(86dvh, 720px);
+  overflow: hidden;
+  border-radius: 20px 20px 0 0;
+  background: #fff;
+  box-shadow: 0 -12px 36px rgb(18 37 47 / 24%);
+}
+
+.mobileForm {
+  display: grid;
+  max-height: min(86dvh, 720px);
+  overflow: hidden;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+}
+
+.mobileSheetHeader {
+  display: flex;
+  min-height: 56px;
+  padding: 6px 10px 6px 18px;
+  border-bottom: 1px solid #e7e9ec;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.mobileSheetHeader h2 {
+  margin: 0;
+  color: #1e2124;
+  font-size: 18px;
+  line-height: 1.4;
+}
+
+.mobileHeaderActions {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.mobileReset,
+.mobileClose {
+  min-width: 44px;
+  min-height: 44px;
+  border: 0;
+  background: transparent;
+}
+
+.mobileReset {
+  padding: 0 8px;
+  color: #58616a;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.mobileClose {
+  color: #343a40;
+  font-size: 25px;
+  font-weight: 400;
+  line-height: 1;
+}
+
+.mobileSheetBody {
+  min-height: 0;
+  padding: 0 18px 20px;
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior-y: contain;
+}
+
+.mobileTopic {
+  padding: 20px 0;
+  border-bottom: 1px solid #edf0f2;
+  scroll-margin-top: 12px;
+}
+
+.mobileTopic:last-of-type {
+  border-bottom: 0;
+}
+
+.mobileTopic h3 {
+  margin: 0 0 12px;
+  color: #1e2124;
+  font-size: 15px;
+  line-height: 1.4;
+}
+
+.mobileError {
+  margin: 12px 0 0;
+  padding: 10px 12px;
+  border-radius: 8px;
+  background: #fdefec;
+  color: #8a240f;
+  font-size: 13px;
+}
+
+.mobileFooter {
+  padding: 12px 18px calc(12px + env(safe-area-inset-bottom));
+  border-top: 1px solid #e7e9ec;
+  background: #fff;
+}
+
+.mobileApply {
+  width: 100%;
+  min-height: 50px;
+  border: 1px solid var(--brand);
+  border-radius: 10px;
+  background: var(--brand);
+  color: #fff;
+  font-size: 15px;
+  font-weight: 800;
+}
+
 @media (max-width: 767px) {
-  .toolbar {
-    justify-content: flex-start;
+  .desktopFilters {
+    display: none;
   }
 
-  .trigger {
-    min-height: 44px;
-  }
-
-  .popover {
-    top: 54px;
-    max-height: calc(100% - 54px);
-  }
-
-  .form {
-    max-height: min(48vh, 420px);
+  .mobileToolbar,
+  .mobileBackdrop {
+    display: flex;
   }
 
   .choice span,
-  .actions button {
+  .mobileSheet .actions button {
     min-height: 44px;
     font-size: 14px;
   }
@@ -346,10 +525,6 @@
   .yearRange select {
     min-height: 44px;
     font-size: 16px;
-  }
-
-  .triggerSummary {
-    max-width: 80px;
   }
 }
 

--- a/frontend/src/public-housing/filters/ComplexFilterToolbar.module.css
+++ b/frontend/src/public-housing/filters/ComplexFilterToolbar.module.css
@@ -1,0 +1,365 @@
+.root {
+  position: relative;
+  width: 100%;
+  min-width: 0;
+}
+
+.scroller {
+  width: fit-content;
+  max-width: 100%;
+  margin-inline-start: auto;
+  padding: 3px;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: thin;
+  overscroll-behavior-inline: contain;
+}
+
+.toolbar {
+  display: flex;
+  width: max-content;
+  min-width: 100%;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.trigger {
+  display: inline-flex;
+  min-height: 38px;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 6px;
+  padding: 0 12px;
+  border: 1px solid #d7dce1;
+  border-radius: 999px;
+  background: rgb(255 255 255 / 97%);
+  box-shadow: 0 2px 8px rgb(18 37 47 / 14%);
+  color: #343a40;
+  font-size: 13px;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.trigger:hover {
+  border-color: #8a949e;
+  background: #f8fafc;
+}
+
+.trigger:focus-visible {
+  border-color: var(--focus);
+  outline: 3px solid rgb(37 110 244 / 22%);
+  outline-offset: 1px;
+}
+
+.trigger[data-active='true'],
+.trigger[aria-expanded='true'] {
+  border-color: var(--brand);
+  background: #eff6ff;
+  color: var(--brand-dark);
+}
+
+.triggerText {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.triggerSummary {
+  max-width: 100px;
+  overflow: hidden;
+  color: var(--brand-dark);
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.triggerSummary::before {
+  content: '·';
+  margin-right: 4px;
+  color: #87919a;
+}
+
+.visuallyHidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.chevron {
+  width: 7px;
+  height: 7px;
+  flex: 0 0 auto;
+  margin-top: -4px;
+  border-right: 2px solid currentcolor;
+  border-bottom: 2px solid currentcolor;
+  transform: rotate(45deg);
+}
+
+.chevronExpanded {
+  margin-top: 4px;
+  transform: rotate(225deg);
+}
+
+.popover {
+  position: absolute;
+  z-index: 2;
+  top: 48px;
+  left: var(--popover-left);
+  display: flex;
+  width: var(--popover-width);
+  max-height: calc(100% - 48px);
+  overflow: hidden;
+  border: 1px solid rgb(30 33 36 / 16%);
+  border-radius: 14px;
+  background: #fff;
+  box-shadow: 0 14px 32px rgb(18 37 47 / 21%);
+}
+
+.form {
+  display: grid;
+  width: 100%;
+  min-height: 0;
+  max-height: 520px;
+  overflow: hidden;
+  grid-template-areas:
+    'heading actions'
+    'fields fields'
+    'error error';
+  grid-template-columns: minmax(0, 1fr) auto;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+}
+
+.popoverHeading {
+  display: flex;
+  min-width: 0;
+  margin: 0;
+  padding: 6px 12px;
+  border-bottom: 1px solid #e7e9ec;
+  grid-area: heading;
+  align-items: center;
+  color: #1e2124;
+  font-size: 14px;
+  white-space: nowrap;
+}
+
+.fields {
+  min-height: 0;
+  padding: 12px;
+  overflow-y: auto;
+  grid-area: fields;
+}
+
+.choiceGroup {
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.choiceGroup legend {
+  margin-bottom: 8px;
+  padding: 0;
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.choices {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.choice {
+  position: relative;
+  display: inline-flex;
+  cursor: pointer;
+}
+
+.choice input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+}
+
+.choice > span {
+  display: inline-flex;
+  min-height: 36px;
+  align-items: center;
+  padding: 6px 10px;
+  border: 1px solid #aeb5bd;
+  border-radius: 999px;
+  background: #fff;
+  color: #3b4148;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.choice input:checked + span {
+  border-color: var(--brand);
+  background: #eaf2ff;
+  color: var(--brand-dark);
+}
+
+.choiceCheck {
+  display: none;
+  margin-right: 4px;
+}
+
+.choice input:checked + span .choiceCheck {
+  display: inline;
+}
+
+.choice input:focus-visible + span {
+  outline: 3px solid rgb(37 110 244 / 24%);
+  outline-offset: 1px;
+}
+
+.regionFields {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px 10px;
+}
+
+.field,
+.yearRange label {
+  display: grid;
+  min-width: 0;
+  gap: 5px;
+  color: #3b4148;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.field select,
+.yearRange select {
+  width: 100%;
+  min-width: 0;
+  min-height: 38px;
+  padding: 6px 9px;
+  border: 1px solid #aeb5bd;
+  border-radius: 7px;
+  background: #fff;
+  color: #1e2124;
+}
+
+.regionFields small {
+  grid-column: 1 / -1;
+}
+
+.regionError,
+.error {
+  color: #8a240f;
+}
+
+.rangeStack {
+  display: grid;
+  gap: 10px;
+}
+
+.yearRange {
+  display: grid;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+  align-items: end;
+  gap: 8px;
+}
+
+.yearRange legend {
+  grid-column: 1 / -1;
+  padding: 0;
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.error {
+  margin: 0;
+  padding: 8px 12px;
+  border-top: 1px solid #f2c9c1;
+  background: #fdefec;
+  grid-area: error;
+  font-size: 12px;
+}
+
+.actions {
+  display: flex;
+  padding: 6px 8px;
+  border-bottom: 1px solid #e7e9ec;
+  grid-area: actions;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  background: #fff;
+}
+
+.actions button {
+  min-height: 36px;
+  padding: 0 14px;
+  border-radius: 999px;
+  font-size: 13px;
+  font-weight: 750;
+}
+
+.reset {
+  border: 1px solid #8a949e;
+  background: #fff;
+  color: #1e2124;
+}
+
+.apply {
+  border: 1px solid var(--brand);
+  background: var(--brand);
+  color: #fff;
+}
+
+@media (max-width: 767px) {
+  .toolbar {
+    justify-content: flex-start;
+  }
+
+  .trigger {
+    min-height: 44px;
+  }
+
+  .popover {
+    top: 54px;
+    max-height: calc(100% - 54px);
+  }
+
+  .form {
+    max-height: min(48vh, 420px);
+  }
+
+  .choice span,
+  .actions button {
+    min-height: 44px;
+    font-size: 14px;
+  }
+
+  .field select,
+  .yearRange select {
+    min-height: 44px;
+    font-size: 16px;
+  }
+
+  .triggerSummary {
+    max-width: 80px;
+  }
+}
+
+@media (max-width: 420px) {
+  .regionFields,
+  .yearRange {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .yearRange > span {
+    display: none;
+  }
+}

--- a/frontend/src/public-housing/filters/ComplexFilterToolbar.test.tsx
+++ b/frontend/src/public-housing/filters/ComplexFilterToolbar.test.tsx
@@ -1,0 +1,610 @@
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import type { ComponentProps } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import type { ComplexSearchFilters } from '../api/publicHousingRepository.ts'
+import { ComplexFilterToolbar } from './ComplexFilterToolbar.tsx'
+
+const GYEONGGI_REGIONS = [
+  {
+    regionCode: '41',
+    provinceName: '경기도',
+    districtName: null,
+    displayName: '경기도 전체',
+  },
+  {
+    regionCode: '41110',
+    provinceName: '경기도',
+    districtName: '수원시',
+    displayName: '경기도 수원시',
+  },
+  {
+    regionCode: '41130',
+    provinceName: '경기도',
+    districtName: '성남시',
+    displayName: '경기도 성남시',
+  },
+] as const
+
+const BASE_FILTERS: ComplexSearchFilters = {
+  regionCode: '11',
+  rentalTypes: ['NATIONAL_RENTAL'],
+  applicationStatuses: ['APPLYING'],
+  agencyCodes: ['LH'],
+  recruitmentTypes: ['NEW'],
+  minDeposit: 100_000_000,
+  maxDeposit: 200_000_000,
+  minMonthlyRent: 200_000,
+  maxMonthlyRent: 300_000,
+  minExclusiveArea: 33,
+  maxExclusiveArea: 62.7,
+  builtYearFrom: 2019,
+  builtYearTo: 2024,
+}
+
+describe('ComplexFilterToolbar', () => {
+  it('8개 토픽을 독립 버튼으로 보이고 한 번에 하나의 팝오버만 연다', () => {
+    renderToolbar()
+
+    expect(screen.getByRole('toolbar', { name: '단지 검색 필터' }))
+      .toBeInTheDocument()
+    const topics = [
+      '지역',
+      '임대유형',
+      '모집상태',
+      '공급기관',
+      '모집유형',
+      '가격',
+      '전용면적',
+      '준공년도',
+    ]
+    topics.forEach((topic) => {
+      expect(screen.getByRole('button', { name: `${topic} 필터 열기` }))
+        .toHaveAttribute('aria-expanded', 'false')
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: '지역 필터 열기' }))
+    expect(screen.getByRole('region', { name: '지역 필터' }))
+      .toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', {
+      name: '임대유형 필터 열기',
+    }))
+    expect(screen.queryByRole('region', { name: '지역 필터' }))
+      .not.toBeInTheDocument()
+    expect(screen.getByRole('region', { name: '임대유형 필터' }))
+      .toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '지역 필터 열기' }))
+      .toHaveAttribute('aria-expanded', 'false')
+    expect(screen.getByRole('button', { name: '임대유형 필터 닫기' }))
+      .toHaveAttribute('aria-expanded', 'true')
+  })
+
+  it('팝오버를 누른 필터 칩의 가로 중심에 연결한다', () => {
+    renderToolbar()
+    const toolbar = screen.getByRole('toolbar', { name: '단지 검색 필터' })
+    const root = toolbar.closest('section')
+    const price = screen.getByRole('button', { name: '가격 필터 열기' })
+    if (root === null) throw new Error('필터 root를 찾을 수 없습니다.')
+    vi.spyOn(root, 'getBoundingClientRect').mockReturnValue(
+      domRect({ left: 100, width: 800 }),
+    )
+    vi.spyOn(price, 'getBoundingClientRect').mockReturnValue(
+      domRect({ left: 570, width: 100 }),
+    )
+
+    fireEvent.click(price)
+
+    const popover = screen.getByRole('region', { name: '가격 필터' })
+    expect(popover).toHaveAttribute('data-topic', 'price')
+    expect(popover.style.getPropertyValue('--popover-anchor-x')).toBe('520px')
+    expect(popover.style.getPropertyValue('--popover-width')).toBe('400px')
+    expect(popover.style.getPropertyValue('--popover-left')).toBe('320px')
+  })
+
+  it('필터 행을 가로 스크롤하면 열린 팝오버의 연결 위치를 갱신한다', () => {
+    renderToolbar()
+    const toolbar = screen.getByRole('toolbar', { name: '단지 검색 필터' })
+    const root = toolbar.closest('section')
+    const scroller = toolbar.parentElement
+    const region = screen.getByRole('button', { name: '지역 필터 열기' })
+    if (root === null || scroller === null) {
+      throw new Error('필터 배치 요소를 찾을 수 없습니다.')
+    }
+    vi.spyOn(root, 'getBoundingClientRect').mockReturnValue(
+      domRect({ left: 100, width: 800 }),
+    )
+    let triggerLeft = 180
+    vi.spyOn(region, 'getBoundingClientRect').mockImplementation(() =>
+      domRect({ left: triggerLeft, width: 80 }),
+    )
+
+    fireEvent.click(region)
+    const popover = screen.getByRole('region', { name: '지역 필터' })
+    expect(popover.style.getPropertyValue('--popover-anchor-x')).toBe('120px')
+    expect(popover.style.getPropertyValue('--popover-width')).toBe('320px')
+    expect(popover.style.getPropertyValue('--popover-left')).toBe('0px')
+
+    triggerLeft = 260
+    fireEvent.scroll(scroller)
+
+    expect(popover.style.getPropertyValue('--popover-anchor-x')).toBe('200px')
+    expect(popover.style.getPropertyValue('--popover-left')).toBe('40px')
+  })
+
+  it('좁은 화면에서도 지역 팝오버를 전체 폭으로 늘리지 않고 경계 안에 둔다', () => {
+    renderToolbar()
+    const toolbar = screen.getByRole('toolbar', { name: '단지 검색 필터' })
+    const root = toolbar.closest('section')
+    const region = screen.getByRole('button', { name: '지역 필터 열기' })
+    if (root === null) throw new Error('필터 root를 찾을 수 없습니다.')
+    vi.spyOn(root, 'getBoundingClientRect').mockReturnValue(
+      domRect({ left: 100, width: 360 }),
+    )
+    vi.spyOn(region, 'getBoundingClientRect').mockReturnValue(
+      domRect({ left: 370, width: 60 }),
+    )
+
+    fireEvent.click(region)
+
+    const popover = screen.getByRole('region', { name: '지역 필터' })
+    expect(popover.style.getPropertyValue('--popover-anchor-x')).toBe('300px')
+    expect(popover.style.getPropertyValue('--popover-width')).toBe('320px')
+    expect(popover.style.getPropertyValue('--popover-left')).toBe('40px')
+  })
+
+  it.each([
+    {
+      topic: '임대유형',
+      option: '행복주택',
+      expected: {
+        ...BASE_FILTERS,
+        rentalTypes: ['HAPPY_HOUSING', 'NATIONAL_RENTAL'],
+      },
+    },
+    {
+      topic: '모집상태',
+      option: '접수예정',
+      expected: {
+        ...BASE_FILTERS,
+        applicationStatuses: ['BEFORE_APPLICATION', 'APPLYING'],
+      },
+    },
+    {
+      topic: '공급기관',
+      option: 'SH',
+      expected: {
+        ...BASE_FILTERS,
+        agencyCodes: ['LH', 'SH'],
+      },
+    },
+    {
+      topic: '모집유형',
+      option: '예비입주자 모집',
+      expected: {
+        ...BASE_FILTERS,
+        recruitmentTypes: ['NEW', 'WAITLIST'],
+      },
+    },
+  ])('$topic 적용은 해당 키만 바꾸고 다른 단지 필터를 보존한다', ({
+    expected,
+    option,
+    topic,
+  }) => {
+    const onApply = vi.fn()
+    renderToolbar({ filters: BASE_FILTERS, onApply })
+
+    fireEvent.click(screen.getByRole('button', {
+      name: `${topic} 필터 열기`,
+    }))
+    fireEvent.click(screen.getByRole('checkbox', { name: option }))
+    fireEvent.click(screen.getByRole('button', {
+      name: `${topic} 필터 적용`,
+    }))
+
+    expect(onApply).toHaveBeenCalledOnce()
+    expect(onApply).toHaveBeenCalledWith(expected)
+    expect(screen.queryByRole('region', { name: `${topic} 필터` }))
+      .not.toBeInTheDocument()
+  })
+
+  it('초기화는 해당 토픽의 키만 제거하고 즉시 적용한다', () => {
+    const onApply = vi.fn()
+    renderToolbar({ filters: BASE_FILTERS, onApply })
+
+    fireEvent.click(screen.getByRole('button', {
+      name: '가격 필터 열기',
+    }))
+    fireEvent.click(screen.getByRole('button', { name: '가격 필터 초기화' }))
+
+    expect(onApply).toHaveBeenCalledWith({
+      regionCode: '11',
+      rentalTypes: ['NATIONAL_RENTAL'],
+      applicationStatuses: ['APPLYING'],
+      agencyCodes: ['LH'],
+      recruitmentTypes: ['NEW'],
+      minExclusiveArea: 33,
+      maxExclusiveArea: 62.7,
+      builtYearFrom: 2019,
+      builtYearTo: 2024,
+    })
+    expect(screen.queryByRole('region', { name: '가격 필터' }))
+      .not.toBeInTheDocument()
+  })
+
+  it('Escape와 바깥 클릭은 draft를 적용하지 않고 닫는다', () => {
+    const onApply = vi.fn()
+    renderToolbar({ filters: BASE_FILTERS, onApply })
+
+    fireEvent.click(screen.getByRole('button', {
+      name: '공급기관 필터 열기',
+    }))
+    fireEvent.click(screen.getByRole('checkbox', { name: 'SH' }))
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    expect(onApply).not.toHaveBeenCalled()
+    expect(screen.getByRole('button', { name: '공급기관 필터 열기' }))
+      .toHaveFocus()
+    fireEvent.click(screen.getByRole('button', {
+      name: '공급기관 필터 열기',
+    }))
+    expect(screen.getByRole('checkbox', { name: 'SH' })).not.toBeChecked()
+
+    fireEvent.click(screen.getByRole('checkbox', { name: 'SH' }))
+    fireEvent.pointerDown(document.body)
+
+    expect(onApply).not.toHaveBeenCalled()
+    expect(screen.queryByRole('region', { name: '공급기관 필터' }))
+      .not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', {
+      name: '공급기관 필터 열기',
+    }))
+    expect(screen.getByRole('checkbox', { name: 'SH' })).not.toBeChecked()
+  })
+
+  it('가격 팝오버에서 보증금과 월세 범위를 함께 적용한다', () => {
+    const onApply = vi.fn()
+    renderToolbar({ filters: BASE_FILTERS, onApply })
+
+    fireEvent.click(screen.getByRole('button', { name: '가격 필터 열기' }))
+    const popover = screen.getByRole('region', { name: '가격 필터' })
+    fireEvent.click(within(within(popover).getByRole('group', {
+      name: '임대보증금 빠른 선택',
+    })).getByRole('button', { name: '2~3억' }))
+    fireEvent.click(within(within(popover).getByRole('group', {
+      name: '월 임대료 빠른 선택',
+    })).getByRole('button', { name: '40~60만' }))
+    fireEvent.click(within(popover).getByRole('button', {
+      name: '가격 필터 적용',
+    }))
+
+    expect(onApply).toHaveBeenCalledWith({
+      ...BASE_FILTERS,
+      minDeposit: 200_000_000,
+      maxDeposit: 300_000_000,
+      minMonthlyRent: 400_000,
+      maxMonthlyRent: 590_000,
+    })
+  })
+
+  it('URL의 endpoint·domain 초과·step 비정렬 범위를 무변경 적용하면 그대로 보존한다', () => {
+    const onApply = vi.fn()
+    const filters: ComplexSearchFilters = {
+      minDeposit: 0,
+      maxDeposit: 500_000_000,
+      minMonthlyRent: 610_000,
+      maxMonthlyRent: 700_000,
+      minExclusiveArea: 50,
+      maxExclusiveArea: 150,
+    }
+    renderToolbar({ filters, onApply })
+
+    fireEvent.click(screen.getByRole('button', { name: '가격 필터 열기' }))
+    fireEvent.click(screen.getByRole('button', { name: '가격 필터 적용' }))
+    fireEvent.click(screen.getByRole('button', {
+      name: '전용면적 필터 열기',
+    }))
+    fireEvent.click(screen.getByRole('button', {
+      name: '전용면적 필터 적용',
+    }))
+
+    expect(onApply).toHaveBeenNthCalledWith(1, filters)
+    expect(onApply).toHaveBeenNthCalledWith(2, filters)
+  })
+
+  it('가격 slider를 조작하면 해당 범위만 정규화하고 다른 범위 원값은 보존한다', () => {
+    const onApply = vi.fn()
+    const filters: ComplexSearchFilters = {
+      minDeposit: 140_000_000,
+      maxDeposit: 155_000_000,
+      minMonthlyRent: 610_000,
+      maxMonthlyRent: 700_000,
+    }
+    renderToolbar({ filters, onApply })
+
+    fireEvent.click(screen.getByRole('button', { name: '가격 필터 열기' }))
+    fireEvent.change(screen.getByRole('slider', {
+      name: '임대보증금 최솟값',
+    }), { target: { value: '160000000' } })
+    fireEvent.click(screen.getByRole('button', { name: '가격 필터 적용' }))
+
+    expect(onApply).toHaveBeenCalledWith({
+      minDeposit: 160_000_000,
+      maxDeposit: 160_000_000,
+      minMonthlyRent: 610_000,
+      maxMonthlyRent: 700_000,
+    })
+  })
+
+  it('전용면적은 가격과 분리된 범위 팝오버에서 적용한다', () => {
+    const onApply = vi.fn()
+    renderToolbar({ filters: BASE_FILTERS, onApply })
+
+    fireEvent.click(screen.getByRole('button', {
+      name: '전용면적 필터 열기',
+    }))
+    const popover = screen.getByRole('region', { name: '전용면적 필터' })
+    fireEvent.click(within(within(popover).getByRole('group', {
+      name: '전용면적 빠른 선택',
+    })).getByRole('button', { name: '30평 이상' }))
+    fireEvent.click(within(popover).getByRole('button', {
+      name: '전용면적 필터 적용',
+    }))
+
+    expect(onApply).toHaveBeenCalledWith({
+      regionCode: '11',
+      rentalTypes: ['NATIONAL_RENTAL'],
+      applicationStatuses: ['APPLYING'],
+      agencyCodes: ['LH'],
+      recruitmentTypes: ['NEW'],
+      minDeposit: 100_000_000,
+      maxDeposit: 200_000_000,
+      minMonthlyRent: 200_000,
+      maxMonthlyRent: 300_000,
+      minExclusiveArea: 99,
+      builtYearFrom: 2019,
+      builtYearTo: 2024,
+    })
+  })
+
+  it('준공년도 역전 범위는 적용하지 않고 팝오버에 오류를 보인다', () => {
+    const onApply = vi.fn()
+    renderToolbar({ filters: BASE_FILTERS, onApply })
+
+    fireEvent.click(screen.getByRole('button', {
+      name: '준공년도 필터 열기',
+    }))
+    fireEvent.change(screen.getByRole('combobox', {
+      name: '최소 준공년도',
+    }), { target: { value: '2025' } })
+    fireEvent.change(screen.getByRole('combobox', {
+      name: '최대 준공년도',
+    }), { target: { value: '2020' } })
+    fireEvent.click(screen.getByRole('button', {
+      name: '준공년도 필터 적용',
+    }))
+
+    expect(onApply).not.toHaveBeenCalled()
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      '최소 준공년도는 최대 준공년도보다 클 수 없습니다.',
+    )
+    expect(screen.getByRole('region', { name: '준공년도 필터' }))
+      .toBeInTheDocument()
+  })
+
+  it('준공년도 드롭다운에서 최소·최대 연도를 선택해 적용한다', () => {
+    const onApply = vi.fn()
+    renderToolbar({ onApply })
+
+    fireEvent.click(screen.getByRole('button', {
+      name: '준공년도 필터 열기',
+    }))
+    const minimum = screen.getByRole('combobox', {
+      name: '최소 준공년도',
+    })
+    const maximum = screen.getByRole('combobox', {
+      name: '최대 준공년도',
+    })
+    const latestYear = String(new Date().getFullYear() + 5)
+
+    expect(within(minimum).getByRole('option', { name: '제한 없음' }))
+      .toHaveValue('')
+    expect(within(minimum).getAllByRole<HTMLOptionElement>('option')
+      .map((option) => option.value))
+      .toEqual([
+        '',
+        ...Array.from(
+          { length: Number(latestYear) - 1980 + 1 },
+          (_, index) => String(Number(latestYear) - index),
+        ),
+      ])
+
+    fireEvent.change(minimum, { target: { value: '1998' } })
+    fireEvent.change(maximum, { target: { value: '2021' } })
+    fireEvent.click(screen.getByRole('button', {
+      name: '준공년도 필터 적용',
+    }))
+
+    expect(onApply).toHaveBeenCalledWith({
+      builtYearFrom: 1998,
+      builtYearTo: 2021,
+    })
+  })
+
+  it('선택 범위 밖의 기존 준공년도도 드롭다운에서 보존해 적용한다', () => {
+    const onApply = vi.fn()
+    const filters: ComplexSearchFilters = {
+      builtYearFrom: 1979,
+      builtYearTo: 9999,
+    }
+    renderToolbar({ filters, onApply })
+
+    fireEvent.click(screen.getByRole('button', {
+      name: '준공년도 필터 열기',
+    }))
+    const minimum = screen.getByRole('combobox', {
+      name: '최소 준공년도',
+    })
+    const maximum = screen.getByRole('combobox', {
+      name: '최대 준공년도',
+    })
+
+    expect(minimum).toHaveValue('1979')
+    expect(maximum).toHaveValue('9999')
+    expect(within(minimum).getByRole('option', { name: '1979년' }))
+      .toBeInTheDocument()
+    expect(within(maximum).getByRole('option', { name: '9999년' }))
+      .toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', {
+      name: '준공년도 필터 적용',
+    }))
+
+    expect(onApply).toHaveBeenCalledWith(filters)
+  })
+
+  it('지역 repository로 시군구를 불러와 지역 키만 교체한다', async () => {
+    const onApply = vi.fn()
+    const regionRepository = {
+      search: vi.fn().mockResolvedValue(GYEONGGI_REGIONS),
+    }
+    renderToolbar({ filters: BASE_FILTERS, onApply, regionRepository })
+
+    fireEvent.click(screen.getByRole('button', { name: '지역 필터 열기' }))
+    fireEvent.change(screen.getByLabelText('시·도'), {
+      target: { value: '41' },
+    })
+
+    const districtSelect = await screen.findByLabelText('시·군·구')
+    await waitFor(() => {
+      expect(regionRepository.search).toHaveBeenLastCalledWith(
+        '경기도',
+        expect.any(AbortSignal),
+      )
+      expect(within(districtSelect).getByRole('option', { name: '수원시' }))
+        .toBeInTheDocument()
+    })
+    fireEvent.change(districtSelect, { target: { value: '41110' } })
+    fireEvent.click(screen.getByRole('button', { name: '지역 필터 적용' }))
+
+    expect(onApply).toHaveBeenCalledWith({
+      ...BASE_FILTERS,
+      regionCode: '41110',
+    })
+  })
+
+  it('적용된 토픽 버튼에 요약과 active 상태를 보인다', () => {
+    renderToolbar({ filters: BASE_FILTERS })
+
+    const expectedSummaries = [
+      ['지역', '서울특별시'],
+      ['임대유형', '국민임대'],
+      ['모집상태', '접수중'],
+      ['공급기관', 'LH'],
+      ['모집유형', '신규 모집'],
+      ['가격', '보증금 1억~2억 · 월세 20만~30만'],
+      ['전용면적', '10~19평'],
+      ['준공년도', '2019~2024년'],
+    ] as const
+
+    expectedSummaries.forEach(([topic, summary]) => {
+      const button = screen.getByRole('button', {
+        name: `${topic} 필터 열기`,
+      })
+      expect(button).toHaveAttribute('data-active', 'true')
+      expect(button).toHaveTextContent(summary)
+      expect(button).toHaveAccessibleDescription(`적용됨: ${summary}`)
+    })
+  })
+
+  it('다섯 자리 지역은 실제 시군구 이름을 active 요약으로 보인다', async () => {
+    const regionRepository = {
+      search: vi.fn().mockResolvedValue(GYEONGGI_REGIONS),
+    }
+    renderToolbar({ filters: { regionCode: '41110' }, regionRepository })
+
+    const region = screen.getByRole('button', { name: '지역 필터 열기' })
+    await waitFor(() => {
+      expect(region).toHaveTextContent('경기도 수원시')
+      expect(region).toHaveAccessibleDescription('적용됨: 경기도 수원시')
+    })
+  })
+
+  it('시군구 로딩 실패를 즉시 알리고 관련 select와 연결한다', async () => {
+    const regionRepository = {
+      search: vi.fn().mockRejectedValue(new Error('network error')),
+    }
+    renderToolbar({ filters: { regionCode: '11' }, regionRepository })
+
+    fireEvent.click(screen.getByRole('button', { name: '지역 필터 열기' }))
+
+    const alert = await screen.findByRole('alert')
+    expect(alert).toHaveTextContent(
+      '시·군·구를 불러오지 못했습니다.',
+    )
+    expect(screen.getByLabelText('시·군·구'))
+      .toHaveAttribute('aria-describedby', alert.id)
+  })
+
+  it('toolbar 키보드 키로 인접 필터와 양 끝으로 포커스를 옮긴다', () => {
+    renderToolbar()
+    const region = screen.getByRole('button', { name: '지역 필터 열기' })
+    const rentalType = screen.getByRole('button', {
+      name: '임대유형 필터 열기',
+    })
+    const builtYear = screen.getByRole('button', {
+      name: '준공년도 필터 열기',
+    })
+
+    region.focus()
+    fireEvent.keyDown(region, { key: 'ArrowRight' })
+    expect(rentalType).toHaveFocus()
+    fireEvent.keyDown(rentalType, { key: 'End' })
+    expect(builtYear).toHaveFocus()
+    fireEvent.keyDown(builtYear, { key: 'ArrowRight' })
+    expect(region).toHaveFocus()
+    fireEvent.keyDown(region, { key: 'ArrowLeft' })
+    expect(builtYear).toHaveFocus()
+    fireEvent.keyDown(builtYear, { key: 'Home' })
+    expect(region).toHaveFocus()
+  })
+})
+
+function renderToolbar({
+  filters = {},
+  onApply = vi.fn(),
+  regionRepository = { search: vi.fn().mockResolvedValue([]) },
+}: {
+  readonly filters?: ComplexSearchFilters
+  readonly onApply?: ComponentProps<typeof ComplexFilterToolbar>['onApply']
+  readonly regionRepository?: ComponentProps<
+    typeof ComplexFilterToolbar
+  >['regionRepository']
+} = {}) {
+  return render(
+    <ComplexFilterToolbar
+      filters={filters}
+      onApply={onApply}
+      regionRepository={regionRepository}
+    />,
+  )
+}
+
+function domRect({
+  left,
+  width,
+}: {
+  readonly left: number
+  readonly width: number
+}): DOMRect {
+  return {
+    bottom: 0,
+    height: 0,
+    left,
+    right: left + width,
+    top: 0,
+    width,
+    x: left,
+    y: 0,
+    toJSON: () => ({}),
+  }
+}

--- a/frontend/src/public-housing/filters/ComplexFilterToolbar.test.tsx
+++ b/frontend/src/public-housing/filters/ComplexFilterToolbar.test.tsx
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import type { ComponentProps } from 'react'
 import { describe, expect, it, vi } from 'vitest'
@@ -41,7 +43,27 @@ const BASE_FILTERS: ComplexSearchFilters = {
   builtYearTo: 2024,
 }
 
+const TOOLBAR_STYLES = readFileSync(
+  resolve(
+    process.cwd(),
+    'src/public-housing/filters/ComplexFilterToolbar.module.css',
+  ),
+  'utf8',
+)
+
 describe('ComplexFilterToolbar', () => {
+  it('데스크톱 트리거와 선택값을 36px 높이의 둥근 사각형으로 통일한다', () => {
+    const triggerRule = TOOLBAR_STYLES.match(/\.trigger\s*\{([^}]*)\}/)?.[1]
+    const choiceRule = TOOLBAR_STYLES.match(
+      /\.choice\s*>\s*span\s*\{([^}]*)\}/,
+    )?.[1]
+
+    expect(triggerRule).toMatch(/height:\s*36px;/)
+    expect(triggerRule).toMatch(/border-radius:\s*9px;/)
+    expect(choiceRule).toMatch(/min-height:\s*36px;/)
+    expect(choiceRule).toMatch(/border-radius:\s*9px;/)
+  })
+
   it('8개 토픽을 독립 버튼으로 보이고 한 번에 하나의 팝오버만 연다', () => {
     renderToolbar()
 
@@ -86,19 +108,20 @@ describe('ComplexFilterToolbar', () => {
     const price = screen.getByRole('button', { name: '가격 필터 열기' })
     if (root === null) throw new Error('필터 root를 찾을 수 없습니다.')
     vi.spyOn(root, 'getBoundingClientRect').mockReturnValue(
-      domRect({ left: 100, width: 800 }),
+      domRect({ left: 100, top: 40, width: 800 }),
     )
     vi.spyOn(price, 'getBoundingClientRect').mockReturnValue(
-      domRect({ left: 570, width: 100 }),
+      domRect({ height: 36, left: 300, top: 90, width: 100 }),
     )
 
     fireEvent.click(price)
 
     const popover = screen.getByRole('region', { name: '가격 필터' })
     expect(popover).toHaveAttribute('data-topic', 'price')
-    expect(popover.style.getPropertyValue('--popover-anchor-x')).toBe('520px')
-    expect(popover.style.getPropertyValue('--popover-width')).toBe('400px')
-    expect(popover.style.getPropertyValue('--popover-left')).toBe('320px')
+    expect(popover.style.getPropertyValue('--popover-anchor-x')).toBe('250px')
+    expect(popover.style.getPropertyValue('--popover-width')).toBe('420px')
+    expect(popover.style.getPropertyValue('--popover-left')).toBe('200px')
+    expect(popover.style.getPropertyValue('--popover-top')).toBe('94px')
   })
 
   it('필터 행을 가로 스크롤하면 열린 팝오버의 연결 위치를 갱신한다', () => {
@@ -122,13 +145,13 @@ describe('ComplexFilterToolbar', () => {
     const popover = screen.getByRole('region', { name: '지역 필터' })
     expect(popover.style.getPropertyValue('--popover-anchor-x')).toBe('120px')
     expect(popover.style.getPropertyValue('--popover-width')).toBe('320px')
-    expect(popover.style.getPropertyValue('--popover-left')).toBe('0px')
+    expect(popover.style.getPropertyValue('--popover-left')).toBe('80px')
 
     triggerLeft = 260
     fireEvent.scroll(scroller)
 
     expect(popover.style.getPropertyValue('--popover-anchor-x')).toBe('200px')
-    expect(popover.style.getPropertyValue('--popover-left')).toBe('40px')
+    expect(popover.style.getPropertyValue('--popover-left')).toBe('160px')
   })
 
   it('좁은 화면에서도 지역 팝오버를 전체 폭으로 늘리지 않고 경계 안에 둔다', () => {
@@ -284,6 +307,29 @@ describe('ComplexFilterToolbar', () => {
       minMonthlyRent: 400_000,
       maxMonthlyRent: 590_000,
     })
+  })
+
+  it('가격 빠른 선택은 전체 중복 없이 범위별 4~5개만 한 번에 제공한다', () => {
+    renderToolbar()
+
+    fireEvent.click(screen.getByRole('button', { name: '가격 필터 열기' }))
+    const popover = screen.getByRole('region', { name: '가격 필터' })
+    const depositPresets = within(popover).getByRole('group', {
+      name: '임대보증금 빠른 선택',
+    })
+    const rentPresets = within(popover).getByRole('group', {
+      name: '월 임대료 빠른 선택',
+    })
+
+    expect(within(depositPresets).getAllByRole('button').map(
+      (button) => button.textContent,
+    )).toEqual(['1억 이하', '1~2억', '2~3억', '3~5억', '5억 이상'])
+    expect(within(rentPresets).getAllByRole('button').map(
+      (button) => button.textContent,
+    )).toEqual(['10만 이하', '10~20만', '20~30만', '30~40만', '40~60만'])
+    expect(within(popover).getAllByRole('status', {
+      name: /선택 범위/,
+    }).map((output) => output.textContent)).toEqual(['전체', '전체'])
   })
 
   it('URL의 endpoint·domain 초과·step 비정렬 범위를 무변경 적용하면 그대로 보존한다', () => {
@@ -496,12 +542,12 @@ describe('ComplexFilterToolbar', () => {
     renderToolbar({ filters: BASE_FILTERS })
 
     const expectedSummaries = [
-      ['지역', '서울특별시'],
+      ['지역', '서울'],
       ['임대유형', '국민임대'],
       ['모집상태', '접수중'],
       ['공급기관', 'LH'],
       ['모집유형', '신규 모집'],
-      ['가격', '보증금 1억~2억 · 월세 20만~30만'],
+      ['가격', '1억~2억 · 월 20만~30만'],
       ['전용면적', '10~19평'],
       ['준공년도', '2019~2024년'],
     ] as const
@@ -511,9 +557,18 @@ describe('ComplexFilterToolbar', () => {
         name: `${topic} 필터 열기`,
       })
       expect(button).toHaveAttribute('data-active', 'true')
-      expect(button).toHaveTextContent(summary)
+      expect(button.textContent).toBe(summary)
       expect(button).toHaveAccessibleDescription(`적용됨: ${summary}`)
     })
+  })
+
+  it('적용값이 없는 토픽은 분류명을 그대로 보인다', () => {
+    renderToolbar()
+
+    expect(screen.getByRole('button', { name: '지역 필터 열기' }).textContent)
+      .toBe('지역')
+    expect(screen.getByRole('button', { name: '가격 필터 열기' }).textContent)
+      .toBe('가격')
   })
 
   it('다섯 자리 지역은 실제 시군구 이름을 active 요약으로 보인다', async () => {
@@ -524,9 +579,140 @@ describe('ComplexFilterToolbar', () => {
 
     const region = screen.getByRole('button', { name: '지역 필터 열기' })
     await waitFor(() => {
-      expect(region).toHaveTextContent('경기도 수원시')
-      expect(region).toHaveAccessibleDescription('적용됨: 경기도 수원시')
+      expect(region).toHaveTextContent('경기 수원시')
+      expect(region).toHaveAccessibleDescription('적용됨: 경기 수원시')
     })
+  })
+
+  it('모바일 핵심 조건은 적용값을 읽어 주고 하나의 전체 필터 시트에서 초기화한다', async () => {
+    const onApply = vi.fn()
+    renderToolbar({
+      filters: {
+        regionCode: '11',
+        rentalTypes: ['NATIONAL_RENTAL'],
+        minDeposit: 100_000_000,
+        maxDeposit: 200_000_000,
+      },
+      onApply,
+      resultCountLabel: '12곳',
+    })
+    const mobileToolbar = screen.getByRole('toolbar', {
+      name: '모바일 단지 검색 필터',
+    })
+
+    expect(within(mobileToolbar).getAllByRole('button').map(
+      (button) => button.textContent,
+    )).toEqual(['서울', '국민임대', '1억~2억', '필터 3'])
+    expect(within(mobileToolbar).getByRole('button', {
+      name: '가격 1억~2억, 전체 단지 필터 열기',
+    })).toBeInTheDocument()
+
+    fireEvent.click(within(mobileToolbar).getByRole('button', {
+      name: '가격 1억~2억, 전체 단지 필터 열기',
+    }))
+
+    expect(screen.queryByRole('region', { name: '가격 필터' }))
+      .not.toBeInTheDocument()
+    const sheet = screen.getByRole('dialog', { name: '단지 필터' })
+    expect(within(sheet).getByRole('button', {
+      name: '단지 필터 닫기',
+    })).toHaveFocus()
+    expect(within(sheet).getByRole('button', {
+      name: '단지 12곳 보기',
+    })).toBeInTheDocument()
+    expect(within(sheet).getByRole('slider', {
+      name: '임대보증금 최솟값',
+    })).toBeInTheDocument()
+    expect(within(sheet).getByRole('slider', {
+      name: '전용면적 최댓값',
+    })).toBeInTheDocument()
+
+    fireEvent.click(within(sheet).getByRole('button', {
+      name: '전체 필터 초기화',
+    }))
+    expect(onApply).not.toHaveBeenCalled()
+    await waitFor(() => {
+      expect(within(sheet).getByRole('button', {
+        name: '전체 필터 초기화',
+      })).toHaveFocus()
+    })
+
+    fireEvent.click(within(sheet).getByRole('button', {
+      name: '단지 보기',
+    }))
+    expect(onApply).toHaveBeenCalledWith({})
+    expect(screen.queryByRole('dialog', { name: '단지 필터' }))
+      .not.toBeInTheDocument()
+  })
+
+  it('모바일 시트가 열린 동안 외부 필터가 바뀌면 stale draft를 닫는다', () => {
+    const onApply = vi.fn()
+    const regionRepository = { search: vi.fn().mockResolvedValue([]) }
+    const { rerender } = render(
+      <ComplexFilterToolbar
+        filters={{ regionCode: '11' }}
+        onApply={onApply}
+        regionRepository={regionRepository}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', {
+      name: '전체 단지 필터 열기, 1개 적용',
+    }))
+    expect(screen.getByRole('dialog', { name: '단지 필터' }))
+      .toBeInTheDocument()
+
+    rerender(
+      <ComplexFilterToolbar
+        filters={{ regionCode: '41' }}
+        onApply={onApply}
+        regionRepository={regionRepository}
+      />,
+    )
+
+    expect(screen.queryByRole('dialog', { name: '단지 필터' }))
+      .not.toBeInTheDocument()
+    expect(onApply).not.toHaveBeenCalled()
+  })
+
+  it('모바일 시트는 배경 스크롤을 잠그고 내부 토픽만 직접 이동한다', () => {
+    const scrollIntoView = vi.fn()
+    Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+      configurable: true,
+      value: scrollIntoView,
+    })
+    renderToolbar({ filters: { minDeposit: 100_000_000 } })
+
+    fireEvent.click(screen.getByRole('button', {
+      name: '가격 1억 이상, 전체 단지 필터 열기',
+    }))
+
+    expect(scrollIntoView).not.toHaveBeenCalled()
+    expect(document.documentElement.style.overflow).toBe('hidden')
+    expect(document.body.style.overflow).toBe('hidden')
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(document.documentElement.style.overflow).toBe('')
+    expect(document.body.style.overflow).toBe('')
+    Reflect.deleteProperty(HTMLElement.prototype, 'scrollIntoView')
+  })
+
+  it('모바일 시트가 열린 채 데스크톱 너비가 되면 숨은 dialog를 종료한다', () => {
+    const innerWidth = vi.spyOn(window, 'innerWidth', 'get')
+      .mockReturnValue(390)
+    renderToolbar()
+    fireEvent.click(screen.getByRole('button', {
+      name: '전체 단지 필터 열기',
+    }))
+    expect(screen.getByRole('dialog', { name: '단지 필터' }))
+      .toBeInTheDocument()
+
+    innerWidth.mockReturnValue(768)
+    fireEvent(window, new Event('resize'))
+
+    expect(screen.queryByRole('dialog', { name: '단지 필터' }))
+      .not.toBeInTheDocument()
+    innerWidth.mockRestore()
   })
 
   it('시군구 로딩 실패를 즉시 알리고 관련 select와 연결한다', async () => {
@@ -573,38 +759,45 @@ function renderToolbar({
   filters = {},
   onApply = vi.fn(),
   regionRepository = { search: vi.fn().mockResolvedValue([]) },
+  resultCountLabel,
 }: {
   readonly filters?: ComplexSearchFilters
   readonly onApply?: ComponentProps<typeof ComplexFilterToolbar>['onApply']
   readonly regionRepository?: ComponentProps<
     typeof ComplexFilterToolbar
   >['regionRepository']
+  readonly resultCountLabel?: string
 } = {}) {
   return render(
     <ComplexFilterToolbar
       filters={filters}
       onApply={onApply}
       regionRepository={regionRepository}
+      resultCountLabel={resultCountLabel}
     />,
   )
 }
 
 function domRect({
+  height = 0,
   left,
+  top = 0,
   width,
 }: {
+  readonly height?: number
   readonly left: number
+  readonly top?: number
   readonly width: number
 }): DOMRect {
   return {
-    bottom: 0,
-    height: 0,
+    bottom: top + height,
+    height,
     left,
     right: left + width,
-    top: 0,
+    top,
     width,
     x: left,
-    y: 0,
+    y: top,
     toJSON: () => ({}),
   }
 }

--- a/frontend/src/public-housing/filters/ComplexFilterToolbar.tsx
+++ b/frontend/src/public-housing/filters/ComplexFilterToolbar.tsx
@@ -1,0 +1,954 @@
+import {
+  type CSSProperties,
+  type FormEvent,
+  type KeyboardEvent as ReactKeyboardEvent,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
+import {
+  type PublicHousingRegionRepository,
+  publicHousingRegionRepository,
+} from '../api/publicHousingRegionRepository.ts'
+import type {
+  AgencyCodeFilter,
+  ApplicationStatusFilter,
+  ComplexSearchFilters,
+  RecruitmentTypeFilter,
+  RentalTypeFilter,
+} from '../api/publicHousingRepository.ts'
+import {
+  districtRegionOptionsForProvince,
+  type PublicHousingRegion,
+  PUBLIC_HOUSING_PROVINCE_OPTIONS,
+  provinceNameForRegionCode,
+} from '../model/publicHousingRegion.ts'
+import {
+  DualRangeFilter,
+  type DualRangeFilterPreset,
+} from './DualRangeFilter.tsx'
+import { searchFiltersSignature } from './searchFilterLocation.ts'
+import styles from './ComplexFilterToolbar.module.css'
+
+const RENTAL_TYPE_OPTIONS = [
+  ['HAPPY_HOUSING', '행복주택'],
+  ['NATIONAL_RENTAL', '국민임대'],
+  ['PERMANENT_RENTAL', '영구임대'],
+  ['PUBLIC_RENTAL_50Y', '50년 공공임대'],
+  ['INTEGRATED_PUBLIC_RENTAL', '통합공공임대'],
+  ['REDEVELOPMENT_RENTAL', '재개발임대'],
+  ['ETC', '기타'],
+] as const satisfies readonly (readonly [RentalTypeFilter, string])[]
+
+const APPLICATION_STATUS_OPTIONS = [
+  ['BEFORE_APPLICATION', '접수예정'],
+  ['APPLYING', '접수중'],
+  ['CLOSED', '접수마감'],
+] as const satisfies readonly (readonly [ApplicationStatusFilter, string])[]
+
+const AGENCY_OPTIONS = [
+  ['LH', 'LH'],
+  ['SH', 'SH'],
+  ['GH', 'GH'],
+  ['ETC', '기타 기관'],
+] as const satisfies readonly (readonly [AgencyCodeFilter, string])[]
+
+const RECRUITMENT_TYPE_OPTIONS = [
+  ['NEW', '신규 모집'],
+  ['WAITLIST', '예비입주자 모집'],
+  ['ETC', '기타 모집'],
+] as const satisfies readonly (readonly [RecruitmentTypeFilter, string])[]
+
+const DEPOSIT_PRESETS = [
+  { label: '전체', minimum: null, maximum: null },
+  { label: '1억 이하', minimum: null, maximum: 100_000_000 },
+  { label: '1~2억', minimum: 100_000_000, maximum: 200_000_000 },
+  { label: '2~3억', minimum: 200_000_000, maximum: 300_000_000 },
+  { label: '3~5억', minimum: 300_000_000, maximum: 490_000_000 },
+  { label: '5억 이상', minimum: 500_000_000, maximum: null },
+] as const satisfies readonly DualRangeFilterPreset[]
+
+const MONTHLY_RENT_PRESETS = [
+  { label: '전체', minimum: null, maximum: null },
+  { label: '10만 이하', minimum: null, maximum: 100_000 },
+  { label: '10~20만', minimum: 100_000, maximum: 200_000 },
+  { label: '20~30만', minimum: 200_000, maximum: 300_000 },
+  { label: '30~40만', minimum: 300_000, maximum: 400_000 },
+  { label: '40~60만', minimum: 400_000, maximum: 590_000 },
+  { label: '60만 이상', minimum: 600_000, maximum: null },
+] as const satisfies readonly DualRangeFilterPreset[]
+
+const AREA_PRESETS = [
+  { label: '전체', minimum: null, maximum: null },
+  { label: '10평 미만', minimum: null, maximum: 29.7 },
+  { label: '10평대', minimum: 33, maximum: 62.7 },
+  { label: '20평대', minimum: 66, maximum: 95.7 },
+  { label: '30평 이상', minimum: 99, maximum: null },
+] as const satisfies readonly DualRangeFilterPreset[]
+
+type FilterTopic =
+  | 'region'
+  | 'rentalType'
+  | 'applicationStatus'
+  | 'agency'
+  | 'recruitmentType'
+  | 'price'
+  | 'exclusiveArea'
+  | 'builtYear'
+
+const TOPICS = [
+  ['region', '지역'],
+  ['rentalType', '임대유형'],
+  ['applicationStatus', '모집상태'],
+  ['agency', '공급기관'],
+  ['recruitmentType', '모집유형'],
+  ['price', '가격'],
+  ['exclusiveArea', '전용면적'],
+  ['builtYear', '준공년도'],
+] as const satisfies readonly (readonly [FilterTopic, string])[]
+
+const POPOVER_WIDTHS = {
+  region: 320,
+  rentalType: 300,
+  applicationStatus: 300,
+  agency: 300,
+  recruitmentType: 300,
+  price: 400,
+  exclusiveArea: 360,
+  builtYear: 320,
+} as const satisfies Record<FilterTopic, number>
+
+const TOPIC_KEYS = {
+  region: ['regionCode'],
+  rentalType: ['rentalTypes'],
+  applicationStatus: ['applicationStatuses'],
+  agency: ['agencyCodes'],
+  recruitmentType: ['recruitmentTypes'],
+  price: [
+    'minDeposit',
+    'maxDeposit',
+    'minMonthlyRent',
+    'maxMonthlyRent',
+  ],
+  exclusiveArea: ['minExclusiveArea', 'maxExclusiveArea'],
+  builtYear: ['builtYearFrom', 'builtYearTo'],
+} as const satisfies Record<
+  FilterTopic,
+  readonly (keyof ComplexSearchFilters)[]
+>
+
+export interface ComplexFilterToolbarProps {
+  readonly filters: ComplexSearchFilters
+  readonly onApply: (filters: ComplexSearchFilters) => void
+  readonly regionRepository?: PublicHousingRegionRepository
+}
+
+export function ComplexFilterToolbar({
+  filters,
+  onApply,
+  regionRepository = publicHousingRegionRepository,
+}: ComplexFilterToolbarProps) {
+  const [openTopic, setOpenTopic] = useState<FilterTopic | null>(null)
+  const [rovingTopic, setRovingTopic] = useState<FilterTopic>('region')
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [popoverPlacement, setPopoverPlacement] = useState<{
+    readonly anchorX: number
+    readonly left: number
+    readonly width: number
+  }>({
+    anchorX: 0,
+    left: 0,
+    width: POPOVER_WIDTHS.region,
+  })
+  const [resolvedRegionSummary, setResolvedRegionSummary] = useState<{
+    readonly label: string
+    readonly regionCode: string
+  } | null>(null)
+  const rootRef = useRef<HTMLElement>(null)
+  const scrollerRef = useRef<HTMLDivElement>(null)
+  const triggerRefs = useRef<Partial<Record<FilterTopic, HTMLButtonElement>>>(
+    {},
+  )
+
+  useEffect(() => {
+    if (openTopic === null) {
+      return
+    }
+
+    const closeFromOutside = (event: PointerEvent) => {
+      if (
+        event.target instanceof Node
+        && !rootRef.current?.contains(event.target)
+      ) {
+        setOpenTopic(null)
+        setErrorMessage(null)
+      }
+    }
+    const closeFromEscape = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') {
+        return
+      }
+      event.preventDefault()
+      const trigger = triggerRefs.current[openTopic]
+      setOpenTopic(null)
+      setErrorMessage(null)
+      trigger?.focus()
+    }
+
+    document.addEventListener('pointerdown', closeFromOutside, true)
+    document.addEventListener('keydown', closeFromEscape)
+    return () => {
+      document.removeEventListener('pointerdown', closeFromOutside, true)
+      document.removeEventListener('keydown', closeFromEscape)
+    }
+  }, [openTopic])
+
+  useLayoutEffect(() => {
+    if (openTopic === null) {
+      return
+    }
+    const root = rootRef.current
+    const scroller = scrollerRef.current
+    const trigger = triggerRefs.current[openTopic]
+    if (root === null || scroller === null || trigger === undefined) {
+      return
+    }
+
+    const updateAnchor = () => {
+      const rootRect = root.getBoundingClientRect()
+      const triggerRect = trigger.getBoundingClientRect()
+      const triggerCenter = triggerRect.left - rootRect.left
+        + (triggerRect.width / 2)
+      const requestedWidth = POPOVER_WIDTHS[openTopic]
+      const availableWidth = rootRect.width > 0
+        ? rootRect.width
+        : requestedWidth
+      const anchorX = Math.max(0, Math.min(triggerCenter, availableWidth))
+      const width = Math.min(requestedWidth, availableWidth)
+      const left = Math.max(
+        0,
+        Math.min(anchorX - (width / 2), availableWidth - width),
+      )
+      setPopoverPlacement({ anchorX, left, width })
+    }
+
+    updateAnchor()
+    window.addEventListener('resize', updateAnchor)
+    scroller.addEventListener('scroll', updateAnchor, { passive: true })
+    return () => {
+      window.removeEventListener('resize', updateAnchor)
+      scroller.removeEventListener('scroll', updateAnchor)
+    }
+  }, [openTopic])
+
+  useEffect(() => {
+    const regionCode = filters.regionCode
+    if (regionCode?.length !== 5) {
+      return
+    }
+    const provinceName = provinceNameForRegionCode(regionCode)
+    if (provinceName === null) {
+      return
+    }
+    const controller = new AbortController()
+    let active = true
+    regionRepository.search(provinceName, controller.signal)
+      .then((regions) => {
+        const selectedRegion = regions.find(
+          (region) => region.regionCode === regionCode,
+        )
+        if (active && selectedRegion !== undefined) {
+          setResolvedRegionSummary({
+            label: selectedRegion.displayName,
+            regionCode,
+          })
+        }
+      })
+      .catch(() => undefined)
+    return () => {
+      active = false
+      controller.abort()
+    }
+  }, [filters.regionCode, regionRepository])
+
+  function moveToolbarFocus(event: ReactKeyboardEvent<HTMLDivElement>) {
+    if (!['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key)) {
+      return
+    }
+    const currentIndex = TOPICS.findIndex(
+      ([topic]) => triggerRefs.current[topic] === event.target,
+    )
+    if (currentIndex < 0) {
+      return
+    }
+    event.preventDefault()
+    const lastIndex = TOPICS.length - 1
+    const nextIndex = event.key === 'Home'
+      ? 0
+      : event.key === 'End'
+        ? lastIndex
+        : event.key === 'ArrowRight'
+          ? (currentIndex + 1) % TOPICS.length
+          : (currentIndex - 1 + TOPICS.length) % TOPICS.length
+    const nextTopic = TOPICS[nextIndex][0]
+    setRovingTopic(nextTopic)
+    triggerRefs.current[nextTopic]?.focus()
+  }
+
+  function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    if (openTopic === null) {
+      return
+    }
+    const draft = topicDraftFromForm(openTopic, new FormData(event.currentTarget))
+    const rangeError = topicRangeError(openTopic, draft)
+    if (rangeError !== null) {
+      setErrorMessage(rangeError)
+      return
+    }
+    applyAndClose(openTopic, replaceTopic(filters, openTopic, draft))
+  }
+
+  function applyAndClose(topic: FilterTopic, next: ComplexSearchFilters) {
+    setErrorMessage(null)
+    onApply(next)
+    setOpenTopic(null)
+    triggerRefs.current[topic]?.focus()
+  }
+
+  const openLabel = topicLabel(openTopic)
+  const headingId = openTopic === null
+    ? undefined
+    : `complex-${openTopic}-filter-heading`
+
+  return (
+    <section ref={rootRef} className={styles.root}>
+      <div ref={scrollerRef} className={styles.scroller}>
+        <div
+          className={styles.toolbar}
+          role="toolbar"
+          aria-label="단지 검색 필터"
+          onKeyDown={moveToolbarFocus}
+        >
+          {TOPICS.map(([topic, label]) => {
+            const expanded = topic === openTopic
+            const summary = topicSummary(
+              filters,
+              topic,
+              resolvedRegionSummary !== null
+                && resolvedRegionSummary.regionCode === filters.regionCode
+                ? resolvedRegionSummary.label
+                : null,
+            )
+            const summaryId = `complex-${topic}-filter-summary`
+            return (
+              <button
+                ref={(node) => {
+                  if (node === null) {
+                    delete triggerRefs.current[topic]
+                  } else {
+                    triggerRefs.current[topic] = node
+                  }
+                }}
+                key={topic}
+                className={styles.trigger}
+                type="button"
+                tabIndex={rovingTopic === topic ? 0 : -1}
+                aria-controls={`complex-${topic}-filter-popover`}
+                aria-describedby={summary === null ? undefined : summaryId}
+                aria-expanded={expanded}
+                aria-label={`${label} 필터 ${expanded ? '닫기' : '열기'}`}
+                data-active={summary === null ? 'false' : 'true'}
+                onFocus={() => setRovingTopic(topic)}
+                onClick={() => {
+                  setErrorMessage(null)
+                  setOpenTopic((current) => current === topic ? null : topic)
+                }}
+              >
+                <span className={styles.triggerText}>
+                  <span>{label}</span>
+                  {summary !== null && (
+                    <>
+                      <span className={styles.visuallyHidden} id={summaryId}>
+                        적용됨: {summary}
+                      </span>
+                      <span className={styles.triggerSummary} aria-hidden="true">
+                        {summary}
+                      </span>
+                    </>
+                  )}
+                </span>
+                <span
+                  className={`${styles.chevron}${
+                    expanded ? ` ${styles.chevronExpanded}` : ''
+                  }`}
+                  aria-hidden="true"
+                />
+              </button>
+            )
+          })}
+        </div>
+      </div>
+
+      {openTopic !== null && openLabel !== null && headingId !== undefined && (
+        <section
+          className={styles.popover}
+          id={`complex-${openTopic}-filter-popover`}
+          aria-labelledby={headingId}
+          data-topic={openTopic}
+          style={{
+            '--popover-anchor-x': `${popoverPlacement.anchorX}px`,
+            '--popover-left': `${popoverPlacement.left}px`,
+            '--popover-width': `${popoverPlacement.width}px`,
+          } as CSSProperties}
+        >
+          <form
+            key={`${openTopic}-${searchFiltersSignature(filters)}`}
+            className={styles.form}
+            onSubmit={submit}
+          >
+            <h2 className={styles.popoverHeading} id={headingId}>
+              {openLabel} 필터
+            </h2>
+            <div className={styles.fields}>
+              <TopicFields
+                filters={filters}
+                regionRepository={regionRepository}
+                topic={openTopic}
+              />
+            </div>
+            {errorMessage !== null && (
+              <p className={styles.error} role="alert">{errorMessage}</p>
+            )}
+            <div className={styles.actions}>
+              <button
+                className={styles.reset}
+                type="button"
+                aria-label={`${openLabel} 필터 초기화`}
+                onClick={() => applyAndClose(
+                  openTopic,
+                  replaceTopic(filters, openTopic, {}),
+                )}
+              >초기화</button>
+              <button
+                className={styles.apply}
+                type="submit"
+                aria-label={`${openLabel} 필터 적용`}
+              >적용</button>
+            </div>
+          </form>
+        </section>
+      )}
+    </section>
+  )
+}
+
+function TopicFields({
+  filters,
+  regionRepository,
+  topic,
+}: {
+  readonly filters: ComplexSearchFilters
+  readonly regionRepository: PublicHousingRegionRepository
+  readonly topic: FilterTopic
+}) {
+  switch (topic) {
+    case 'region':
+      return (
+        <RegionFields
+          initialRegionCode={filters.regionCode ?? ''}
+          repository={regionRepository}
+        />
+      )
+    case 'rentalType':
+      return <ChoiceGroup label="임대유형" name="rentalTypes" values={filters.rentalTypes} options={RENTAL_TYPE_OPTIONS} />
+    case 'applicationStatus':
+      return <ChoiceGroup label="모집상태" name="applicationStatuses" values={filters.applicationStatuses} options={APPLICATION_STATUS_OPTIONS} />
+    case 'agency':
+      return <ChoiceGroup label="공급기관" name="agencyCodes" values={filters.agencyCodes} options={AGENCY_OPTIONS} />
+    case 'recruitmentType':
+      return <ChoiceGroup label="모집유형" name="recruitmentTypes" values={filters.recruitmentTypes} options={RECRUITMENT_TYPE_OPTIONS} />
+    case 'price':
+      return (
+        <div className={styles.rangeStack}>
+          <DualRangeFilter
+            legend="임대보증금"
+            maximumName="maxDeposit"
+            minimumName="minDeposit"
+            minimum={0}
+            maximum={500_000_000}
+            step={10_000_000}
+            majorStep={100_000_000}
+            initialMinimum={filters.minDeposit ?? null}
+            initialMaximum={filters.maxDeposit ?? null}
+            formatValue={formatDeposit}
+            formatTick={formatDepositTick}
+            presets={DEPOSIT_PRESETS}
+            preserveInitialValuesUntilChange
+          />
+          <DualRangeFilter
+            legend="월 임대료"
+            maximumName="maxMonthlyRent"
+            minimumName="minMonthlyRent"
+            minimum={0}
+            maximum={600_000}
+            step={10_000}
+            majorStep={100_000}
+            initialMinimum={filters.minMonthlyRent ?? null}
+            initialMaximum={filters.maxMonthlyRent ?? null}
+            formatValue={formatMonthlyRent}
+            formatTick={formatMonthlyRentTick}
+            presets={MONTHLY_RENT_PRESETS}
+            preserveInitialValuesUntilChange
+          />
+        </div>
+      )
+    case 'exclusiveArea':
+      return (
+        <DualRangeFilter
+          legend="전용면적"
+          maximumName="maxExclusiveArea"
+          minimumName="minExclusiveArea"
+          minimum={0}
+          maximum={132}
+          step={3.3}
+          majorStep={33}
+          initialMinimum={filters.minExclusiveArea ?? null}
+          initialMaximum={filters.maxExclusiveArea ?? null}
+          formatValue={formatArea}
+          formatTick={formatAreaTick}
+          presets={AREA_PRESETS}
+          preserveInitialValuesUntilChange
+        />
+      )
+    case 'builtYear':
+      return <BuiltYearFields filters={filters} />
+  }
+}
+
+function ChoiceGroup({
+  label,
+  name,
+  options,
+  values = [],
+}: {
+  readonly label: string
+  readonly name: string
+  readonly options: readonly (readonly [string, string])[]
+  readonly values?: readonly string[]
+}) {
+  const selected = new Set(values)
+  return (
+    <fieldset className={styles.choiceGroup}>
+      <legend>{label}</legend>
+      <div className={styles.choices}>
+        {options.map(([value, optionLabel]) => (
+          <label key={value} className={styles.choice}>
+            <input
+              type="checkbox"
+              name={name}
+              value={value}
+              defaultChecked={selected.has(value)}
+            />
+            <span>
+              <span className={styles.choiceCheck} aria-hidden="true">✓</span>
+              {optionLabel}
+            </span>
+          </label>
+        ))}
+      </div>
+    </fieldset>
+  )
+}
+
+function RegionFields({
+  initialRegionCode,
+  repository,
+}: {
+  readonly initialRegionCode: string
+  readonly repository: PublicHousingRegionRepository
+}) {
+  const [provinceCode, setProvinceCode] = useState(
+    provinceCodeFrom(initialRegionCode),
+  )
+  const [districtCode, setDistrictCode] = useState(
+    initialRegionCode.length === 5 ? initialRegionCode : '',
+  )
+  const [regions, setRegions] = useState<readonly PublicHousingRegion[]>([])
+  const [loadStatus, setLoadStatus] = useState<'idle' | 'loading' | 'error'>(
+    'idle',
+  )
+  const loadErrorId = 'complex-region-load-error'
+  const provinceName = provinceNameForRegionCode(provinceCode)
+  const districts = useMemo(() => {
+    const options = districtRegionOptionsForProvince(regions, provinceCode)
+    if (
+      districtCode === ''
+      || options.some(({ regionCode }) => regionCode === districtCode)
+    ) {
+      return options
+    }
+    return [
+      regions.find(({ regionCode }) => regionCode === districtCode)
+        ?? selectedRegionFallback(districtCode, provinceName),
+      ...options,
+    ]
+  }, [districtCode, provinceCode, provinceName, regions])
+
+  useEffect(() => {
+    if (provinceName === null) {
+      setRegions([])
+      setLoadStatus('idle')
+      return
+    }
+    const controller = new AbortController()
+    let active = true
+    setLoadStatus('loading')
+    repository.search(provinceName, controller.signal)
+      .then((items) => {
+        if (active) {
+          setRegions(items)
+          setLoadStatus('idle')
+        }
+      })
+      .catch((error: unknown) => {
+        if (active && !isAbortError(error)) {
+          setRegions([])
+          setLoadStatus('error')
+        }
+      })
+    return () => {
+      active = false
+      controller.abort()
+    }
+  }, [provinceName, repository])
+
+  return (
+    <div className={styles.regionFields}>
+      <label className={styles.field}>
+        <span>시·도</span>
+        <select
+          name="provinceCode"
+          value={provinceCode}
+          onChange={(event) => {
+            setProvinceCode(event.currentTarget.value)
+            setDistrictCode('')
+          }}
+        >
+          <option value="">전체</option>
+          {PUBLIC_HOUSING_PROVINCE_OPTIONS.map(([code, label]) => (
+            <option key={code} value={code}>{label}</option>
+          ))}
+        </select>
+      </label>
+      <label className={styles.field}>
+        <span>시·군·구</span>
+        <select
+          name="districtCode"
+          value={districtCode}
+          disabled={provinceCode === ''}
+          aria-describedby={loadStatus === 'error' ? loadErrorId : undefined}
+          onChange={(event) => setDistrictCode(event.currentTarget.value)}
+        >
+          <option value="">{provinceCode === '' ? '시·도를 먼저 선택' : '전체'}</option>
+          {districts.map(({ districtName, regionCode }) => (
+            <option key={regionCode} value={regionCode}>
+              {districtName ?? regionCode}
+            </option>
+          ))}
+        </select>
+      </label>
+      {loadStatus === 'loading' && <small role="status">시·군·구를 불러오는 중입니다.</small>}
+      {loadStatus === 'error' && (
+        <small
+          className={styles.regionError}
+          id={loadErrorId}
+          role="alert"
+        >
+          시·군·구를 불러오지 못했습니다. 시·도만 적용할 수 있습니다.
+        </small>
+      )}
+    </div>
+  )
+}
+
+function BuiltYearFields({ filters }: {
+  readonly filters: ComplexSearchFilters
+}) {
+  const years = builtYearOptions(
+    filters.builtYearFrom,
+    filters.builtYearTo,
+  )
+  return (
+    <fieldset className={styles.yearRange}>
+      <legend>준공년도</legend>
+      <label>
+        <span>최소 준공년도</span>
+        <select
+          name="builtYearFrom"
+          aria-label="최소 준공년도"
+          defaultValue={filters.builtYearFrom ?? ''}
+        >
+          <option value="">제한 없음</option>
+          {years.map((year) => (
+            <option key={year} value={year}>{year}년</option>
+          ))}
+        </select>
+      </label>
+      <span aria-hidden="true">~</span>
+      <label>
+        <span>최대 준공년도</span>
+        <select
+          name="builtYearTo"
+          aria-label="최대 준공년도"
+          defaultValue={filters.builtYearTo ?? ''}
+        >
+          <option value="">제한 없음</option>
+          {years.map((year) => (
+            <option key={year} value={year}>{year}년</option>
+          ))}
+        </select>
+      </label>
+    </fieldset>
+  )
+}
+
+function builtYearOptions(
+  ...selectedYears: readonly (number | null | undefined)[]
+) {
+  const latestYear = new Date().getFullYear() + 5
+  const years = new Set(Array.from(
+    { length: latestYear - 1980 + 1 },
+    (_, index) => latestYear - index,
+  ))
+  selectedYears.forEach((year) => {
+    if (
+      year != null
+      && Number.isInteger(year)
+      && year >= 1
+      && year <= 9999
+    ) {
+      years.add(year)
+    }
+  })
+  return [...years].sort((left, right) => right - left)
+}
+
+function topicDraftFromForm(topic: FilterTopic, data: FormData) {
+  switch (topic) {
+    case 'region': {
+      const regionCode = textValue(data, 'districtCode')
+        || textValue(data, 'provinceCode')
+      return regionCode === '' ? {} : { regionCode }
+    }
+    case 'rentalType':
+      return optionalValues('rentalTypes', formValues<RentalTypeFilter>(data, 'rentalTypes'))
+    case 'applicationStatus':
+      return optionalValues('applicationStatuses', formValues<ApplicationStatusFilter>(data, 'applicationStatuses'))
+    case 'agency':
+      return optionalValues('agencyCodes', formValues<AgencyCodeFilter>(data, 'agencyCodes'))
+    case 'recruitmentType':
+      return optionalValues('recruitmentTypes', formValues<RecruitmentTypeFilter>(data, 'recruitmentTypes'))
+    case 'price':
+      return numbersFromForm(data, TOPIC_KEYS.price)
+    case 'exclusiveArea':
+      return numbersFromForm(data, TOPIC_KEYS.exclusiveArea)
+    case 'builtYear':
+      return numbersFromForm(data, TOPIC_KEYS.builtYear)
+  }
+}
+
+function replaceTopic(
+  filters: ComplexSearchFilters,
+  topic: FilterTopic,
+  draft: ComplexSearchFilters,
+) {
+  const next: Record<string, unknown> = { ...filters }
+  TOPIC_KEYS[topic].forEach((key) => delete next[key])
+  return { ...next, ...draft } as ComplexSearchFilters
+}
+
+function topicRangeError(topic: FilterTopic, draft: ComplexSearchFilters) {
+  return topic === 'builtYear'
+    && draft.builtYearFrom != null
+    && draft.builtYearTo != null
+    && draft.builtYearFrom > draft.builtYearTo
+    ? '최소 준공년도는 최대 준공년도보다 클 수 없습니다.'
+    : null
+}
+
+function topicSummary(
+  filters: ComplexSearchFilters,
+  topic: FilterTopic,
+  resolvedRegionName: string | null,
+) {
+  switch (topic) {
+    case 'region': {
+      if (!filters.regionCode) return null
+      const name = provinceNameForRegionCode(filters.regionCode)
+      return name === null
+        ? filters.regionCode
+        : filters.regionCode.length === 5
+          ? resolvedRegionName ?? `${name} ${filters.regionCode}`
+          : name
+    }
+    case 'rentalType':
+      return optionsSummary(filters.rentalTypes, RENTAL_TYPE_OPTIONS)
+    case 'applicationStatus':
+      return optionsSummary(filters.applicationStatuses, APPLICATION_STATUS_OPTIONS)
+    case 'agency':
+      return optionsSummary(filters.agencyCodes, AGENCY_OPTIONS)
+    case 'recruitmentType':
+      return optionsSummary(filters.recruitmentTypes, RECRUITMENT_TYPE_OPTIONS)
+    case 'price': {
+      const deposit = rangeSummary(filters.minDeposit, filters.maxDeposit, formatDeposit)
+      const rent = rangeSummary(filters.minMonthlyRent, filters.maxMonthlyRent, formatRentSummary)
+      return [
+        deposit === null ? null : `보증금 ${deposit}`,
+        rent === null ? null : `월세 ${rent}`,
+      ].filter((value): value is string => value !== null).join(' · ') || null
+    }
+    case 'exclusiveArea':
+      return suffixedRangeSummary(
+        filters.minExclusiveArea,
+        filters.maxExclusiveArea,
+        (value) => compact(value / 3.3),
+        '평',
+      )
+    case 'builtYear':
+      return suffixedRangeSummary(
+        filters.builtYearFrom,
+        filters.builtYearTo,
+        String,
+        '년',
+      )
+  }
+}
+
+function topicLabel(topic: FilterTopic | null) {
+  return TOPICS.find(([candidate]) => candidate === topic)?.[1] ?? null
+}
+
+function optionsSummary(
+  values: readonly string[] | undefined,
+  options: readonly (readonly [string, string])[],
+) {
+  if (!values?.length) return null
+  if (values.length > 1) return `${values.length}개 선택`
+  return options.find(([value]) => value === values[0])?.[1] ?? values[0]
+}
+
+function rangeSummary(
+  minimum: number | null | undefined,
+  maximum: number | null | undefined,
+  format: (value: number) => string,
+) {
+  if (minimum == null && maximum == null) return null
+  if (minimum == null) return `${format(maximum as number)} 이하`
+  if (maximum == null) return `${format(minimum)} 이상`
+  return `${format(minimum)}~${format(maximum)}`
+}
+
+function suffixedRangeSummary(
+  minimum: number | null | undefined,
+  maximum: number | null | undefined,
+  format: (value: number) => string,
+  suffix: string,
+) {
+  if (minimum == null && maximum == null) return null
+  if (minimum == null) return `${format(maximum as number)}${suffix} 이하`
+  if (maximum == null) return `${format(minimum)}${suffix} 이상`
+  return `${format(minimum)}~${format(maximum)}${suffix}`
+}
+
+function optionalValues<Value extends string>(
+  key:
+    | 'rentalTypes'
+    | 'applicationStatuses'
+    | 'agencyCodes'
+    | 'recruitmentTypes',
+  values: readonly Value[],
+): ComplexSearchFilters {
+  return values.length === 0 ? {} : { [key]: values } as ComplexSearchFilters
+}
+
+function numbersFromForm(
+  data: FormData,
+  names: readonly (keyof ComplexSearchFilters)[],
+) {
+  return Object.fromEntries(names.flatMap((name) => {
+    const value = textValue(data, name)
+    return value === '' ? [] : [[name, Number(value)]]
+  })) as ComplexSearchFilters
+}
+
+function textValue(data: FormData, name: string) {
+  const value = data.get(name)
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function formValues<Value extends string>(data: FormData, name: string) {
+  return data.getAll(name).filter(
+    (value): value is Value => typeof value === 'string',
+  )
+}
+
+function provinceCodeFrom(regionCode: string) {
+  const code = regionCode.slice(0, 2)
+  return PUBLIC_HOUSING_PROVINCE_OPTIONS.some(([value]) => value === code)
+    ? code
+    : ''
+}
+
+function selectedRegionFallback(
+  regionCode: string,
+  provinceName: string | null,
+): PublicHousingRegion {
+  return {
+    regionCode,
+    provinceName: provinceName ?? '',
+    districtName: `선택 지역 (${regionCode})`,
+    displayName: `선택 지역 (${regionCode})`,
+  }
+}
+
+function formatDeposit(value: number) {
+  return `${compact(value / 100_000_000)}억`
+}
+
+function formatDepositTick(value: number) {
+  return value === 500_000_000 ? '5억+' : value === 0 ? '0' : formatDeposit(value)
+}
+
+function formatMonthlyRent(value: number) {
+  return `${compact(value / 10_000)}만 원`
+}
+
+function formatRentSummary(value: number) {
+  return `${compact(value / 10_000)}만`
+}
+
+function formatMonthlyRentTick(value: number) {
+  return value === 600_000 ? '60만+' : value === 0 ? '0' : formatRentSummary(value)
+}
+
+function formatArea(value: number) {
+  return `${compact(value / 3.3)}평`
+}
+
+function formatAreaTick(value: number) {
+  return value === 132 ? '40평+' : value === 0 ? '0' : formatArea(value)
+}
+
+function compact(value: number) {
+  return String(Number(value.toFixed(1)))
+}
+
+function isAbortError(error: unknown) {
+  return typeof error === 'object'
+    && error !== null
+    && 'name' in error
+    && error.name === 'AbortError'
+}

--- a/frontend/src/public-housing/filters/ComplexFilterToolbar.tsx
+++ b/frontend/src/public-housing/filters/ComplexFilterToolbar.tsx
@@ -1,5 +1,6 @@
 import {
   type CSSProperties,
+  Fragment,
   type FormEvent,
   type KeyboardEvent as ReactKeyboardEvent,
   useEffect,
@@ -62,7 +63,6 @@ const RECRUITMENT_TYPE_OPTIONS = [
 ] as const satisfies readonly (readonly [RecruitmentTypeFilter, string])[]
 
 const DEPOSIT_PRESETS = [
-  { label: '전체', minimum: null, maximum: null },
   { label: '1억 이하', minimum: null, maximum: 100_000_000 },
   { label: '1~2억', minimum: 100_000_000, maximum: 200_000_000 },
   { label: '2~3억', minimum: 200_000_000, maximum: 300_000_000 },
@@ -71,17 +71,14 @@ const DEPOSIT_PRESETS = [
 ] as const satisfies readonly DualRangeFilterPreset[]
 
 const MONTHLY_RENT_PRESETS = [
-  { label: '전체', minimum: null, maximum: null },
   { label: '10만 이하', minimum: null, maximum: 100_000 },
   { label: '10~20만', minimum: 100_000, maximum: 200_000 },
   { label: '20~30만', minimum: 200_000, maximum: 300_000 },
   { label: '30~40만', minimum: 300_000, maximum: 400_000 },
   { label: '40~60만', minimum: 400_000, maximum: 590_000 },
-  { label: '60만 이상', minimum: 600_000, maximum: null },
 ] as const satisfies readonly DualRangeFilterPreset[]
 
 const AREA_PRESETS = [
-  { label: '전체', minimum: null, maximum: null },
   { label: '10평 미만', minimum: null, maximum: 29.7 },
   { label: '10평대', minimum: 33, maximum: 62.7 },
   { label: '20평대', minimum: 66, maximum: 95.7 },
@@ -109,14 +106,31 @@ const TOPICS = [
   ['builtYear', '준공년도'],
 ] as const satisfies readonly (readonly [FilterTopic, string])[]
 
+const MOBILE_PRIMARY_TOPICS = [
+  ['region', '지역'],
+  ['rentalType', '임대유형'],
+  ['price', '가격'],
+] as const satisfies readonly (readonly [FilterTopic, string])[]
+
+const MOBILE_SHEET_TOPICS = [
+  ['region', '지역'],
+  ['rentalType', '임대유형'],
+  ['price', '가격'],
+  ['exclusiveArea', '전용면적'],
+  ['applicationStatus', '모집상태'],
+  ['agency', '공급기관'],
+  ['recruitmentType', '모집유형'],
+  ['builtYear', '준공년도'],
+] as const satisfies readonly (readonly [FilterTopic, string])[]
+
 const POPOVER_WIDTHS = {
   region: 320,
-  rentalType: 300,
-  applicationStatus: 300,
-  agency: 300,
-  recruitmentType: 300,
-  price: 400,
-  exclusiveArea: 360,
+  rentalType: 280,
+  applicationStatus: 280,
+  agency: 280,
+  recruitmentType: 280,
+  price: 420,
+  exclusiveArea: 380,
   builtYear: 320,
 } as const satisfies Record<FilterTopic, number>
 
@@ -143,23 +157,34 @@ export interface ComplexFilterToolbarProps {
   readonly filters: ComplexSearchFilters
   readonly onApply: (filters: ComplexSearchFilters) => void
   readonly regionRepository?: PublicHousingRegionRepository
+  readonly resultCountLabel?: string
 }
 
 export function ComplexFilterToolbar({
   filters,
   onApply,
   regionRepository = publicHousingRegionRepository,
+  resultCountLabel,
 }: ComplexFilterToolbarProps) {
+  const filtersSignature = searchFiltersSignature(filters)
   const [openTopic, setOpenTopic] = useState<FilterTopic | null>(null)
+  const [mobileSheetOpen, setMobileSheetOpen] = useState(false)
+  const [mobileDraftFilters, setMobileDraftFilters] = useState(filters)
+  const [mobileDraftDirty, setMobileDraftDirty] = useState(false)
+  const [mobileFormRevision, setMobileFormRevision] = useState(0)
+  const [mobileInitialTopic, setMobileInitialTopic] =
+    useState<FilterTopic | null>(null)
   const [rovingTopic, setRovingTopic] = useState<FilterTopic>('region')
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const [popoverPlacement, setPopoverPlacement] = useState<{
     readonly anchorX: number
     readonly left: number
+    readonly top: number
     readonly width: number
   }>({
     anchorX: 0,
     left: 0,
+    top: 0,
     width: POPOVER_WIDTHS.region,
   })
   const [resolvedRegionSummary, setResolvedRegionSummary] = useState<{
@@ -168,6 +193,13 @@ export function ComplexFilterToolbar({
   } | null>(null)
   const rootRef = useRef<HTMLElement>(null)
   const scrollerRef = useRef<HTMLDivElement>(null)
+  const mobileSheetRef = useRef<HTMLElement>(null)
+  const mobileSheetBodyRef = useRef<HTMLDivElement>(null)
+  const mobileCloseRef = useRef<HTMLButtonElement>(null)
+  const mobileResetRef = useRef<HTMLButtonElement>(null)
+  const mobileResetFocusPendingRef = useRef(false)
+  const mobileTriggerRef = useRef<HTMLButtonElement | null>(null)
+  const mobileOpenedFiltersSignatureRef = useRef(filtersSignature)
   const triggerRefs = useRef<Partial<Record<FilterTopic, HTMLButtonElement>>>(
     {},
   )
@@ -205,6 +237,104 @@ export function ComplexFilterToolbar({
     }
   }, [openTopic])
 
+  useEffect(() => {
+    if (!mobileSheetOpen) {
+      return
+    }
+    const opener = mobileTriggerRef.current
+    const html = document.documentElement
+    const body = document.body
+    const previousHtmlOverflow = html.style.overflow
+    const previousBodyOverflow = body.style.overflow
+    const close = () => {
+      setMobileSheetOpen(false)
+      setMobileInitialTopic(null)
+      setErrorMessage(null)
+      opener?.focus()
+    }
+    const closeAtDesktopBreakpoint = () => {
+      if (window.innerWidth <= 767) {
+        return
+      }
+      const desktopTopic = mobileInitialTopic ?? 'region'
+      setMobileSheetOpen(false)
+      setMobileInitialTopic(null)
+      setErrorMessage(null)
+      window.requestAnimationFrame(() => {
+        triggerRefs.current[desktopTopic]?.focus()
+      })
+    }
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault()
+        event.stopPropagation()
+        close()
+        return
+      }
+      if (event.key !== 'Tab' || mobileSheetRef.current === null) {
+        return
+      }
+      const focusable = focusableElements(mobileSheetRef.current)
+      const first = focusable[0]
+      const last = focusable.at(-1)
+      if (first === undefined || last === undefined) {
+        return
+      }
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault()
+        last.focus()
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault()
+        first.focus()
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown, true)
+    window.addEventListener('resize', closeAtDesktopBreakpoint)
+    html.style.overflow = 'hidden'
+    body.style.overflow = 'hidden'
+    mobileCloseRef.current?.focus()
+    if (mobileInitialTopic !== null) {
+      const scrollContainer = mobileSheetBodyRef.current
+      const target = mobileSheetRef.current?.querySelector<HTMLElement>(
+        `[data-mobile-topic="${mobileInitialTopic}"]`,
+      )
+      if (scrollContainer !== null && target !== null && target !== undefined) {
+        const containerTop = scrollContainer.getBoundingClientRect().top
+        const targetTop = target.getBoundingClientRect().top
+        scrollContainer.scrollTop += targetTop - containerTop - 12
+      }
+    }
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown, true)
+      window.removeEventListener('resize', closeAtDesktopBreakpoint)
+      html.style.overflow = previousHtmlOverflow
+      body.style.overflow = previousBodyOverflow
+    }
+  }, [mobileInitialTopic, mobileSheetOpen])
+
+  useLayoutEffect(() => {
+    if (!mobileSheetOpen || !mobileResetFocusPendingRef.current) {
+      return
+    }
+    mobileResetFocusPendingRef.current = false
+    mobileResetRef.current?.focus()
+  }, [mobileFormRevision, mobileSheetOpen])
+
+  useEffect(() => {
+    if (
+      !mobileSheetOpen
+      || mobileOpenedFiltersSignatureRef.current === filtersSignature
+    ) {
+      return
+    }
+    const opener = mobileTriggerRef.current
+    setMobileSheetOpen(false)
+    setMobileInitialTopic(null)
+    setErrorMessage(null)
+    opener?.focus()
+  }, [filtersSignature, mobileSheetOpen])
+
   useLayoutEffect(() => {
     if (openTopic === null) {
       return
@@ -226,12 +356,17 @@ export function ComplexFilterToolbar({
         ? rootRect.width
         : requestedWidth
       const anchorX = Math.max(0, Math.min(triggerCenter, availableWidth))
-      const width = Math.min(requestedWidth, availableWidth)
+      const width = Math.min(
+        Math.max(280, Math.min(420, requestedWidth)),
+        availableWidth,
+      )
+      const triggerLeft = triggerRect.left - rootRect.left
       const left = Math.max(
         0,
-        Math.min(anchorX - (width / 2), availableWidth - width),
+        Math.min(triggerLeft, availableWidth - width),
       )
-      setPopoverPlacement({ anchorX, left, width })
+      const top = Math.max(0, triggerRect.bottom - rootRect.top + 8)
+      setPopoverPlacement({ anchorX, left, top, width })
     }
 
     updateAnchor()
@@ -241,7 +376,7 @@ export function ComplexFilterToolbar({
       window.removeEventListener('resize', updateAnchor)
       scroller.removeEventListener('scroll', updateAnchor)
     }
-  }, [openTopic])
+  }, [openTopic, resolvedRegionSummary])
 
   useEffect(() => {
     const regionCode = filters.regionCode
@@ -297,6 +432,53 @@ export function ComplexFilterToolbar({
     triggerRefs.current[nextTopic]?.focus()
   }
 
+  function openMobileSheet(
+    topic: FilterTopic | null,
+    trigger: HTMLButtonElement,
+  ) {
+    mobileTriggerRef.current = trigger
+    mobileOpenedFiltersSignatureRef.current = filtersSignature
+    setOpenTopic(null)
+    setErrorMessage(null)
+    setMobileDraftFilters(filters)
+    setMobileDraftDirty(false)
+    setMobileFormRevision((current) => current + 1)
+    setMobileInitialTopic(topic)
+    setMobileSheetOpen(true)
+  }
+
+  function closeMobileSheet() {
+    const opener = mobileTriggerRef.current
+    setMobileSheetOpen(false)
+    setMobileInitialTopic(null)
+    setErrorMessage(null)
+    opener?.focus()
+  }
+
+  function submitMobileSheet(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    const data = new FormData(event.currentTarget)
+    const next = MOBILE_SHEET_TOPICS.reduce<ComplexSearchFilters>(
+      (draft, [topic]) => ({ ...draft, ...topicDraftFromForm(topic, data) }),
+      {},
+    )
+    const rangeError = topicRangeError('builtYear', next)
+    if (rangeError !== null) {
+      setErrorMessage(rangeError)
+      return
+    }
+    onApply(next)
+    closeMobileSheet()
+  }
+
+  function resetMobileSheet() {
+    setErrorMessage(null)
+    mobileResetFocusPendingRef.current = true
+    setMobileDraftFilters({})
+    setMobileDraftDirty(filtersSignature !== '')
+    setMobileFormRevision((current) => current + 1)
+  }
+
   function submit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()
     if (openTopic === null) {
@@ -322,124 +504,267 @@ export function ComplexFilterToolbar({
   const headingId = openTopic === null
     ? undefined
     : `complex-${openTopic}-filter-heading`
+  const resolvedRegionName = resolvedRegionSummary !== null
+    && resolvedRegionSummary.regionCode === filters.regionCode
+    ? resolvedRegionSummary.label
+    : null
+  const appliedTopicCount = TOPICS.reduce(
+    (count, [topic]) => count + (
+      topicSummary(filters, topic, resolvedRegionName) === null ? 0 : 1
+    ),
+    0,
+  )
+  const mobileResultAction = !mobileDraftDirty
+    && resultCountLabel !== undefined
+    && /^\d+곳(?: 이상)?$/.test(resultCountLabel)
+    ? `단지 ${resultCountLabel} 보기`
+    : '단지 보기'
 
   return (
     <section ref={rootRef} className={styles.root}>
-      <div ref={scrollerRef} className={styles.scroller}>
-        <div
-          className={styles.toolbar}
-          role="toolbar"
-          aria-label="단지 검색 필터"
-          onKeyDown={moveToolbarFocus}
-        >
-          {TOPICS.map(([topic, label]) => {
-            const expanded = topic === openTopic
-            const summary = topicSummary(
-              filters,
-              topic,
-              resolvedRegionSummary !== null
-                && resolvedRegionSummary.regionCode === filters.regionCode
-                ? resolvedRegionSummary.label
-                : null,
-            )
-            const summaryId = `complex-${topic}-filter-summary`
-            return (
-              <button
-                ref={(node) => {
-                  if (node === null) {
-                    delete triggerRefs.current[topic]
-                  } else {
-                    triggerRefs.current[topic] = node
-                  }
-                }}
-                key={topic}
-                className={styles.trigger}
-                type="button"
-                tabIndex={rovingTopic === topic ? 0 : -1}
-                aria-controls={`complex-${topic}-filter-popover`}
-                aria-describedby={summary === null ? undefined : summaryId}
-                aria-expanded={expanded}
-                aria-label={`${label} 필터 ${expanded ? '닫기' : '열기'}`}
-                data-active={summary === null ? 'false' : 'true'}
-                onFocus={() => setRovingTopic(topic)}
-                onClick={() => {
-                  setErrorMessage(null)
-                  setOpenTopic((current) => current === topic ? null : topic)
-                }}
-              >
-                <span className={styles.triggerText}>
-                  <span>{label}</span>
+      <div className={styles.desktopFilters}>
+        <div ref={scrollerRef} className={styles.scroller}>
+          <div
+            className={styles.toolbar}
+            role="toolbar"
+            aria-label="단지 검색 필터"
+            onKeyDown={moveToolbarFocus}
+          >
+            {TOPICS.map(([topic, label]) => {
+              const expanded = topic === openTopic
+              const summary = topicSummary(
+                filters,
+                topic,
+                resolvedRegionName,
+              )
+              const summaryId = `complex-${topic}-filter-summary`
+              return (
+                <Fragment key={topic}>
+                  <button
+                    ref={(node) => {
+                      if (node === null) {
+                        delete triggerRefs.current[topic]
+                      } else {
+                        triggerRefs.current[topic] = node
+                      }
+                    }}
+                    className={styles.trigger}
+                    type="button"
+                    title={summary ?? label}
+                    tabIndex={rovingTopic === topic ? 0 : -1}
+                    aria-controls={`complex-${topic}-filter-popover`}
+                    aria-describedby={summary === null ? undefined : summaryId}
+                    aria-expanded={expanded}
+                    aria-label={`${label} 필터 ${expanded ? '닫기' : '열기'}`}
+                    data-active={summary === null ? 'false' : 'true'}
+                    onFocus={() => setRovingTopic(topic)}
+                    onClick={() => {
+                      setErrorMessage(null)
+                      setOpenTopic((current) => current === topic ? null : topic)
+                    }}
+                  >
+                    <span className={styles.triggerText} aria-hidden="true">
+                      {summary ?? label}
+                    </span>
+                    <span
+                      className={`${styles.chevron}${
+                        expanded ? ` ${styles.chevronExpanded}` : ''
+                      }`}
+                      aria-hidden="true"
+                    />
+                  </button>
                   {summary !== null && (
-                    <>
-                      <span className={styles.visuallyHidden} id={summaryId}>
-                        적용됨: {summary}
-                      </span>
-                      <span className={styles.triggerSummary} aria-hidden="true">
-                        {summary}
-                      </span>
-                    </>
+                    <span className={styles.visuallyHidden} id={summaryId}>
+                      적용됨: {summary}
+                    </span>
                   )}
-                </span>
-                <span
-                  className={`${styles.chevron}${
-                    expanded ? ` ${styles.chevronExpanded}` : ''
-                  }`}
-                  aria-hidden="true"
-                />
-              </button>
-            )
-          })}
+                </Fragment>
+              )
+            })}
+          </div>
         </div>
+
+        {openTopic !== null && openLabel !== null && headingId !== undefined && (
+          <section
+            className={styles.popover}
+            id={`complex-${openTopic}-filter-popover`}
+            aria-labelledby={headingId}
+            data-topic={openTopic}
+            style={{
+              '--popover-anchor-x': `${popoverPlacement.anchorX}px`,
+              '--popover-left': `${popoverPlacement.left}px`,
+              '--popover-top': `${popoverPlacement.top}px`,
+              '--popover-width': `${popoverPlacement.width}px`,
+            } as CSSProperties}
+          >
+            <form
+              key={`${openTopic}-${searchFiltersSignature(filters)}`}
+              className={styles.form}
+              onSubmit={submit}
+            >
+              <h2 className={styles.popoverHeading} id={headingId}>
+                {openLabel} 필터
+              </h2>
+              <div className={styles.fields}>
+                <TopicFields
+                  filters={filters}
+                  regionRepository={regionRepository}
+                  topic={openTopic}
+                />
+              </div>
+              {errorMessage !== null && (
+                <p className={styles.error} role="alert">{errorMessage}</p>
+              )}
+              <div className={styles.actions}>
+                <button
+                  className={styles.reset}
+                  type="button"
+                  aria-label={`${openLabel} 필터 초기화`}
+                  onClick={() => applyAndClose(
+                    openTopic,
+                    replaceTopic(filters, openTopic, {}),
+                  )}
+                >초기화</button>
+                <button
+                  className={styles.apply}
+                  type="submit"
+                  aria-label={`${openLabel} 필터 적용`}
+                >적용</button>
+              </div>
+            </form>
+          </section>
+        )}
       </div>
 
-      {openTopic !== null && openLabel !== null && headingId !== undefined && (
-        <section
-          className={styles.popover}
-          id={`complex-${openTopic}-filter-popover`}
-          aria-labelledby={headingId}
-          data-topic={openTopic}
-          style={{
-            '--popover-anchor-x': `${popoverPlacement.anchorX}px`,
-            '--popover-left': `${popoverPlacement.left}px`,
-            '--popover-width': `${popoverPlacement.width}px`,
-          } as CSSProperties}
+      <div
+        className={styles.mobileToolbar}
+        role="toolbar"
+        aria-label="모바일 단지 검색 필터"
+      >
+        {MOBILE_PRIMARY_TOPICS.map(([topic, label]) => {
+          const summary = topicSummary(filters, topic, resolvedRegionName)
+          return (
+            <button
+              key={topic}
+              className={styles.mobileTrigger}
+              type="button"
+              title={summary ?? label}
+              aria-controls="mobile-complex-filter-sheet"
+              aria-expanded={mobileSheetOpen}
+              aria-label={summary === null
+                ? `${label} 조건으로 전체 단지 필터 열기`
+                : `${label} ${summary}, 전체 단지 필터 열기`}
+              data-active={summary === null ? 'false' : 'true'}
+              onClick={(event) => openMobileSheet(topic, event.currentTarget)}
+            >
+              <span>{summary ?? label}</span>
+            </button>
+          )
+        })}
+        <button
+          className={styles.mobileAllTrigger}
+          type="button"
+          aria-controls="mobile-complex-filter-sheet"
+          aria-expanded={mobileSheetOpen}
+          aria-label={appliedTopicCount > 0
+            ? `전체 단지 필터 열기, ${appliedTopicCount}개 적용`
+            : '전체 단지 필터 열기'}
+          data-active={appliedTopicCount > 0 ? 'true' : 'false'}
+          onClick={(event) => openMobileSheet(null, event.currentTarget)}
         >
-          <form
-            key={`${openTopic}-${searchFiltersSignature(filters)}`}
-            className={styles.form}
-            onSubmit={submit}
+          필터{appliedTopicCount > 0 ? ` ${appliedTopicCount}` : ''}
+        </button>
+      </div>
+
+      {mobileSheetOpen && (
+        <div
+          className={styles.mobileBackdrop}
+          onPointerDown={(event) => {
+            if (event.target === event.currentTarget) {
+              closeMobileSheet()
+            }
+          }}
+        >
+          <section
+            ref={mobileSheetRef}
+            className={styles.mobileSheet}
+            id="mobile-complex-filter-sheet"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="mobile-complex-filter-heading"
           >
-            <h2 className={styles.popoverHeading} id={headingId}>
-              {openLabel} 필터
-            </h2>
-            <div className={styles.fields}>
-              <TopicFields
-                filters={filters}
-                regionRepository={regionRepository}
-                topic={openTopic}
-              />
-            </div>
-            {errorMessage !== null && (
-              <p className={styles.error} role="alert">{errorMessage}</p>
-            )}
-            <div className={styles.actions}>
-              <button
-                className={styles.reset}
-                type="button"
-                aria-label={`${openLabel} 필터 초기화`}
-                onClick={() => applyAndClose(
-                  openTopic,
-                  replaceTopic(filters, openTopic, {}),
+            <form
+              key={`mobile-${mobileFormRevision}-${searchFiltersSignature(mobileDraftFilters)}`}
+              className={styles.mobileForm}
+              aria-label="단지 필터 조건"
+              onSubmit={submitMobileSheet}
+            >
+              <header className={styles.mobileSheetHeader}>
+                <h2 id="mobile-complex-filter-heading">단지 필터</h2>
+                <div className={styles.mobileHeaderActions}>
+                  <button
+                    ref={mobileResetRef}
+                    className={styles.mobileReset}
+                    type="button"
+                    aria-label="전체 필터 초기화"
+                    onClick={resetMobileSheet}
+                  >초기화</button>
+                  <button
+                    ref={mobileCloseRef}
+                    className={styles.mobileClose}
+                    type="button"
+                    aria-label="단지 필터 닫기"
+                    onClick={closeMobileSheet}
+                  >×</button>
+                </div>
+              </header>
+
+              <div
+                ref={mobileSheetBodyRef}
+                className={styles.mobileSheetBody}
+                onClickCapture={(event) => {
+                  if (
+                    event.target instanceof Element
+                    && event.target.closest('button') !== null
+                  ) {
+                    setMobileDraftDirty(true)
+                  }
+                }}
+                onChange={() => setMobileDraftDirty(true)}
+              >
+                {MOBILE_SHEET_TOPICS.map(([topic, label]) => (
+                  <section
+                    key={topic}
+                    className={styles.mobileTopic}
+                    data-mobile-topic={topic}
+                  >
+                    {(topic === 'region' || topic === 'price') && (
+                      <h3>{label}</h3>
+                    )}
+                    <TopicFields
+                      filters={mobileDraftFilters}
+                      regionRepository={regionRepository}
+                      topic={topic}
+                    />
+                  </section>
+                ))}
+                {errorMessage !== null && (
+                  <p className={styles.mobileError} role="alert">
+                    {errorMessage}
+                  </p>
                 )}
-              >초기화</button>
-              <button
-                className={styles.apply}
-                type="submit"
-                aria-label={`${openLabel} 필터 적용`}
-              >적용</button>
-            </div>
-          </form>
-        </section>
+              </div>
+
+              <div className={styles.mobileFooter}>
+                <button
+                  className={styles.mobileApply}
+                  type="submit"
+                  aria-label={mobileResultAction}
+                >{mobileResultAction}</button>
+              </div>
+            </form>
+          </section>
+        </div>
       )}
     </section>
   )
@@ -788,11 +1113,12 @@ function topicSummary(
     case 'region': {
       if (!filters.regionCode) return null
       const name = provinceNameForRegionCode(filters.regionCode)
-      return name === null
+      const label = name === null
         ? filters.regionCode
         : filters.regionCode.length === 5
           ? resolvedRegionName ?? `${name} ${filters.regionCode}`
           : name
+      return compactRegionLabel(label)
     }
     case 'rentalType':
       return optionsSummary(filters.rentalTypes, RENTAL_TYPE_OPTIONS)
@@ -806,8 +1132,8 @@ function topicSummary(
       const deposit = rangeSummary(filters.minDeposit, filters.maxDeposit, formatDeposit)
       const rent = rangeSummary(filters.minMonthlyRent, filters.maxMonthlyRent, formatRentSummary)
       return [
-        deposit === null ? null : `보증금 ${deposit}`,
-        rent === null ? null : `월세 ${rent}`,
+        deposit,
+        rent === null ? null : `월 ${rent}`,
       ].filter((value): value is string => value !== null).join(' · ') || null
     }
     case 'exclusiveArea':
@@ -836,8 +1162,39 @@ function optionsSummary(
   options: readonly (readonly [string, string])[],
 ) {
   if (!values?.length) return null
-  if (values.length > 1) return `${values.length}개 선택`
-  return options.find(([value]) => value === values[0])?.[1] ?? values[0]
+  const labels = values.map((selected) =>
+    options.find(([value]) => value === selected)?.[1] ?? selected)
+  return labels.length > 1 ? `${labels[0]} 외 ${labels.length - 1}` : labels[0]
+}
+
+const COMPACT_PROVINCE_NAMES = new Map<string, string>([
+  ['서울특별시', '서울'],
+  ['전남광주통합특별시', '광주'],
+  ['부산광역시', '부산'],
+  ['대구광역시', '대구'],
+  ['인천광역시', '인천'],
+  ['대전광역시', '대전'],
+  ['울산광역시', '울산'],
+  ['세종특별자치시', '세종'],
+  ['경기도', '경기'],
+  ['충청북도', '충북'],
+  ['충청남도', '충남'],
+  ['경상북도', '경북'],
+  ['경상남도', '경남'],
+  ['제주특별자치도', '제주'],
+  ['강원특별자치도', '강원'],
+  ['전북특별자치도', '전북'],
+])
+
+function compactRegionLabel(label: string) {
+  const province = [...COMPACT_PROVINCE_NAMES.entries()].find(
+    ([fullName]) => label === fullName || label.startsWith(`${fullName} `),
+  )
+  if (province === undefined) {
+    return label
+  }
+  const [fullName, compactName] = province
+  return `${compactName}${label.slice(fullName.length)}`
 }
 
 function rangeSummary(
@@ -944,6 +1301,12 @@ function formatAreaTick(value: number) {
 
 function compact(value: number) {
   return String(Number(value.toFixed(1)))
+}
+
+function focusableElements(container: HTMLElement) {
+  return [...container.querySelectorAll<HTMLElement>(
+    'button:not([disabled]), select:not([disabled]), input:not([type="hidden"]):not([disabled]), [tabindex]:not([tabindex="-1"])',
+  )].filter((element) => !element.hasAttribute('hidden'))
 }
 
 function isAbortError(error: unknown) {

--- a/frontend/src/public-housing/filters/DualRangeFilter.module.css
+++ b/frontend/src/public-housing/filters/DualRangeFilter.module.css
@@ -1,35 +1,57 @@
 .filter {
   min-width: 0;
   margin: 0;
-  padding: 10px;
-  border: 1px solid #d7dce1;
-  border-radius: 10px;
-  background: #ffffff;
+  padding: 0;
+  border: 0;
+  background: transparent;
 }
 
 .legend {
-  padding: 0 5px;
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  border: 0;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+.header {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.label {
   color: #1e2124;
-  font-size: 12px;
+  font-size: 14px;
   font-weight: 850;
+  line-height: 1.5;
 }
 
 .output {
-  display: block;
-  min-height: 20px;
+  min-width: 0;
+  margin-left: auto;
   color: var(--brand-dark, #174a91);
-  font-size: 13px;
+  font-size: 14px;
   font-variant-numeric: tabular-nums;
   font-weight: 850;
   line-height: 1.5;
+  text-align: right;
+  white-space: nowrap;
 }
 
 .presets {
   display: flex;
   flex-wrap: nowrap;
   gap: 8px;
-  margin-top: 2px;
-  padding: 0 4px;
+  margin-top: 8px;
+  padding: 0;
   overflow-x: auto;
   overflow-y: hidden;
   overscroll-behavior-x: contain;
@@ -61,7 +83,7 @@
   z-index: -1;
   height: 36px;
   border: 1px solid #aeb5bd;
-  border-radius: 999px;
+  border-radius: 9px;
   background: #ffffff;
   content: '';
   transform: translateY(-50%);
@@ -265,12 +287,6 @@
 
 .tick:last-child::before {
   margin-right: 0;
-}
-
-@media (max-width: 767px) {
-  .filter {
-    padding: 12px;
-  }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/frontend/src/public-housing/filters/DualRangeFilter.module.css
+++ b/frontend/src/public-housing/filters/DualRangeFilter.module.css
@@ -1,0 +1,327 @@
+.filter {
+  min-width: 0;
+  margin: 0;
+  padding: 10px;
+  border: 1px solid #d7dce1;
+  border-radius: 10px;
+  background: #ffffff;
+}
+
+.legend {
+  padding: 0 5px;
+  color: #1e2124;
+  font-size: 12px;
+  font-weight: 850;
+}
+
+.output {
+  display: block;
+  min-height: 20px;
+  color: var(--brand-dark, #174a91);
+  font-size: 13px;
+  font-variant-numeric: tabular-nums;
+  font-weight: 850;
+  line-height: 1.5;
+}
+
+.presets {
+  display: flex;
+  flex-wrap: nowrap;
+  gap: 8px;
+  margin-top: 2px;
+  padding: 0 4px;
+  overflow-x: auto;
+  overflow-y: hidden;
+  overscroll-behavior-x: contain;
+  scrollbar-width: thin;
+}
+
+.preset {
+  position: relative;
+  isolation: isolate;
+  flex: 0 0 auto;
+  min-width: 44px;
+  min-height: 44px;
+  padding: 0 7px;
+  border: 0;
+  background: transparent;
+  color: #3b4148;
+  cursor: pointer;
+  font-size: 11px;
+  font-weight: 750;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.preset::before {
+  position: absolute;
+  top: 50%;
+  right: 0;
+  left: 0;
+  z-index: -1;
+  height: 36px;
+  border: 1px solid #aeb5bd;
+  border-radius: 999px;
+  background: #ffffff;
+  content: '';
+  transform: translateY(-50%);
+  pointer-events: none;
+}
+
+.preset:hover::before {
+  border-color: var(--brand, #256ef4);
+}
+
+.preset[aria-pressed='true']::before {
+  border-color: var(--brand, #256ef4);
+  background: #eaf2ff;
+}
+
+.preset[aria-pressed='true'] {
+  color: var(--brand-dark, #174a91);
+}
+
+.preset:focus-visible {
+  outline: none;
+}
+
+.preset:focus-visible::before {
+  outline: 3px solid rgb(37 110 244 / 28%);
+  outline-offset: 1px;
+}
+
+.slider {
+  position: relative;
+  height: 44px;
+  margin-top: 8px;
+}
+
+.track {
+  position: absolute;
+  top: 50%;
+  right: 22px;
+  left: 22px;
+  height: 6px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: #d8dde3;
+  transform: translateY(-50%);
+  pointer-events: none;
+}
+
+.selectedTrack {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: var(--range-start);
+  right: calc(100% - var(--range-end));
+  border-radius: inherit;
+  background: var(--brand, #256ef4);
+}
+
+.rangeInput {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 44px;
+  margin: 0;
+  appearance: none;
+  border-radius: 999px;
+  background: transparent;
+  pointer-events: none;
+  touch-action: none;
+}
+
+.rangeInput:focus-visible {
+  outline: none;
+  z-index: 5;
+}
+
+.minimumInput {
+  right: auto;
+  width: calc(var(--range-end) + var(--minimum-input-compensation));
+  z-index: 2;
+}
+
+.maximumInput {
+  left: calc(var(--range-start) - var(--maximum-input-compensation));
+  width: auto;
+  z-index: 3;
+}
+
+.minimumOnTop {
+  z-index: 4;
+}
+
+.rangeInput::-webkit-slider-runnable-track {
+  height: 6px;
+  border: 0;
+  background: transparent;
+}
+
+.rangeInput::-webkit-slider-thumb {
+  width: 44px;
+  height: 44px;
+  margin-top: -19px;
+  appearance: none;
+  border: 0;
+  border-radius: 50%;
+  background: radial-gradient(
+    circle,
+    #ffffff 0 9px,
+    var(--brand, #256ef4) 10px 12px,
+    transparent 13px
+  );
+  cursor: grab;
+  pointer-events: auto;
+}
+
+.rangeInput::-moz-range-track {
+  height: 6px;
+  border: 0;
+  background: transparent;
+}
+
+.rangeInput::-moz-range-progress {
+  background: transparent;
+}
+
+.rangeInput::-moz-range-thumb {
+  width: 44px;
+  height: 44px;
+  border: 0;
+  border-radius: 50%;
+  background: radial-gradient(
+    circle,
+    #ffffff 0 9px,
+    var(--brand, #256ef4) 10px 12px,
+    transparent 13px
+  );
+  cursor: grab;
+  pointer-events: auto;
+}
+
+.rangeInput:focus-visible::-webkit-slider-thumb {
+  outline: 3px solid #102a43;
+  outline-offset: -7px;
+}
+
+.rangeInput:focus-visible::-moz-range-thumb {
+  outline: 3px solid #102a43;
+  outline-offset: -7px;
+}
+
+.rangeInput:active::-webkit-slider-thumb {
+  cursor: grabbing;
+}
+
+.rangeInput:active::-moz-range-thumb {
+  cursor: grabbing;
+}
+
+.ticks {
+  position: relative;
+  height: 26px;
+  margin: 0 22px;
+  padding: 0;
+  list-style: none;
+}
+
+.tick {
+  position: absolute;
+  top: 0;
+  color: #58616a;
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  line-height: 1.35;
+  text-align: center;
+  white-space: nowrap;
+  transform: translateX(-50%);
+}
+
+.tick::before {
+  display: block;
+  width: 1px;
+  height: 7px;
+  margin: 0 auto 3px;
+  background: #8d98a3;
+  content: '';
+}
+
+.tick:first-child {
+  text-align: left;
+  transform: none;
+}
+
+.tick:first-child::before {
+  margin-left: 0;
+}
+
+.tick:last-child {
+  text-align: right;
+  transform: translateX(-100%);
+}
+
+.tick:last-child::before {
+  margin-right: 0;
+}
+
+@media (max-width: 767px) {
+  .filter {
+    padding: 12px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .preset {
+    transition: none;
+  }
+}
+
+@media (forced-colors: active) {
+  .preset[aria-pressed='true']::before {
+    border-color: Highlight;
+    background: Highlight;
+    forced-color-adjust: none;
+  }
+
+  .preset[aria-pressed='true'] {
+    color: HighlightText;
+    forced-color-adjust: none;
+  }
+
+  .preset:focus-visible::before {
+    outline: 3px solid Highlight;
+  }
+
+  .track {
+    background: GrayText;
+  }
+
+  .selectedTrack {
+    background: Highlight;
+  }
+
+  .rangeInput::-webkit-slider-thumb {
+    border: 2px solid ButtonText;
+    background: Canvas;
+    forced-color-adjust: auto;
+  }
+
+  .rangeInput::-moz-range-thumb {
+    border: 2px solid ButtonText;
+    background: Canvas;
+    forced-color-adjust: auto;
+  }
+
+  .rangeInput:focus-visible::-webkit-slider-thumb {
+    outline: 3px solid Highlight;
+    outline-offset: -7px;
+  }
+
+  .rangeInput:focus-visible::-moz-range-thumb {
+    outline: 3px solid Highlight;
+    outline-offset: -7px;
+  }
+}

--- a/frontend/src/public-housing/filters/DualRangeFilter.test.tsx
+++ b/frontend/src/public-housing/filters/DualRangeFilter.test.tsx
@@ -1,0 +1,635 @@
+/// <reference types="node" />
+
+import { fireEvent, render, screen, within } from '@testing-library/react'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import {
+  DualRangeFilter,
+  type DualRangeFilterPreset,
+} from './DualRangeFilter'
+
+const PRESETS = [
+  { label: '전체', minimum: null, maximum: null },
+  { label: '5천만 원 이하', minimum: null, maximum: 50 },
+  { label: '3천만~7천만 원', minimum: 30, maximum: 70 },
+  { label: '5천만 원 이상', minimum: 50, maximum: null },
+] as const satisfies readonly DualRangeFilterPreset[]
+
+function formatValue(value: number) {
+  return `${value * 100}만 원`
+}
+
+function renderFilter({
+  initialMinimum = null,
+  initialMaximum = null,
+  presets = PRESETS,
+  preserveInitialValuesUntilChange = false,
+}: {
+  readonly initialMinimum?: number | null
+  readonly initialMaximum?: number | null
+  readonly presets?: readonly DualRangeFilterPreset[]
+  readonly preserveInitialValuesUntilChange?: boolean
+} = {}) {
+  const result = render(
+    <form aria-label="검색 조건">
+      <DualRangeFilter
+        legend="임대보증금"
+        minimumName="minDeposit"
+        maximumName="maxDeposit"
+        minimum={0}
+        maximum={100}
+        step={10}
+        majorStep={25}
+        initialMinimum={initialMinimum}
+        initialMaximum={initialMaximum}
+        formatValue={formatValue}
+        formatTick={(value) => `${value}`}
+        presets={presets}
+        preserveInitialValuesUntilChange={preserveInitialValuesUntilChange}
+      />
+      <button type="reset">초기화</button>
+    </form>,
+  )
+
+  const form = screen.getByRole('form', {
+    name: '검색 조건',
+  }) as HTMLFormElement
+  const minimumInput = screen.getByRole('slider', {
+    name: '임대보증금 최솟값',
+  }) as HTMLInputElement
+  const maximumInput = screen.getByRole('slider', {
+    name: '임대보증금 최댓값',
+  }) as HTMLInputElement
+  const hiddenMinimum = form.elements.namedItem(
+    'minDeposit',
+  ) as HTMLInputElement
+  const hiddenMaximum = form.elements.namedItem(
+    'maxDeposit',
+  ) as HTMLInputElement
+  const output = screen.getByRole('status', {
+    name: '임대보증금 선택 범위',
+  })
+
+  return {
+    ...result,
+    form,
+    hiddenMaximum,
+    hiddenMinimum,
+    maximumInput,
+    minimumInput,
+    output,
+  }
+}
+
+describe('DualRangeFilter', () => {
+  it('null 양끝값을 전체 범위로 표시하고 API용 hidden 값은 비운다', () => {
+    const {
+      hiddenMaximum,
+      hiddenMinimum,
+      maximumInput,
+      minimumInput,
+      output,
+    } = renderFilter()
+
+    expect(minimumInput).toHaveAttribute('type', 'range')
+    expect(minimumInput).toHaveAttribute('min', '0')
+    expect(minimumInput).toHaveAttribute('max', '100')
+    expect(minimumInput).toHaveAttribute('step', '10')
+    expect(minimumInput).toHaveValue('0')
+    expect(minimumInput).toHaveAttribute('aria-valuetext', '0만 원')
+
+    expect(maximumInput).toHaveAttribute('type', 'range')
+    expect(maximumInput).toHaveAttribute('min', '0')
+    expect(maximumInput).toHaveAttribute('max', '100')
+    expect(maximumInput).toHaveAttribute('step', '10')
+    expect(maximumInput).toHaveValue('100')
+    expect(maximumInput).toHaveAttribute('aria-valuetext', '10000만 원')
+
+    expect(output).toHaveTextContent('전체')
+    expect(hiddenMinimum).toHaveAttribute('type', 'hidden')
+    expect(hiddenMinimum).toHaveValue('')
+    expect(hiddenMaximum).toHaveAttribute('type', 'hidden')
+    expect(hiddenMaximum).toHaveValue('')
+  })
+
+  it.each([
+    {
+      label: '상한만 선택하면 이하로 표시한다',
+      initialMinimum: null,
+      initialMaximum: 60,
+      expectedOutput: '6000만 원 이하',
+      expectedMinimum: '',
+      expectedMaximum: '60',
+    },
+    {
+      label: '하한만 선택하면 이상으로 표시한다',
+      initialMinimum: 20,
+      initialMaximum: null,
+      expectedOutput: '2000만 원 이상',
+      expectedMinimum: '20',
+      expectedMaximum: '',
+    },
+    {
+      label: '양끝을 선택하면 구간으로 표시한다',
+      initialMinimum: 20,
+      initialMaximum: 60,
+      expectedOutput: '2000만 원 ~ 6000만 원',
+      expectedMinimum: '20',
+      expectedMaximum: '60',
+    },
+  ])(
+    '$label',
+    ({
+      initialMinimum,
+      initialMaximum,
+      expectedOutput,
+      expectedMinimum,
+      expectedMaximum,
+    }) => {
+      const { hiddenMaximum, hiddenMinimum, output } = renderFilter({
+        initialMinimum,
+        initialMaximum,
+      })
+
+      expect(output).toHaveTextContent(expectedOutput)
+      expect(hiddenMinimum).toHaveValue(expectedMinimum)
+      expect(hiddenMaximum).toHaveValue(expectedMaximum)
+    },
+  )
+
+  it('최솟값 손잡이는 선택값을 갱신하되 최댓값을 넘어가지 않는다', () => {
+    const { hiddenMinimum, minimumInput, output } = renderFilter({
+      initialMinimum: 20,
+      initialMaximum: 60,
+    })
+
+    fireEvent.change(minimumInput, { target: { value: '50' } })
+
+    expect(minimumInput).toHaveValue('50')
+    expect(minimumInput).toHaveAttribute('aria-valuetext', '5000만 원')
+    expect(minimumInput).toHaveAttribute('max', '60')
+    expect(minimumInput).toHaveAttribute('aria-valuemax', '60')
+    expect(hiddenMinimum).toHaveValue('50')
+    expect(output).toHaveTextContent('5000만 원 ~ 6000만 원')
+
+    fireEvent.change(minimumInput, { target: { value: '90' } })
+
+    expect(minimumInput).toHaveValue('60')
+    expect(hiddenMinimum).toHaveValue('60')
+    expect(output).toHaveTextContent('6000만 원 ~ 6000만 원')
+  })
+
+  it('최댓값 손잡이는 선택값을 갱신하되 최솟값 아래로 내려가지 않는다', () => {
+    const { hiddenMaximum, maximumInput, output } = renderFilter({
+      initialMinimum: 20,
+      initialMaximum: 60,
+    })
+
+    fireEvent.change(maximumInput, { target: { value: '40' } })
+
+    expect(maximumInput).toHaveValue('40')
+    expect(maximumInput).toHaveAttribute('aria-valuetext', '4000만 원')
+    expect(maximumInput).toHaveAttribute('min', '20')
+    expect(maximumInput).toHaveAttribute('aria-valuemin', '20')
+    expect(hiddenMaximum).toHaveValue('40')
+    expect(output).toHaveTextContent('2000만 원 ~ 4000만 원')
+
+    fireEvent.change(maximumInput, { target: { value: '10' } })
+
+    expect(maximumInput).toHaveValue('20')
+    expect(hiddenMaximum).toHaveValue('20')
+    expect(output).toHaveTextContent('2000만 원 ~ 2000만 원')
+  })
+
+  it('한 손잡이를 조작하면 같은 범위의 양끝을 정규화해 제출한다', () => {
+    const {
+      hiddenMaximum,
+      hiddenMinimum,
+      minimumInput,
+    } = renderFilter({
+      initialMinimum: 15,
+      initialMaximum: 25,
+      preserveInitialValuesUntilChange: true,
+    })
+
+    expect(hiddenMinimum).toHaveValue('15')
+    expect(hiddenMaximum).toHaveValue('25')
+
+    fireEvent.change(minimumInput, { target: { value: '30' } })
+
+    expect(hiddenMinimum).toHaveValue('30')
+    expect(hiddenMaximum).toHaveValue('30')
+  })
+
+  it('최솟값만 바꾸면 호환되는 off-step 초기 최댓값을 그대로 제출한다', () => {
+    const { hiddenMaximum, hiddenMinimum, minimumInput } = renderFilter({
+      initialMinimum: 15,
+      initialMaximum: 55,
+      preserveInitialValuesUntilChange: true,
+    })
+
+    fireEvent.change(minimumInput, { target: { value: '30' } })
+
+    expect(hiddenMinimum).toHaveValue('30')
+    expect(hiddenMaximum).toHaveValue('55')
+  })
+
+  it('최댓값만 바꾸면 호환되는 off-step 초기 최솟값을 그대로 제출한다', () => {
+    const { hiddenMaximum, hiddenMinimum, maximumInput } = renderFilter({
+      initialMinimum: 15,
+      initialMaximum: 55,
+      preserveInitialValuesUntilChange: true,
+    })
+
+    fireEvent.change(maximumInput, { target: { value: '80' } })
+
+    expect(hiddenMinimum).toHaveValue('15')
+    expect(hiddenMaximum).toHaveValue('80')
+  })
+
+  it('최댓값만 바꾸면 명시적인 domain 최솟값을 그대로 제출한다', () => {
+    const { hiddenMaximum, hiddenMinimum, maximumInput } = renderFilter({
+      initialMinimum: 0,
+      initialMaximum: 60,
+      preserveInitialValuesUntilChange: true,
+    })
+
+    fireEvent.change(maximumInput, { target: { value: '80' } })
+
+    expect(hiddenMinimum).toHaveValue('0')
+    expect(hiddenMaximum).toHaveValue('80')
+  })
+
+  it('최솟값이 원래 최댓값을 넘으면 정규화된 최댓값을 제출한다', () => {
+    const result = render(
+      <form aria-label="고액 검색 조건">
+        <DualRangeFilter
+          legend="임대보증금"
+          minimumName="minDeposit"
+          maximumName="maxDeposit"
+          minimum={0}
+          maximum={200}
+          step={10}
+          majorStep={25}
+          initialMinimum={140}
+          initialMaximum={155}
+          formatValue={formatValue}
+          formatTick={String}
+          presets={[]}
+          preserveInitialValuesUntilChange
+        />
+      </form>,
+    )
+    const form = screen.getByRole('form', {
+      name: '고액 검색 조건',
+    }) as HTMLFormElement
+    const minimumInput = screen.getByRole('slider', {
+      name: '임대보증금 최솟값',
+    })
+    const hiddenMaximum = form.elements.namedItem(
+      'maxDeposit',
+    ) as HTMLInputElement
+
+    fireEvent.change(minimumInput, { target: { value: '150' } })
+
+    expect(hiddenMaximum).toHaveValue('155')
+
+    fireEvent.change(minimumInput, { target: { value: '160' } })
+
+    expect(hiddenMaximum).toHaveValue('160')
+    result.unmount()
+  })
+
+  it('한 손잡이를 조작하면 반대쪽 초과값도 endpoint 의미로 정규화한다', () => {
+    const {
+      hiddenMaximum,
+      hiddenMinimum,
+      minimumInput,
+    } = renderFilter({
+      initialMinimum: 0,
+      initialMaximum: 120,
+      preserveInitialValuesUntilChange: true,
+    })
+
+    expect(hiddenMinimum).toHaveValue('0')
+    expect(hiddenMaximum).toHaveValue('120')
+
+    fireEvent.change(minimumInput, { target: { value: '20' } })
+
+    expect(hiddenMinimum).toHaveValue('20')
+    expect(hiddenMaximum).toHaveValue('')
+  })
+
+  it('preset의 null을 domain 끝으로 해석하고 현재 preset을 aria-pressed로 알린다', () => {
+    const {
+      hiddenMaximum,
+      hiddenMinimum,
+      maximumInput,
+      minimumInput,
+      output,
+    } = renderFilter({ initialMinimum: 30, initialMaximum: 70 })
+    const presets = screen.getByRole('group', {
+      name: '임대보증금 빠른 선택',
+    })
+    const intervalPreset = within(presets).getByRole('button', {
+      name: '3천만~7천만 원',
+    })
+    const maximumPreset = within(presets).getByRole('button', {
+      name: '5천만 원 이하',
+    })
+    const minimumPreset = within(presets).getByRole('button', {
+      name: '5천만 원 이상',
+    })
+    const allPreset = within(presets).getByRole('button', { name: '전체' })
+
+    expect(intervalPreset).toHaveAttribute('aria-pressed', 'true')
+    expect(allPreset).toHaveAttribute('aria-pressed', 'false')
+
+    fireEvent.click(maximumPreset)
+
+    expect(maximumPreset).toHaveAttribute('aria-pressed', 'true')
+    expect(minimumInput).toHaveValue('0')
+    expect(maximumInput).toHaveValue('50')
+    expect(hiddenMinimum).toHaveValue('')
+    expect(hiddenMaximum).toHaveValue('50')
+    expect(output).toHaveTextContent('5000만 원 이하')
+
+    fireEvent.click(minimumPreset)
+
+    expect(minimumPreset).toHaveAttribute('aria-pressed', 'true')
+    expect(minimumInput).toHaveValue('50')
+    expect(maximumInput).toHaveValue('100')
+    expect(hiddenMinimum).toHaveValue('50')
+    expect(hiddenMaximum).toHaveValue('')
+    expect(output).toHaveTextContent('5000만 원 이상')
+
+    fireEvent.click(allPreset)
+
+    expect(allPreset).toHaveAttribute('aria-pressed', 'true')
+    expect(hiddenMinimum).toHaveValue('')
+    expect(hiddenMaximum).toHaveValue('')
+    expect(output).toHaveTextContent('전체')
+  })
+
+  it('부모 form의 reset 이벤트가 초기 선택 범위를 복원한다', () => {
+    const {
+      hiddenMaximum,
+      hiddenMinimum,
+      maximumInput,
+      minimumInput,
+      output,
+    } = renderFilter({ initialMinimum: 20, initialMaximum: 60 })
+
+    fireEvent.change(minimumInput, { target: { value: '50' } })
+    fireEvent.change(maximumInput, { target: { value: '80' } })
+    expect(output).toHaveTextContent('5000만 원 ~ 8000만 원')
+
+    fireEvent.click(screen.getByRole('button', { name: '초기화' }))
+
+    expect(minimumInput).toHaveValue('20')
+    expect(maximumInput).toHaveValue('60')
+    expect(hiddenMinimum).toHaveValue('20')
+    expect(hiddenMaximum).toHaveValue('60')
+    expect(output).toHaveTextContent('2000만 원 ~ 6000만 원')
+  })
+
+  it('majorStep 눈금 라벨과 선택 구간 track 위치를 계산한다', () => {
+    renderFilter({ initialMinimum: 20, initialMaximum: 60 })
+    const filter = screen.getByRole('group', { name: '임대보증금' })
+    const ticks = screen.getByRole('list', {
+      name: '임대보증금 주요 눈금',
+    })
+
+    expect(
+      within(ticks).getAllByRole('listitem').map((tick) => tick.textContent),
+    ).toEqual(['0', '25', '50', '75', '100'])
+    expect(filter.style.getPropertyValue('--range-start')).toBe('20%')
+    expect(filter.style.getPropertyValue('--range-end')).toBe('60%')
+    expect(
+      filter.style.getPropertyValue('--minimum-input-compensation'),
+    ).toBe('17.6px')
+    expect(
+      filter.style.getPropertyValue('--maximum-input-compensation'),
+    ).toBe('8.8px')
+  })
+
+  it('domain 밖 초기값을 양끝으로 clamp해 표시값과 제출값을 일치시킨다', () => {
+    const {
+      hiddenMaximum,
+      hiddenMinimum,
+      maximumInput,
+      minimumInput,
+      output,
+    } = renderFilter({ initialMinimum: -20, initialMaximum: 120 })
+
+    expect(minimumInput).toHaveValue('0')
+    expect(maximumInput).toHaveValue('100')
+    expect(hiddenMinimum).toHaveValue('')
+    expect(hiddenMaximum).toHaveValue('')
+    expect(output).toHaveTextContent('전체')
+  })
+
+  it('소수 domain과 majorStep을 부동소수점 잡음 없이 표시하고 제출한다', () => {
+    render(
+      <DualRangeFilter
+        legend="전용면적"
+        minimumName="minArea"
+        maximumName="maxArea"
+        minimum={0.1}
+        maximum={3.3}
+        step={0.1}
+        majorStep={0.8}
+        initialMinimum={0.3}
+        initialMaximum={2.7}
+        formatValue={(value) => `${value}㎡`}
+        formatTick={(value) => String(value)}
+        presets={[]}
+      />,
+    )
+    const filter = screen.getByRole('group', { name: '전용면적' })
+    const minimumInput = screen.getByRole('slider', {
+      name: '전용면적 최솟값',
+    }) as HTMLInputElement
+    const hiddenMinimum = document.querySelector(
+      'input[name="minArea"]',
+    ) as HTMLInputElement
+    const ticks = screen.getByRole('list', { name: '전용면적 주요 눈금' })
+
+    expect(
+      within(ticks).getAllByRole('listitem').map((tick) => tick.textContent),
+    ).toEqual(['0.1', '0.9', '1.7', '2.5', '3.3'])
+    expect(filter.style.getPropertyValue('--range-start')).toBe('6.25%')
+    expect(filter.style.getPropertyValue('--range-end')).toBe('81.25%')
+
+    fireEvent.change(minimumInput, {
+      target: { value: '0.30000000000000004' },
+    })
+
+    expect(minimumInput).toHaveValue('0.3')
+    expect(hiddenMinimum).toHaveValue('0.3')
+  })
+
+  it('off-step 초기값과 preset을 가까운 유효 step으로 맞춰 form validity를 보존한다', () => {
+    const offStepPreset = [
+      { label: '엇갈린 눈금', minimum: 15, maximum: 85 },
+    ] as const satisfies readonly DualRangeFilterPreset[]
+    const {
+      form,
+      hiddenMaximum,
+      hiddenMinimum,
+      maximumInput,
+      minimumInput,
+    } = renderFilter({
+      initialMinimum: 25,
+      initialMaximum: 75,
+      presets: offStepPreset,
+    })
+
+    expect(minimumInput).toHaveValue('30')
+    expect(maximumInput).toHaveValue('80')
+    expect(hiddenMinimum).toHaveValue('30')
+    expect(hiddenMaximum).toHaveValue('80')
+    expect(form.checkValidity()).toBe(true)
+
+    fireEvent.click(screen.getByRole('button', { name: '엇갈린 눈금' }))
+
+    expect(minimumInput).toHaveValue('20')
+    expect(maximumInput).toHaveValue('90')
+    expect(hiddenMinimum).toHaveValue('20')
+    expect(hiddenMaximum).toHaveValue('90')
+    expect(form.checkValidity()).toBe(true)
+  })
+
+  it('유효하지 않은 domain step을 명시적으로 거절한다', () => {
+    expect(() => render(
+      <DualRangeFilter
+        legend="잘못된 범위"
+        minimumName="minimum"
+        maximumName="maximum"
+        minimum={0}
+        maximum={100}
+        step={0}
+        majorStep={10}
+        initialMinimum={null}
+        initialMaximum={null}
+        formatValue={String}
+        formatTick={String}
+        presets={[]}
+      />,
+    )).toThrow(/step/)
+  })
+
+  it('두 range를 한 track으로 겹치고 손잡이와 preset에 44px 터치 목표를 둔다', () => {
+    const filterStyles = readFileSync(
+      resolve(
+        process.cwd(),
+        'src/public-housing/filters/DualRangeFilter.module.css',
+      ),
+      'utf8',
+    )
+
+    expect(filterStyles).toMatch(
+      /\.rangeInput\s*\{[\s\S]*?height:\s*44px;[\s\S]*?pointer-events:\s*none;/,
+    )
+    expect(filterStyles).toMatch(
+      /\.rangeInput::-webkit-slider-thumb\s*\{[\s\S]*?width:\s*44px;[\s\S]*?height:\s*44px;/,
+    )
+    expect(filterStyles).toMatch(
+      /\.rangeInput::-moz-range-thumb\s*\{[\s\S]*?width:\s*44px;[\s\S]*?height:\s*44px;/,
+    )
+    expect(filterStyles).toMatch(
+      /\.preset\s*\{[\s\S]*?min-width:\s*44px;[\s\S]*?min-height:\s*44px;/,
+    )
+    expect(filterStyles).toMatch(
+      /\.selectedTrack\s*\{[\s\S]*?left:\s*var\(--range-start\);[\s\S]*?right:\s*calc\(100% - var\(--range-end\)\);/,
+    )
+    expect(filterStyles).toMatch(
+      /\.minimumInput\s*\{[\s\S]*?width:\s*calc\(var\(--range-end\) \+ var\(--minimum-input-compensation\)\);/,
+    )
+    expect(filterStyles).toMatch(
+      /\.maximumInput\s*\{[\s\S]*?left:\s*calc\(var\(--range-start\) - var\(--maximum-input-compensation\)\);/,
+    )
+    expect(filterStyles).toMatch(
+      /\.rangeInput:focus-visible::-webkit-slider-thumb\s*\{[\s\S]*?outline:/,
+    )
+    expect(filterStyles).toMatch(
+      /\.rangeInput:focus-visible::-moz-range-thumb\s*\{[\s\S]*?outline:/,
+    )
+    expect(filterStyles).toMatch(
+      /\.rangeInput:focus-visible\s*\{[\s\S]*?z-index:\s*5;/,
+    )
+    const forcedColors = filterStyles.slice(
+      filterStyles.indexOf('@media (forced-colors: active)'),
+    )
+    expect(forcedColors).toMatch(
+      /\.rangeInput::-webkit-slider-thumb\s*\{[\s\S]*?forced-color-adjust:\s*auto;/,
+    )
+    expect(forcedColors).toMatch(
+      /\.rangeInput::-moz-range-thumb\s*\{[\s\S]*?forced-color-adjust:\s*auto;/,
+    )
+    expect(forcedColors).toMatch(
+      /\.rangeInput:focus-visible::-webkit-slider-thumb\s*\{[\s\S]*?outline:\s*3px solid Highlight;/,
+    )
+    expect(forcedColors).toMatch(
+      /\.rangeInput:focus-visible::-moz-range-thumb\s*\{[\s\S]*?outline:\s*3px solid Highlight;/,
+    )
+    expect(forcedColors).toMatch(
+      /\.preset\[aria-pressed='true'\]::before\s*\{[\s\S]*?border-color:\s*Highlight;[\s\S]*?background:\s*Highlight;/,
+    )
+    expect(forcedColors).toMatch(
+      /\.preset\[aria-pressed='true'\]\s*\{[\s\S]*?color:\s*HighlightText;/,
+    )
+    expect(forcedColors).toMatch(
+      /\.preset:focus-visible::before\s*\{[\s\S]*?outline:\s*3px solid Highlight;/,
+    )
+  })
+
+  it('빠른 선택을 한 줄로 유지하고 44px 터치 영역 안에 36px 칩을 보인다', () => {
+    const filterStyles = readFileSync(
+      resolve(
+        process.cwd(),
+        'src/public-housing/filters/DualRangeFilter.module.css',
+      ),
+      'utf8',
+    )
+
+    expect(filterStyles).toMatch(
+      /\.presets\s*\{[\s\S]*?flex-wrap:\s*nowrap;[\s\S]*?overflow-x:\s*auto;[\s\S]*?overflow-y:\s*hidden;/,
+    )
+    expect(filterStyles).toMatch(
+      /\.preset\s*\{[\s\S]*?flex:\s*0 0 auto;[\s\S]*?min-width:\s*44px;[\s\S]*?min-height:\s*44px;[\s\S]*?white-space:\s*nowrap;/,
+    )
+    expect(filterStyles).toMatch(
+      /\.preset::before\s*\{[\s\S]*?height:\s*36px;[\s\S]*?border-radius:\s*999px;/,
+    )
+    expect(filterStyles).toMatch(
+      /\.preset:focus-visible::before\s*\{[\s\S]*?outline:\s*3px solid/,
+    )
+  })
+
+  it('두 값이 domain maximum에서 겹치면 최솟값 손잡이를 위로 올린다', () => {
+    const { minimumInput } = renderFilter({
+      initialMinimum: 20,
+      initialMaximum: null,
+    })
+
+    fireEvent.change(minimumInput, { target: { value: '100' } })
+
+    expect(minimumInput.className).toMatch(/minimumOnTop/)
+
+    const filterStyles = readFileSync(
+      resolve(
+        process.cwd(),
+        'src/public-housing/filters/DualRangeFilter.module.css',
+      ),
+      'utf8',
+    )
+    expect(filterStyles).toMatch(
+      /\.minimumOnTop\s*\{[\s\S]*?z-index:\s*4;/,
+    )
+
+    fireEvent.change(minimumInput, { target: { value: '90' } })
+    expect(minimumInput.className).not.toMatch(/minimumOnTop/)
+  })
+})

--- a/frontend/src/public-housing/filters/DualRangeFilter.test.tsx
+++ b/frontend/src/public-housing/filters/DualRangeFilter.test.tsx
@@ -134,7 +134,7 @@ describe('DualRangeFilter', () => {
       label: '양끝을 선택하면 구간으로 표시한다',
       initialMinimum: 20,
       initialMaximum: 60,
-      expectedOutput: '2000만 원 ~ 6000만 원',
+      expectedOutput: '2000만 원~6000만 원',
       expectedMinimum: '20',
       expectedMaximum: '60',
     },
@@ -171,13 +171,13 @@ describe('DualRangeFilter', () => {
     expect(minimumInput).toHaveAttribute('max', '60')
     expect(minimumInput).toHaveAttribute('aria-valuemax', '60')
     expect(hiddenMinimum).toHaveValue('50')
-    expect(output).toHaveTextContent('5000만 원 ~ 6000만 원')
+    expect(output).toHaveTextContent('5000만 원~6000만 원')
 
     fireEvent.change(minimumInput, { target: { value: '90' } })
 
     expect(minimumInput).toHaveValue('60')
     expect(hiddenMinimum).toHaveValue('60')
-    expect(output).toHaveTextContent('6000만 원 ~ 6000만 원')
+    expect(output).toHaveTextContent('6000만 원~6000만 원')
   })
 
   it('최댓값 손잡이는 선택값을 갱신하되 최솟값 아래로 내려가지 않는다', () => {
@@ -193,13 +193,13 @@ describe('DualRangeFilter', () => {
     expect(maximumInput).toHaveAttribute('min', '20')
     expect(maximumInput).toHaveAttribute('aria-valuemin', '20')
     expect(hiddenMaximum).toHaveValue('40')
-    expect(output).toHaveTextContent('2000만 원 ~ 4000만 원')
+    expect(output).toHaveTextContent('2000만 원~4000만 원')
 
     fireEvent.change(maximumInput, { target: { value: '10' } })
 
     expect(maximumInput).toHaveValue('20')
     expect(hiddenMaximum).toHaveValue('20')
-    expect(output).toHaveTextContent('2000만 원 ~ 2000만 원')
+    expect(output).toHaveTextContent('2000만 원~2000만 원')
   })
 
   it('한 손잡이를 조작하면 같은 범위의 양끝을 정규화해 제출한다', () => {
@@ -383,7 +383,7 @@ describe('DualRangeFilter', () => {
 
     fireEvent.change(minimumInput, { target: { value: '50' } })
     fireEvent.change(maximumInput, { target: { value: '80' } })
-    expect(output).toHaveTextContent('5000만 원 ~ 8000만 원')
+    expect(output).toHaveTextContent('5000만 원~8000만 원')
 
     fireEvent.click(screen.getByRole('button', { name: '초기화' }))
 
@@ -391,7 +391,7 @@ describe('DualRangeFilter', () => {
     expect(maximumInput).toHaveValue('60')
     expect(hiddenMinimum).toHaveValue('20')
     expect(hiddenMaximum).toHaveValue('60')
-    expect(output).toHaveTextContent('2000만 원 ~ 6000만 원')
+    expect(output).toHaveTextContent('2000만 원~6000만 원')
   })
 
   it('majorStep 눈금 라벨과 선택 구간 track 위치를 계산한다', () => {
@@ -585,7 +585,7 @@ describe('DualRangeFilter', () => {
     )
   })
 
-  it('빠른 선택을 한 줄로 유지하고 44px 터치 영역 안에 36px 칩을 보인다', () => {
+  it('빠른 선택을 한 줄로 유지하고 44px 터치 영역 안에 36px 둥근 사각형을 보인다', () => {
     const filterStyles = readFileSync(
       resolve(
         process.cwd(),
@@ -601,7 +601,7 @@ describe('DualRangeFilter', () => {
       /\.preset\s*\{[\s\S]*?flex:\s*0 0 auto;[\s\S]*?min-width:\s*44px;[\s\S]*?min-height:\s*44px;[\s\S]*?white-space:\s*nowrap;/,
     )
     expect(filterStyles).toMatch(
-      /\.preset::before\s*\{[\s\S]*?height:\s*36px;[\s\S]*?border-radius:\s*999px;/,
+      /\.preset::before\s*\{[\s\S]*?height:\s*36px;[\s\S]*?border-radius:\s*9px;/,
     )
     expect(filterStyles).toMatch(
       /\.preset:focus-visible::before\s*\{[\s\S]*?outline:\s*3px solid/,

--- a/frontend/src/public-housing/filters/DualRangeFilter.tsx
+++ b/frontend/src/public-housing/filters/DualRangeFilter.tsx
@@ -1,0 +1,413 @@
+import { type CSSProperties, useEffect, useRef, useState } from 'react'
+import styles from './DualRangeFilter.module.css'
+
+const RANGE_TOUCH_TARGET_SIZE = 44
+
+export interface DualRangeFilterPreset {
+  readonly label: string
+  readonly minimum: number | null
+  readonly maximum: number | null
+}
+
+export interface DualRangeFilterProps {
+  readonly legend: string
+  readonly minimumName: string
+  readonly maximumName: string
+  readonly minimum: number
+  readonly maximum: number
+  readonly step: number
+  readonly majorStep: number
+  readonly initialMinimum: number | null
+  readonly initialMaximum: number | null
+  readonly formatValue: (value: number) => string
+  readonly formatTick: (value: number) => string
+  readonly presets: readonly DualRangeFilterPreset[]
+  readonly preserveInitialValuesUntilChange?: boolean
+}
+
+export function DualRangeFilter({
+  legend,
+  minimumName,
+  maximumName,
+  minimum,
+  maximum,
+  step,
+  majorStep,
+  initialMinimum,
+  initialMaximum,
+  formatValue,
+  formatTick,
+  presets,
+  preserveInitialValuesUntilChange = false,
+}: DualRangeFilterProps) {
+  validateDomain(minimum, maximum, step, majorStep)
+  const fieldsetRef = useRef<HTMLFieldSetElement>(null)
+  const [normalizedInitialMinimum, normalizedInitialMaximum] = normalizeRange(
+    initialMinimum,
+    initialMaximum,
+    minimum,
+    maximum,
+    step,
+  )
+  const [selectedMinimum, setSelectedMinimum] = useState(
+    normalizedInitialMinimum,
+  )
+  const [selectedMaximum, setSelectedMaximum] = useState(
+    normalizedInitialMaximum,
+  )
+  const [minimumChanged, setMinimumChanged] = useState(false)
+  const [maximumChanged, setMaximumChanged] = useState(false)
+  const rangeText = selectedMinimum === minimum
+    ? selectedMaximum === maximum
+      ? '전체'
+      : `${formatValue(selectedMaximum)} 이하`
+    : selectedMaximum === maximum
+      ? `${formatValue(selectedMinimum)} 이상`
+      : `${formatValue(selectedMinimum)} ~ ${formatValue(selectedMaximum)}`
+  const startPercentage = rangePercentage(selectedMinimum, minimum, maximum)
+  const endPercentage = rangePercentage(selectedMaximum, minimum, maximum)
+  const rangeStyle = {
+    '--range-start': `${startPercentage}%`,
+    '--range-end': `${endPercentage}%`,
+    '--minimum-input-compensation': `${roundToDecimalPlaces(
+      RANGE_TOUCH_TARGET_SIZE * (1 - endPercentage / 100),
+      10,
+    )}px`,
+    '--maximum-input-compensation': `${roundToDecimalPlaces(
+      RANGE_TOUCH_TARGET_SIZE * (startPercentage / 100),
+      10,
+    )}px`,
+  } as CSSProperties
+  const majorTicks = createMajorTicks(minimum, maximum, majorStep)
+
+  useEffect(() => {
+    const form = fieldsetRef.current?.form
+    if (form === null || form === undefined) {
+      return
+    }
+    const reset = () => {
+      setSelectedMinimum(normalizedInitialMinimum)
+      setSelectedMaximum(normalizedInitialMaximum)
+      setMinimumChanged(false)
+      setMaximumChanged(false)
+    }
+    form.addEventListener('reset', reset)
+    return () => form.removeEventListener('reset', reset)
+  }, [normalizedInitialMaximum, normalizedInitialMinimum])
+
+  return (
+    <fieldset ref={fieldsetRef} className={styles.filter} style={rangeStyle}>
+      <legend className={styles.legend}>{legend}</legend>
+      <output
+        className={styles.output}
+        role="status"
+        aria-atomic="true"
+        aria-label={`${legend} 선택 범위`}
+      >
+        {rangeText}
+      </output>
+
+      {presets.length > 0 && (
+        <div
+          className={styles.presets}
+          role="group"
+          aria-label={`${legend} 빠른 선택`}
+        >
+          {presets.map((preset) => {
+            const [presetMinimum, presetMaximum] = normalizeRange(
+              preset.minimum,
+              preset.maximum,
+              minimum,
+              maximum,
+              step,
+            )
+            const selected = (
+              selectedMinimum === presetMinimum
+              && selectedMaximum === presetMaximum
+            )
+
+            return (
+              <button
+                key={preset.label}
+                className={styles.preset}
+                type="button"
+                aria-pressed={selected}
+                onClick={() => {
+                  setSelectedMinimum(presetMinimum)
+                  setSelectedMaximum(presetMaximum)
+                  setMinimumChanged(true)
+                  setMaximumChanged(true)
+                }}
+              >
+                {preset.label}
+              </button>
+            )
+          })}
+        </div>
+      )}
+
+      <div className={styles.slider}>
+        <div className={styles.track} aria-hidden="true">
+          <span className={styles.selectedTrack} />
+        </div>
+        <input
+          className={`${styles.rangeInput} ${styles.minimumInput}${
+            selectedMinimum === maximum ? ` ${styles.minimumOnTop}` : ''
+          }`}
+          type="range"
+          aria-label={`${legend} 최솟값`}
+          aria-valuetext={formatValue(selectedMinimum)}
+          aria-valuemin={minimum}
+          aria-valuemax={selectedMaximum}
+          min={minimum}
+          max={selectedMaximum}
+          step={step}
+          value={selectedMinimum}
+          onChange={(event) => {
+            const nextValue = normalizeValue(
+              Number(event.currentTarget.value),
+              minimum,
+              maximum,
+              step,
+            )
+            setSelectedMinimum(Math.min(nextValue, selectedMaximum))
+            setMinimumChanged(true)
+          }}
+        />
+        <input
+          className={`${styles.rangeInput} ${styles.maximumInput}`}
+          type="range"
+          aria-label={`${legend} 최댓값`}
+          aria-valuetext={formatValue(selectedMaximum)}
+          aria-valuemin={selectedMinimum}
+          aria-valuemax={maximum}
+          min={selectedMinimum}
+          max={maximum}
+          step={step}
+          value={selectedMaximum}
+          onChange={(event) => {
+            const nextValue = normalizeValue(
+              Number(event.currentTarget.value),
+              minimum,
+              maximum,
+              step,
+            )
+            setSelectedMaximum(Math.max(nextValue, selectedMinimum))
+            setMaximumChanged(true)
+          }}
+        />
+      </div>
+
+      <ol className={styles.ticks} aria-label={`${legend} 주요 눈금`}>
+        {majorTicks.map((tick) => (
+          <li
+            key={tick}
+            className={styles.tick}
+            style={{ left: `${rangePercentage(tick, minimum, maximum)}%` }}
+          >
+            {formatTick(tick)}
+          </li>
+        ))}
+      </ol>
+
+      <input
+        type="hidden"
+        name={minimumName}
+        value={preservedSubmissionValue(
+          initialMinimum,
+          selectedMinimum,
+          minimum,
+          maximum,
+          minimum,
+          preserveInitialValuesUntilChange,
+          minimumChanged,
+          maximumChanged,
+          initialMinimum === null || initialMinimum <= selectedMaximum,
+        )}
+      />
+      <input
+        type="hidden"
+        name={maximumName}
+        value={preservedSubmissionValue(
+          initialMaximum,
+          selectedMaximum,
+          minimum,
+          maximum,
+          maximum,
+          preserveInitialValuesUntilChange,
+          maximumChanged,
+          minimumChanged,
+          initialMaximum === null || selectedMinimum <= initialMaximum,
+        )}
+      />
+    </fieldset>
+  )
+}
+
+function preservedSubmissionValue(
+  initialValue: number | null,
+  selectedValue: number,
+  minimum: number,
+  maximum: number,
+  domainBoundary: number,
+  preserveInitialValuesUntilChange: boolean,
+  changed: boolean,
+  oppositeChanged: boolean,
+  compatibleWithOppositeValue: boolean,
+) {
+  if (
+    preserveInitialValuesUntilChange
+    && !changed
+    && (
+      !oppositeChanged
+      || isCompatibleInitialValue(
+        initialValue,
+        minimum,
+        maximum,
+        compatibleWithOppositeValue,
+      )
+    )
+  ) {
+    return initialValue ?? ''
+  }
+  return selectedValue === domainBoundary ? '' : selectedValue
+}
+
+function isCompatibleInitialValue(
+  initialValue: number | null,
+  minimum: number,
+  maximum: number,
+  compatibleWithOppositeValue: boolean,
+) {
+  return initialValue === null || (
+    initialValue >= minimum
+    && initialValue <= maximum
+    && compatibleWithOppositeValue
+  )
+}
+
+function createMajorTicks(minimum: number, maximum: number, majorStep: number) {
+  if (!(majorStep > 0) || !(maximum > minimum)) {
+    return [minimum, maximum].filter(
+      (tick, index, ticks) => index === 0 || tick !== ticks[index - 1],
+    )
+  }
+  const precision = decimalPlacesFor(minimum, maximum, majorStep)
+  const count = Math.floor(
+    roundToDecimalPlaces((maximum - minimum) / majorStep, 10),
+  )
+  const ticks = Array.from(
+    { length: count + 1 },
+    (_, index) => roundToDecimalPlaces(
+      minimum + index * majorStep,
+      precision,
+    ),
+  )
+  if (ticks.at(-1) !== maximum) {
+    ticks.push(maximum)
+  }
+  return ticks
+}
+
+function normalizeRange(
+  selectedMinimum: number | null,
+  selectedMaximum: number | null,
+  minimum: number,
+  maximum: number,
+  step: number,
+) {
+  const normalizedMinimum = normalizeValue(
+    selectedMinimum ?? minimum,
+    minimum,
+    maximum,
+    step,
+  )
+  const normalizedMaximum = normalizeValue(
+    selectedMaximum ?? maximum,
+    minimum,
+    maximum,
+    step,
+  )
+  return [
+    Math.min(normalizedMinimum, normalizedMaximum),
+    Math.max(normalizedMinimum, normalizedMaximum),
+  ] as const
+}
+
+function normalizeValue(
+  value: number,
+  minimum: number,
+  maximum: number,
+  step: number,
+) {
+  const clamped = Math.min(maximum, Math.max(minimum, value))
+  if (clamped === minimum || clamped === maximum) {
+    return clamped
+  }
+  const stepIndex = Math.round((clamped - minimum) / step)
+  const snapped = minimum + stepIndex * step
+  return Math.min(
+    maximum,
+    Math.max(
+      minimum,
+      roundToDecimalPlaces(
+        snapped,
+        decimalPlacesFor(minimum, maximum, step),
+      ),
+    ),
+  )
+}
+
+function rangePercentage(value: number, minimum: number, maximum: number) {
+  if (maximum === minimum) {
+    return 0
+  }
+  return roundToDecimalPlaces(
+    ((value - minimum) / (maximum - minimum)) * 100,
+    10,
+  )
+}
+
+function validateDomain(
+  minimum: number,
+  maximum: number,
+  step: number,
+  majorStep: number,
+) {
+  if (!Number.isFinite(minimum) || !Number.isFinite(maximum) || minimum >= maximum) {
+    throw new Error('DualRangeFilter minimum과 maximum은 유효한 증가 구간이어야 합니다.')
+  }
+  if (!Number.isFinite(step) || step <= 0) {
+    throw new Error('DualRangeFilter step은 0보다 큰 유한수여야 합니다.')
+  }
+  if (!isStepAligned(maximum, minimum, step)) {
+    throw new Error('DualRangeFilter maximum은 minimum부터 step 단위에 맞아야 합니다.')
+  }
+  if (!Number.isFinite(majorStep) || majorStep <= 0) {
+    throw new Error('DualRangeFilter majorStep은 0보다 큰 유한수여야 합니다.')
+  }
+}
+
+function isStepAligned(value: number, minimum: number, step: number) {
+  const steps = (value - minimum) / step
+  const tolerance = Number.EPSILON * Math.max(1, Math.abs(steps)) * 8
+  return Math.abs(steps - Math.round(steps)) <= tolerance
+}
+
+function decimalPlacesFor(...values: readonly number[]) {
+  return Math.min(15, Math.max(...values.map(decimalPlaces)))
+}
+
+function decimalPlaces(value: number) {
+  const [coefficient, exponentText] = Math.abs(value)
+    .toString()
+    .toLowerCase()
+    .split('e')
+  const fractionLength = coefficient.split('.')[1]?.length ?? 0
+  const exponent = Number(exponentText ?? 0)
+  return Math.max(0, fractionLength - exponent)
+}
+
+function roundToDecimalPlaces(value: number, places: number) {
+  return Number(value.toFixed(places))
+}

--- a/frontend/src/public-housing/filters/DualRangeFilter.tsx
+++ b/frontend/src/public-housing/filters/DualRangeFilter.tsx
@@ -63,7 +63,7 @@ export function DualRangeFilter({
       : `${formatValue(selectedMaximum)} 이하`
     : selectedMaximum === maximum
       ? `${formatValue(selectedMinimum)} 이상`
-      : `${formatValue(selectedMinimum)} ~ ${formatValue(selectedMaximum)}`
+      : `${formatValue(selectedMinimum)}~${formatValue(selectedMaximum)}`
   const startPercentage = rangePercentage(selectedMinimum, minimum, maximum)
   const endPercentage = rangePercentage(selectedMaximum, minimum, maximum)
   const rangeStyle = {
@@ -98,14 +98,19 @@ export function DualRangeFilter({
   return (
     <fieldset ref={fieldsetRef} className={styles.filter} style={rangeStyle}>
       <legend className={styles.legend}>{legend}</legend>
-      <output
-        className={styles.output}
-        role="status"
-        aria-atomic="true"
-        aria-label={`${legend} 선택 범위`}
-      >
-        {rangeText}
-      </output>
+      <div className={styles.header}>
+        <span className={styles.label} aria-hidden="true">
+          {legend}
+        </span>
+        <output
+          className={styles.output}
+          role="status"
+          aria-atomic="true"
+          aria-label={`${legend} 선택 범위`}
+        >
+          {rangeText}
+        </output>
+      </div>
 
       {presets.length > 0 && (
         <div

--- a/frontend/src/public-housing/filters/SearchFilterPanel.module.css
+++ b/frontend/src/public-housing/filters/SearchFilterPanel.module.css
@@ -118,11 +118,11 @@
 
 .choice span {
   display: inline-flex;
-  min-height: 38px;
+  min-height: 36px;
   align-items: center;
   padding: 7px 10px;
   border: 1px solid #aeb5bd;
-  border-radius: 999px;
+  border-radius: 9px;
   background: #ffffff;
   color: #3b4148;
   font-size: 13px;

--- a/frontend/src/public-housing/filters/SearchFilterPanel.module.css
+++ b/frontend/src/public-housing/filters/SearchFilterPanel.module.css
@@ -89,14 +89,18 @@
 }
 
 .choiceGroup legend {
-  margin-bottom: 6px;
+  margin-bottom: 0;
   padding: 0;
+  color: #1e2124;
+  font-weight: 800;
 }
 
 .choiceOptions {
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
+  padding-top: 8px;
+  border-top: 1px solid #d7dce1;
 }
 
 .choice {

--- a/frontend/src/public-housing/filters/SearchFilterPanel.module.css
+++ b/frontend/src/public-housing/filters/SearchFilterPanel.module.css
@@ -1,0 +1,289 @@
+.panel {
+  flex: 0 0 auto;
+  border-bottom: 1px solid var(--border);
+  background: #f8fafc;
+}
+
+.toggle {
+  display: flex;
+  width: 100%;
+  min-height: 48px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 0 16px;
+  border: 0;
+  background: #ffffff;
+  color: #1e2124;
+  font-weight: 750;
+  text-align: left;
+}
+
+.toggleMeta {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--brand-dark);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  max-height: min(52vh, 520px);
+  overflow: hidden;
+  border-top: 1px solid #e7e9ec;
+}
+
+.fields {
+  min-height: 0;
+  padding: 14px 16px;
+  overflow-y: auto;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.regionFields {
+  display: grid;
+  grid-column: 1 / -1;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px 12px;
+}
+
+.regionMessage,
+.regionError {
+  grid-column: 1 / -1;
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.regionMessage {
+  color: #58616a;
+}
+
+.regionError {
+  color: #8a240f;
+}
+
+.field,
+.choiceGroup,
+.range label {
+  display: grid;
+  min-width: 0;
+  align-content: start;
+  gap: 6px;
+  color: #3b4148;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.choiceGroup {
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.choiceGroup legend {
+  margin-bottom: 6px;
+  padding: 0;
+}
+
+.choiceOptions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.choice {
+  position: relative;
+  display: inline-flex;
+  cursor: pointer;
+}
+
+.choice input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+}
+
+.choice span {
+  display: inline-flex;
+  min-height: 38px;
+  align-items: center;
+  padding: 7px 10px;
+  border: 1px solid #aeb5bd;
+  border-radius: 999px;
+  background: #ffffff;
+  color: #3b4148;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.choice input:checked + span {
+  border-color: var(--brand);
+  background: #eaf2ff;
+  color: var(--brand-dark);
+}
+
+.choice input:checked + span::before {
+  content: '✓';
+  margin-right: 4px;
+  font-weight: 900;
+}
+
+.choice input:focus-visible + span {
+  outline: 3px solid rgb(37 110 244 / 24%);
+  outline-offset: 1px;
+}
+
+.field select,
+.range input {
+  width: 100%;
+  min-width: 0;
+  min-height: 40px;
+  padding: 8px 10px;
+  border: 1px solid #aeb5bd;
+  border-radius: 7px;
+  background: #ffffff;
+  color: #1e2124;
+}
+
+.field select:focus,
+.range input:focus {
+  border-color: var(--focus);
+  outline: 3px solid rgb(37 110 244 / 18%);
+}
+
+.ranges {
+  display: grid;
+  margin-top: 16px;
+  gap: 12px;
+}
+
+.range {
+  display: grid;
+  min-width: 0;
+  margin: 0;
+  padding: 12px;
+  border: 1px solid #d7dce1;
+  border-radius: 8px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.range legend {
+  padding: 0 5px;
+  color: #1e2124;
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.inputWithUnit {
+  position: relative;
+  display: block;
+}
+
+.inputWithUnit input {
+  padding-right: 32px;
+}
+
+.inputWithUnit small {
+  position: absolute;
+  top: 50%;
+  right: 10px;
+  color: #58616a;
+  font-size: 12px;
+  transform: translateY(-50%);
+  pointer-events: none;
+}
+
+.error {
+  flex: 0 0 auto;
+  margin: 0;
+  padding: 10px 12px;
+  border-top: 1px solid #f2c9c1;
+  background: #fdefec;
+  color: #8a240f;
+  font-size: 13px;
+}
+
+.actions {
+  display: flex;
+  flex: 0 0 auto;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 12px 16px 16px;
+  border-top: 1px solid #e1e5e9;
+  background: #f8fafc;
+}
+
+.actions button {
+  min-height: 40px;
+  padding: 0 14px;
+  border-radius: 7px;
+  font-weight: 750;
+}
+
+.reset {
+  border: 1px solid #8a949e;
+  background: #ffffff;
+  color: #1e2124;
+}
+
+.apply {
+  border: 1px solid var(--brand);
+  background: var(--brand);
+  color: #ffffff;
+}
+
+@media (max-width: 767px) {
+  .form {
+    max-height: 34vh;
+  }
+
+  .fields {
+    padding: 12px;
+  }
+
+  .grid {
+    gap: 10px;
+  }
+
+  .range {
+    padding: 10px;
+  }
+
+  .field select,
+  .range input,
+  .choice span {
+    font-size: 16px;
+  }
+
+  .choice span,
+  .actions button {
+    min-height: 44px;
+  }
+
+  .choice span {
+    min-width: 44px;
+    justify-content: center;
+  }
+
+  .actions {
+    padding: 10px 12px 12px;
+  }
+}
+
+@media (max-width: 420px) {
+  .grid,
+  .range,
+  .regionFields {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}

--- a/frontend/src/public-housing/filters/SearchFilterPanel.test.tsx
+++ b/frontend/src/public-housing/filters/SearchFilterPanel.test.tsx
@@ -1,7 +1,32 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { type ComponentProps, createElement } from 'react'
-import { describe, expect, it, vi } from 'vitest'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+import searchFilterPanelClasses from './SearchFilterPanel.module.css'
 import { SearchFilterPanel } from './SearchFilterPanel.tsx'
+
+const styleElement = document.createElement('style')
+const searchFilterPanelStylesheet = scopeCssModule(
+  readFileSync(
+    resolve(
+      process.cwd(),
+      'src/public-housing/filters/SearchFilterPanel.module.css',
+    ),
+    'utf8',
+  ),
+  {
+    choiceGroup: searchFilterPanelClasses.choiceGroup,
+    choiceOptions: searchFilterPanelClasses.choiceOptions,
+  },
+)
+
+beforeAll(() => {
+  styleElement.textContent = searchFilterPanelStylesheet
+  document.head.append(styleElement)
+})
+
+afterAll(() => styleElement.remove())
 
 const GYEONGGI_REGIONS = [
   {
@@ -37,6 +62,29 @@ const GYEONGGI_REGIONS = [
 ] as const
 
 describe('SearchFilterPanel', () => {
+  it('공고 필터 항목명과 선택값을 구분선과 간격으로 분리한다', () => {
+    renderFilter({ kind: 'announcement' })
+
+    fireEvent.click(screen.getByRole('button', { name: '공고 필터 열기' }))
+
+    const rentalTypeGroup = screen.getByRole('group', { name: '임대유형' })
+    const firstChoice = within(rentalTypeGroup).getByRole('checkbox', {
+      name: '행복주택',
+    })
+    const valueArea = firstChoice.closest('div')
+    const legend = within(rentalTypeGroup).getByText('임대유형')
+
+    if (!(valueArea instanceof HTMLElement)) {
+      throw new Error('임대유형 선택값 영역을 찾을 수 없습니다.')
+    }
+    expect(getComputedStyle(valueArea).borderTopStyle)
+      .toBe('solid')
+    expect(getComputedStyle(valueArea).borderTopWidth)
+      .toBe('1px')
+    expect(getComputedStyle(valueArea).paddingTop).toBe('8px')
+    expect(getComputedStyle(legend).fontWeight).toBe('800')
+  })
+
   it('시도를 선택하면 직속 시군구를 불러오고 시도만 또는 시군구까지 적용한다', async () => {
     const onApply = vi.fn()
     const regionRepository = {
@@ -149,10 +197,12 @@ describe('SearchFilterPanel', () => {
 
 function renderFilter({
   filters = {},
+  kind = 'complex',
   onApply = vi.fn(),
   regionRepository = { search: vi.fn().mockResolvedValue([]) },
 }: {
   readonly filters?: ComponentProps<typeof SearchFilterPanel>['filters']
+  readonly kind?: ComponentProps<typeof SearchFilterPanel>['kind']
   readonly onApply?: ComponentProps<typeof SearchFilterPanel>['onApply']
   readonly regionRepository?: {
     readonly search: (
@@ -163,9 +213,22 @@ function renderFilter({
 } = {}) {
   const props = {
     filters,
-    kind: 'complex',
+    kind,
     onApply,
     regionRepository,
   } as ComponentProps<typeof SearchFilterPanel>
   return render(createElement(SearchFilterPanel, props))
+}
+
+function scopeCssModule(
+  stylesheet: string,
+  classNames: Readonly<Record<string, string>>,
+) {
+  return Object.entries(classNames).reduce(
+    (scopedStylesheet, [className, scopedClassName]) => scopedStylesheet.replace(
+      new RegExp(`\\.${className}(?![\\w-])`, 'g'),
+      `.${scopedClassName}`,
+    ),
+    stylesheet,
+  )
 }

--- a/frontend/src/public-housing/filters/SearchFilterPanel.test.tsx
+++ b/frontend/src/public-housing/filters/SearchFilterPanel.test.tsx
@@ -1,0 +1,171 @@
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { type ComponentProps, createElement } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { SearchFilterPanel } from './SearchFilterPanel.tsx'
+
+const GYEONGGI_REGIONS = [
+  {
+    regionCode: '41',
+    provinceName: '경기도',
+    districtName: null,
+    displayName: '경기도 전체',
+  },
+  {
+    regionCode: '41110',
+    provinceName: '경기도',
+    districtName: '수원시',
+    displayName: '경기도 수원시',
+  },
+  {
+    regionCode: '41111',
+    provinceName: '경기도',
+    districtName: '수원시 장안구',
+    displayName: '경기도 수원시 장안구',
+  },
+  {
+    regionCode: '41130',
+    provinceName: '경기도',
+    districtName: '성남시',
+    displayName: '경기도 성남시',
+  },
+  {
+    regionCode: '41135',
+    provinceName: '경기도',
+    districtName: '성남시 분당구',
+    displayName: '경기도 성남시 분당구',
+  },
+] as const
+
+describe('SearchFilterPanel', () => {
+  it('시도를 선택하면 직속 시군구를 불러오고 시도만 또는 시군구까지 적용한다', async () => {
+    const onApply = vi.fn()
+    const regionRepository = {
+      search: vi.fn().mockResolvedValue(GYEONGGI_REGIONS),
+    }
+    renderFilter({ onApply, regionRepository })
+
+    fireEvent.click(screen.getByRole('button', { name: '단지 필터 열기' }))
+    fireEvent.change(screen.getByLabelText('시·도'), {
+      target: { value: '41' },
+    })
+
+    const districtSelect = await screen.findByLabelText('시·군·구')
+    expect(regionRepository.search).toHaveBeenCalledWith(
+      '경기도',
+      expect.any(AbortSignal),
+    )
+    expect(within(districtSelect).getByRole('option', { name: '수원시' }))
+      .toBeInTheDocument()
+    expect(within(districtSelect).getByRole('option', { name: '성남시' }))
+      .toBeInTheDocument()
+    expect(within(districtSelect).queryByRole('option', {
+      name: '수원시 장안구',
+    })).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: '단지 필터 적용' }))
+    expect(onApply).toHaveBeenLastCalledWith({ regionCode: '41' })
+
+    fireEvent.change(districtSelect, { target: { value: '41110' } })
+    fireEvent.click(screen.getByRole('button', { name: '단지 필터 적용' }))
+    expect(onApply).toHaveBeenLastCalledWith({ regionCode: '41110' })
+  })
+
+  it('공유 URL의 세부 지역은 일반 후보에서 숨겨져도 선택값을 복원한다', async () => {
+    const regionRepository = {
+      search: vi.fn().mockResolvedValue(GYEONGGI_REGIONS),
+    }
+    renderFilter({
+      filters: { regionCode: '41135' },
+      regionRepository,
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: '단지 필터 열기' }))
+
+    expect(screen.getByLabelText('시·도')).toHaveValue('41')
+    await waitFor(() => {
+      expect(screen.getByLabelText('시·군·구')).toHaveValue('41135')
+    })
+    expect(screen.getByRole('option', {
+      name: '성남시 분당구',
+    })).toBeInTheDocument()
+  })
+
+  it('시군구 로딩 실패를 즉시 알리고 관련 select와 연결한다', async () => {
+    const regionRepository = {
+      search: vi.fn().mockRejectedValue(new Error('network error')),
+    }
+    renderFilter({ filters: { regionCode: '41' }, regionRepository })
+
+    fireEvent.click(screen.getByRole('button', { name: '단지 필터 열기' }))
+
+    const alert = await screen.findByRole('alert')
+    expect(alert).toHaveTextContent('시·군·구를 불러오지 못했습니다.')
+    expect(screen.getByLabelText('시·군·구'))
+      .toHaveAttribute('aria-describedby', alert.id)
+  })
+
+  it('보증금·월세·면적을 승인된 간격의 슬라이더와 빠른 선택으로 적용한다', () => {
+    const onApply = vi.fn()
+    renderFilter({ onApply })
+
+    fireEvent.click(screen.getByRole('button', { name: '단지 필터 열기' }))
+    const depositMinimum = screen.getByRole('slider', {
+      name: '임대보증금 최솟값',
+    })
+    const depositMaximum = screen.getByRole('slider', {
+      name: '임대보증금 최댓값',
+    })
+    const monthlyMinimum = screen.getByRole('slider', {
+      name: '월 임대료 최솟값',
+    })
+    const areaMinimum = screen.getByRole('slider', {
+      name: '전용면적 최솟값',
+    })
+
+    expect(depositMinimum).toHaveAttribute('step', '10000000')
+    expect(depositMaximum).toHaveAttribute('max', '500000000')
+    expect(monthlyMinimum).toHaveAttribute('step', '10000')
+    expect(monthlyMinimum).toHaveAttribute('max', '600000')
+    expect(areaMinimum).toHaveAttribute('step', '3.3')
+    expect(areaMinimum).toHaveAttribute('max', '132')
+
+    fireEvent.change(depositMinimum, { target: { value: '100000000' } })
+    fireEvent.change(depositMaximum, { target: { value: '300000000' } })
+    expect(screen.getByRole('status', {
+      name: '임대보증금 선택 범위',
+    })).toHaveTextContent('1억 ~ 3억')
+
+    fireEvent.click(screen.getByRole('button', { name: '10평대' }))
+    fireEvent.click(screen.getByRole('button', { name: '단지 필터 적용' }))
+
+    expect(onApply).toHaveBeenLastCalledWith({
+      maxDeposit: 300_000_000,
+      maxExclusiveArea: 62.7,
+      minDeposit: 100_000_000,
+      minExclusiveArea: 33,
+    })
+  })
+})
+
+function renderFilter({
+  filters = {},
+  onApply = vi.fn(),
+  regionRepository = { search: vi.fn().mockResolvedValue([]) },
+}: {
+  readonly filters?: ComponentProps<typeof SearchFilterPanel>['filters']
+  readonly onApply?: ComponentProps<typeof SearchFilterPanel>['onApply']
+  readonly regionRepository?: {
+    readonly search: (
+      keyword: string,
+      signal: AbortSignal,
+    ) => Promise<readonly unknown[]>
+  }
+} = {}) {
+  const props = {
+    filters,
+    kind: 'complex',
+    onApply,
+    regionRepository,
+  } as ComponentProps<typeof SearchFilterPanel>
+  return render(createElement(SearchFilterPanel, props))
+}

--- a/frontend/src/public-housing/filters/SearchFilterPanel.test.tsx
+++ b/frontend/src/public-housing/filters/SearchFilterPanel.test.tsx
@@ -16,6 +16,7 @@ const searchFilterPanelStylesheet = scopeCssModule(
     'utf8',
   ),
   {
+    choice: searchFilterPanelClasses.choice,
     choiceGroup: searchFilterPanelClasses.choiceGroup,
     choiceOptions: searchFilterPanelClasses.choiceOptions,
   },
@@ -72,10 +73,14 @@ describe('SearchFilterPanel', () => {
       name: '행복주택',
     })
     const valueArea = firstChoice.closest('div')
+    const choiceVisual = firstChoice.nextElementSibling
     const legend = within(rentalTypeGroup).getByText('임대유형')
 
-    if (!(valueArea instanceof HTMLElement)) {
-      throw new Error('임대유형 선택값 영역을 찾을 수 없습니다.')
+    if (
+      !(valueArea instanceof HTMLElement)
+      || !(choiceVisual instanceof HTMLElement)
+    ) {
+      throw new Error('임대유형 선택값 영역과 버튼을 찾을 수 없습니다.')
     }
     expect(getComputedStyle(valueArea).borderTopStyle)
       .toBe('solid')
@@ -83,6 +88,8 @@ describe('SearchFilterPanel', () => {
       .toBe('1px')
     expect(getComputedStyle(valueArea).paddingTop).toBe('8px')
     expect(getComputedStyle(legend).fontWeight).toBe('800')
+    expect(getComputedStyle(choiceVisual).minHeight).toBe('36px')
+    expect(getComputedStyle(choiceVisual).borderRadius).toBe('9px')
   })
 
   it('시도를 선택하면 직속 시군구를 불러오고 시도만 또는 시군구까지 적용한다', async () => {
@@ -181,7 +188,7 @@ describe('SearchFilterPanel', () => {
     fireEvent.change(depositMaximum, { target: { value: '300000000' } })
     expect(screen.getByRole('status', {
       name: '임대보증금 선택 범위',
-    })).toHaveTextContent('1억 ~ 3억')
+    })).toHaveTextContent('1억~3억')
 
     fireEvent.click(screen.getByRole('button', { name: '10평대' }))
     fireEvent.click(screen.getByRole('button', { name: '단지 필터 적용' }))

--- a/frontend/src/public-housing/filters/SearchFilterPanel.tsx
+++ b/frontend/src/public-housing/filters/SearchFilterPanel.tsx
@@ -1,0 +1,654 @@
+import { type FormEvent, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  type PublicHousingRegionRepository,
+  publicHousingRegionRepository,
+} from '../api/publicHousingRegionRepository.ts'
+import type {
+  AgencyCodeFilter,
+  ApplicationStatusFilter,
+  ComplexSearchFilters,
+  RecruitmentTypeFilter,
+  RentalTypeFilter,
+} from '../api/publicHousingRepository.ts'
+import {
+  districtRegionOptionsForProvince,
+  type PublicHousingRegion,
+  PUBLIC_HOUSING_PROVINCE_OPTIONS,
+  provinceNameForRegionCode,
+} from '../model/publicHousingRegion.ts'
+import {
+  DualRangeFilter,
+  type DualRangeFilterPreset,
+} from './DualRangeFilter.tsx'
+import { searchFiltersSignature } from './searchFilterLocation.ts'
+import styles from './SearchFilterPanel.module.css'
+
+const RENTAL_TYPE_OPTIONS = [
+  ['HAPPY_HOUSING', '행복주택'],
+  ['NATIONAL_RENTAL', '국민임대'],
+  ['PERMANENT_RENTAL', '영구임대'],
+  ['PUBLIC_RENTAL_50Y', '50년 공공임대'],
+  ['INTEGRATED_PUBLIC_RENTAL', '통합공공임대'],
+  ['REDEVELOPMENT_RENTAL', '재개발임대'],
+  ['ETC', '기타'],
+] as const satisfies readonly (readonly [RentalTypeFilter, string])[]
+
+const APPLICATION_STATUS_OPTIONS = [
+  ['BEFORE_APPLICATION', '접수예정'],
+  ['APPLYING', '접수중'],
+  ['CLOSED', '접수마감'],
+] as const satisfies readonly (readonly [ApplicationStatusFilter, string])[]
+
+const AGENCY_OPTIONS = [
+  ['LH', 'LH'],
+  ['SH', 'SH'],
+  ['GH', 'GH'],
+  ['ETC', '기타 기관'],
+] as const satisfies readonly (readonly [AgencyCodeFilter, string])[]
+
+const RECRUITMENT_TYPE_OPTIONS = [
+  ['NEW', '신규 모집'],
+  ['WAITLIST', '예비입주자 모집'],
+  ['ETC', '기타 모집'],
+] as const satisfies readonly (readonly [RecruitmentTypeFilter, string])[]
+
+const DEPOSIT_PRESETS = [
+  { label: '전체', minimum: null, maximum: null },
+  { label: '1억 이하', minimum: null, maximum: 100_000_000 },
+  { label: '1~2억', minimum: 100_000_000, maximum: 200_000_000 },
+  { label: '2~3억', minimum: 200_000_000, maximum: 300_000_000 },
+  { label: '3~5억', minimum: 300_000_000, maximum: 490_000_000 },
+  { label: '5억 이상', minimum: 500_000_000, maximum: null },
+] as const satisfies readonly DualRangeFilterPreset[]
+
+const MONTHLY_RENT_PRESETS = [
+  { label: '전체', minimum: null, maximum: null },
+  { label: '10만 이하', minimum: null, maximum: 100_000 },
+  { label: '10~20만', minimum: 100_000, maximum: 200_000 },
+  { label: '20~30만', minimum: 200_000, maximum: 300_000 },
+  { label: '30~40만', minimum: 300_000, maximum: 400_000 },
+  { label: '40~60만', minimum: 400_000, maximum: 590_000 },
+  { label: '60만 이상', minimum: 600_000, maximum: null },
+] as const satisfies readonly DualRangeFilterPreset[]
+
+const EXCLUSIVE_AREA_PRESETS = [
+  { label: '전체', minimum: null, maximum: null },
+  { label: '10평 미만', minimum: null, maximum: 29.7 },
+  { label: '10평대', minimum: 33, maximum: 62.7 },
+  { label: '20평대', minimum: 66, maximum: 95.7 },
+  { label: '30평 이상', minimum: 99, maximum: null },
+] as const satisfies readonly DualRangeFilterPreset[]
+
+type FilterKind = 'announcement' | 'complex'
+
+interface SearchFilterPanelProps {
+  readonly filters: ComplexSearchFilters
+  readonly kind: FilterKind
+  readonly onApply: (filters: ComplexSearchFilters) => void
+  readonly regionRepository?: PublicHousingRegionRepository
+}
+
+export function SearchFilterPanel({
+  filters,
+  kind,
+  onApply,
+  regionRepository = publicHousingRegionRepository,
+}: SearchFilterPanelProps) {
+  const [open, setOpen] = useState(false)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const formRef = useRef<HTMLFormElement>(null)
+  const label = kind === 'complex' ? '단지' : '공고'
+  const panelId = `${kind}-search-filter-panel`
+  const summaryId = `${panelId}-summary`
+  const appliedCount = appliedFilterCount(filters, kind)
+
+  function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    const nextFilters = filtersFromForm(event.currentTarget, kind)
+    const rangeError = filterRangeError(nextFilters)
+    if (rangeError !== null) {
+      setErrorMessage(rangeError)
+      return
+    }
+    setErrorMessage(null)
+    onApply(nextFilters)
+  }
+
+  function reset() {
+    formRef.current?.reset()
+    setErrorMessage(null)
+    onApply({})
+  }
+
+  return (
+    <section className={styles.panel} aria-label={`${label} 검색 필터`}>
+      <button
+        className={styles.toggle}
+        type="button"
+        aria-label={open ? `${label} 필터 닫기` : `${label} 필터 열기`}
+        aria-controls={panelId}
+        aria-describedby={summaryId}
+        aria-expanded={open}
+        onClick={() => setOpen((current) => !current)}
+      >
+        <span>{label} 필터</span>
+        <span className={styles.toggleMeta}>
+          <span id={summaryId}>
+            {appliedCount > 0 ? `${appliedCount}개 적용` : '조건 선택'}
+          </span>
+          <span aria-hidden="true">{open ? '▲' : '▼'}</span>
+        </span>
+      </button>
+
+      {open && (
+        <form
+          ref={formRef}
+          key={searchFiltersSignature(filters)}
+          id={panelId}
+          className={styles.form}
+          onSubmit={submit}
+        >
+          <div className={styles.fields}>
+            <div className={styles.grid}>
+              <RegionSelect
+                defaultValue={filters.regionCode ?? ''}
+                messageId={`${kind}-region-district-load-error`}
+                repository={regionRepository}
+              />
+              <FilterCheckboxGroup
+                label="임대유형"
+                name="rentalTypes"
+                defaultValues={filters.rentalTypes}
+                options={RENTAL_TYPE_OPTIONS}
+              />
+              <FilterCheckboxGroup
+                label="모집상태"
+                name="applicationStatuses"
+                defaultValues={filters.applicationStatuses}
+                options={APPLICATION_STATUS_OPTIONS}
+              />
+              <FilterCheckboxGroup
+                label="공급기관"
+                name="agencyCodes"
+                defaultValues={filters.agencyCodes}
+                options={AGENCY_OPTIONS}
+              />
+              <FilterCheckboxGroup
+                label="모집유형"
+                name="recruitmentTypes"
+                defaultValues={filters.recruitmentTypes}
+                options={RECRUITMENT_TYPE_OPTIONS}
+              />
+            </div>
+
+            {kind === 'complex' && (
+              <div className={styles.ranges}>
+                <DualRangeFilter
+                  legend="임대보증금"
+                  maximumName="maxDeposit"
+                  minimumName="minDeposit"
+                  minimum={0}
+                  maximum={500_000_000}
+                  step={10_000_000}
+                  majorStep={100_000_000}
+                  initialMinimum={filters.minDeposit ?? null}
+                  initialMaximum={filters.maxDeposit ?? null}
+                  formatValue={formatDeposit}
+                  formatTick={formatDepositTick}
+                  presets={DEPOSIT_PRESETS}
+                />
+                <DualRangeFilter
+                  legend="월 임대료"
+                  maximumName="maxMonthlyRent"
+                  minimumName="minMonthlyRent"
+                  minimum={0}
+                  maximum={600_000}
+                  step={10_000}
+                  majorStep={100_000}
+                  initialMinimum={filters.minMonthlyRent ?? null}
+                  initialMaximum={filters.maxMonthlyRent ?? null}
+                  formatValue={formatMonthlyRent}
+                  formatTick={formatMonthlyRentTick}
+                  presets={MONTHLY_RENT_PRESETS}
+                />
+                <DualRangeFilter
+                  legend="전용면적"
+                  maximumName="maxExclusiveArea"
+                  minimumName="minExclusiveArea"
+                  minimum={0}
+                  maximum={132}
+                  step={3.3}
+                  majorStep={33}
+                  initialMinimum={filters.minExclusiveArea ?? null}
+                  initialMaximum={filters.maxExclusiveArea ?? null}
+                  formatValue={formatExclusiveArea}
+                  formatTick={formatExclusiveAreaTick}
+                  presets={EXCLUSIVE_AREA_PRESETS}
+                />
+                <RangeFields
+                  legend="준공년도"
+                  minimumLabel="최소 준공년도"
+                  minimumName="builtYearFrom"
+                  minimumValue={filters.builtYearFrom}
+                  maximumLabel="최대 준공년도"
+                  maximumName="builtYearTo"
+                  maximumValue={filters.builtYearTo}
+                  step="1"
+                  unit="년"
+                  maximum={9999}
+                  minimum={1}
+                />
+              </div>
+            )}
+          </div>
+
+          {errorMessage !== null && (
+            <p className={styles.error} role="alert">{errorMessage}</p>
+          )}
+
+          <div className={styles.actions}>
+            <button className={styles.reset} type="button" onClick={reset}>
+              초기화
+            </button>
+            <button className={styles.apply} type="submit">
+              {label} 필터 적용
+            </button>
+          </div>
+        </form>
+      )}
+    </section>
+  )
+}
+
+function RegionSelect({ defaultValue, messageId, repository }: {
+  readonly defaultValue: string
+  readonly messageId: string
+  readonly repository: PublicHousingRegionRepository
+}) {
+  const initialProvinceCode = provinceCodeFrom(defaultValue)
+  const initialDistrictCode = defaultValue.length === 5 ? defaultValue : ''
+  const [provinceCode, setProvinceCode] = useState(initialProvinceCode)
+  const [districtCode, setDistrictCode] = useState(initialDistrictCode)
+  const [regions, setRegions] = useState<readonly PublicHousingRegion[]>([])
+  const [loadStatus, setLoadStatus] = useState<
+    'idle' | 'loading' | 'ready' | 'error'
+  >('idle')
+  const provinceSelectRef = useRef<HTMLSelectElement>(null)
+  const provinceName = provinceNameForRegionCode(provinceCode)
+  const districtOptions = useMemo(() => {
+    const options = districtRegionOptionsForProvince(regions, provinceCode)
+    if (
+      districtCode === ''
+      || options.some(({ regionCode }) => regionCode === districtCode)
+    ) {
+      return options
+    }
+    const selectedRegion = regions.find(
+      ({ regionCode }) => regionCode === districtCode,
+    ) ?? selectedRegionFallback(districtCode, provinceName)
+    return [selectedRegion, ...options]
+  }, [districtCode, provinceCode, provinceName, regions])
+
+  useEffect(() => {
+    const form = provinceSelectRef.current?.form
+    if (form === null || form === undefined) {
+      return
+    }
+    const reset = () => {
+      setProvinceCode(initialProvinceCode)
+      setDistrictCode(initialDistrictCode)
+    }
+    form.addEventListener('reset', reset)
+    return () => form.removeEventListener('reset', reset)
+  }, [initialDistrictCode, initialProvinceCode])
+
+  useEffect(() => {
+    if (provinceCode === '' || provinceName === null) {
+      setRegions([])
+      setLoadStatus('idle')
+      return
+    }
+
+    const controller = new AbortController()
+    let active = true
+    setLoadStatus('loading')
+    repository.search(provinceName, controller.signal)
+      .then((items) => {
+        if (!active) {
+          return
+        }
+        setRegions(items)
+        setLoadStatus('ready')
+      })
+      .catch((error: unknown) => {
+        if (!active || isAbortError(error)) {
+          return
+        }
+        setRegions([])
+        setLoadStatus('error')
+      })
+
+    return () => {
+      active = false
+      controller.abort()
+    }
+  }, [provinceCode, provinceName, repository])
+
+  return (
+    <div className={styles.regionFields}>
+      <label className={styles.field}>
+        <span>시·도</span>
+        <select
+          ref={provinceSelectRef}
+          name="provinceCode"
+          value={provinceCode}
+          onChange={(event) => {
+            setProvinceCode(event.currentTarget.value)
+            setDistrictCode('')
+          }}
+        >
+          <option value="">전체</option>
+          {PUBLIC_HOUSING_PROVINCE_OPTIONS.map(([value, optionLabel]) => (
+            <option key={value} value={value}>{optionLabel}</option>
+          ))}
+        </select>
+      </label>
+
+      <label className={styles.field}>
+        <span>시·군·구</span>
+        <select
+          name="districtCode"
+          value={districtCode}
+          disabled={provinceCode === ''}
+          aria-describedby={loadStatus === 'error'
+            ? messageId
+            : undefined}
+          onChange={(event) => setDistrictCode(event.currentTarget.value)}
+        >
+          <option value="">
+            {provinceCode === '' ? '시·도를 먼저 선택' : '전체'}
+          </option>
+          {districtOptions.map(({ districtName, regionCode }) => (
+            <option key={regionCode} value={regionCode}>
+              {districtName ?? regionCode}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      {loadStatus === 'loading' && (
+        <small className={styles.regionMessage} role="status">
+          시·군·구 목록을 불러오는 중입니다.
+        </small>
+      )}
+      {loadStatus === 'error' && (
+        <small
+          className={styles.regionError}
+          id={messageId}
+          role="alert"
+        >
+          시·군·구를 불러오지 못했습니다. 시·도만 적용할 수 있습니다.
+        </small>
+      )}
+    </div>
+  )
+}
+
+function provinceCodeFrom(regionCode: string) {
+  const provinceCode = regionCode.slice(0, 2)
+  return PUBLIC_HOUSING_PROVINCE_OPTIONS.some(
+    ([value]) => value === provinceCode,
+  )
+    ? provinceCode
+    : ''
+}
+
+function selectedRegionFallback(
+  regionCode: string,
+  provinceName: string | null,
+): PublicHousingRegion {
+  return {
+    regionCode,
+    provinceName: provinceName ?? '',
+    districtName: `선택 지역 (${regionCode})`,
+    displayName: `선택 지역 (${regionCode})`,
+  }
+}
+
+function FilterCheckboxGroup({
+  defaultValues = [],
+  label,
+  name,
+  options,
+}: {
+  readonly defaultValues?: readonly string[]
+  readonly label: string
+  readonly name: string
+  readonly options: readonly (readonly [string, string])[]
+}) {
+  const selected = new Set(defaultValues)
+  return (
+    <fieldset className={styles.choiceGroup}>
+      <legend>{label}</legend>
+      <div className={styles.choiceOptions}>
+        {options.map(([value, optionLabel]) => (
+          <label key={value} className={styles.choice}>
+            <input
+              type="checkbox"
+              name={name}
+              value={value}
+              defaultChecked={selected.has(value)}
+            />
+            <span>{optionLabel}</span>
+          </label>
+        ))}
+      </div>
+    </fieldset>
+  )
+}
+
+function RangeFields({
+  legend,
+  maximum = undefined,
+  maximumLabel,
+  maximumName,
+  maximumValue,
+  minimum = 0,
+  minimumLabel,
+  minimumName,
+  minimumValue,
+  step,
+  unit,
+}: {
+  readonly legend: string
+  readonly maximum?: number
+  readonly maximumLabel: string
+  readonly maximumName: string
+  readonly maximumValue: number | null | undefined
+  readonly minimum?: number
+  readonly minimumLabel: string
+  readonly minimumName: string
+  readonly minimumValue: number | null | undefined
+  readonly step: string
+  readonly unit: string
+}) {
+  const minimumUnitId = `${minimumName}-unit`
+  const maximumUnitId = `${maximumName}-unit`
+  return (
+    <fieldset className={styles.range}>
+      <legend>{legend}</legend>
+      <label>
+        <span>{minimumLabel}</span>
+        <span className={styles.inputWithUnit}>
+          <input
+            type="number"
+            name={minimumName}
+            aria-label={minimumLabel}
+            aria-describedby={minimumUnitId}
+            min={minimum}
+            max={maximum}
+            step={step}
+            defaultValue={minimumValue ?? ''}
+          />
+          <small id={minimumUnitId}>{unit}</small>
+        </span>
+      </label>
+      <label>
+        <span>{maximumLabel}</span>
+        <span className={styles.inputWithUnit}>
+          <input
+            type="number"
+            name={maximumName}
+            aria-label={maximumLabel}
+            aria-describedby={maximumUnitId}
+            min={minimum}
+            max={maximum}
+            step={step}
+            defaultValue={maximumValue ?? ''}
+          />
+          <small id={maximumUnitId}>{unit}</small>
+        </span>
+      </label>
+    </fieldset>
+  )
+}
+
+function filtersFromForm(
+  form: HTMLFormElement,
+  kind: FilterKind,
+): ComplexSearchFilters {
+  const data = new FormData(form)
+  const provinceCode = textValue(data, 'provinceCode')
+  const districtCode = textValue(data, 'districtCode')
+  const regionCode = districtCode || provinceCode
+  const rentalTypes = formValues<RentalTypeFilter>(data, 'rentalTypes')
+  const applicationStatuses = formValues<ApplicationStatusFilter>(
+    data,
+    'applicationStatuses',
+  )
+  const agencyCodes = formValues<AgencyCodeFilter>(data, 'agencyCodes')
+  const recruitmentTypes = formValues<RecruitmentTypeFilter>(
+    data,
+    'recruitmentTypes',
+  )
+  const shared: ComplexSearchFilters = {
+    ...(regionCode === '' ? {} : { regionCode }),
+    ...(rentalTypes.length === 0 ? {} : { rentalTypes }),
+    ...(applicationStatuses.length === 0 ? {} : { applicationStatuses }),
+    ...(agencyCodes.length === 0 ? {} : { agencyCodes }),
+    ...(recruitmentTypes.length === 0 ? {} : { recruitmentTypes }),
+  }
+  if (kind === 'announcement') {
+    return shared
+  }
+  return {
+    ...shared,
+    ...optionalFormNumber(data, 'minDeposit'),
+    ...optionalFormNumber(data, 'maxDeposit'),
+    ...optionalFormNumber(data, 'minMonthlyRent'),
+    ...optionalFormNumber(data, 'maxMonthlyRent'),
+    ...optionalFormNumber(data, 'minExclusiveArea'),
+    ...optionalFormNumber(data, 'maxExclusiveArea'),
+    ...optionalFormNumber(data, 'builtYearFrom'),
+    ...optionalFormNumber(data, 'builtYearTo'),
+  }
+}
+
+function filterRangeError(filters: ComplexSearchFilters) {
+  const ranges = [
+    [filters.minDeposit, filters.maxDeposit, '임대보증금'],
+    [filters.minMonthlyRent, filters.maxMonthlyRent, '월 임대료'],
+    [filters.minExclusiveArea, filters.maxExclusiveArea, '전용면적'],
+    [filters.builtYearFrom, filters.builtYearTo, '준공년도'],
+  ] as const
+  const invalid = ranges.find(([minimum, maximum]) => (
+    minimum != null
+    && maximum != null
+    && minimum > maximum
+  ))
+  return invalid === undefined
+    ? null
+    : `${invalid[2]} 최솟값은 최댓값보다 클 수 없습니다.`
+}
+
+function appliedFilterCount(filters: ComplexSearchFilters, kind: FilterKind) {
+  const common = [
+    filters.regionCode,
+    filters.rentalTypes?.length,
+    filters.applicationStatuses?.length,
+    filters.agencyCodes?.length,
+    filters.recruitmentTypes?.length,
+  ].filter(Boolean).length
+  if (kind === 'announcement') {
+    return common
+  }
+  return common + [
+    filters.minDeposit != null || filters.maxDeposit != null,
+    filters.minMonthlyRent != null || filters.maxMonthlyRent != null,
+    filters.minExclusiveArea != null || filters.maxExclusiveArea != null,
+    filters.builtYearFrom != null || filters.builtYearTo != null,
+  ].filter(Boolean).length
+}
+
+function textValue(data: FormData, name: string) {
+  const value = data.get(name)
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function formValues<Value extends string>(data: FormData, name: string) {
+  return data.getAll(name).filter(
+    (value): value is Value => typeof value === 'string',
+  )
+}
+
+function optionalFormNumber(data: FormData, name: string) {
+  const value = textValue(data, name)
+  return value === '' ? {} : { [name]: Number(value) }
+}
+
+function formatDeposit(value: number) {
+  return `${compactDecimal(value / 100_000_000)}억`
+}
+
+function formatDepositTick(value: number) {
+  return value === 500_000_000
+    ? '5억+'
+    : value === 0
+      ? '0'
+      : formatDeposit(value)
+}
+
+function formatMonthlyRent(value: number) {
+  return `${compactDecimal(value / 10_000)}만 원`
+}
+
+function formatMonthlyRentTick(value: number) {
+  return value === 600_000
+    ? '60만+'
+    : value === 0
+      ? '0'
+      : `${compactDecimal(value / 10_000)}만`
+}
+
+function formatExclusiveArea(value: number) {
+  return `${compactDecimal(value / 3.3)}평`
+}
+
+function formatExclusiveAreaTick(value: number) {
+  return value === 132
+    ? '40평+'
+    : value === 0
+      ? '0'
+      : formatExclusiveArea(value)
+}
+
+function compactDecimal(value: number) {
+  return String(Number(value.toFixed(1)))
+}
+
+function isAbortError(error: unknown) {
+  return typeof error === 'object'
+    && error !== null
+    && 'name' in error
+    && error.name === 'AbortError'
+}

--- a/frontend/src/public-housing/filters/searchFilterLocation.test.ts
+++ b/frontend/src/public-housing/filters/searchFilterLocation.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it } from 'vitest'
+
+import type {
+  AnnouncementSearchFilters,
+  ComplexSearchFilters,
+} from '../api/publicHousingRepository.ts'
+import {
+  parseAnnouncementSearchFilters,
+  parseComplexSearchFilters,
+  setAnnouncementSearchFilters,
+  setComplexSearchFilters,
+} from './searchFilterLocation.ts'
+
+const COMPLEX_COMMON_FILTERS = {
+  agencyCodes: ['LH', 'GH'],
+  applicationStatuses: ['BEFORE_APPLICATION', 'APPLYING'],
+  recruitmentTypes: ['NEW', 'WAITLIST'],
+  regionCode: '11',
+  rentalTypes: ['NATIONAL_RENTAL', 'HAPPY_HOUSING'],
+} as const satisfies ComplexSearchFilters
+
+const ANNOUNCEMENT_FILTERS = {
+  agencyCodes: ['SH', 'ETC'],
+  applicationStatuses: ['APPLYING', 'CLOSED'],
+  recruitmentTypes: ['WAITLIST', 'ETC'],
+  regionCode: '41135',
+  rentalTypes: ['PERMANENT_RENTAL', 'PUBLIC_RENTAL_50Y'],
+} as const satisfies AnnouncementSearchFilters
+
+describe('검색 필터 URL namespace', () => {
+  it('단지와 공고 필터를 분리하고 기존 지도와 상세 query를 보존한다', () => {
+    const current = new URLSearchParams(
+      'mapLat=37.56661&mapLng=126.97839&mapZoom=14.00&complexId=17&announcementId=42',
+    )
+
+    const withComplex = setComplexSearchFilters(
+      current,
+      COMPLEX_COMMON_FILTERS,
+    )
+    const withBoth = setAnnouncementSearchFilters(
+      withComplex,
+      ANNOUNCEMENT_FILTERS,
+    )
+
+    expect(parseComplexSearchFilters(withBoth)).toEqual(
+      COMPLEX_COMMON_FILTERS,
+    )
+    expect(parseAnnouncementSearchFilters(withBoth)).toEqual(
+      ANNOUNCEMENT_FILTERS,
+    )
+    expect(withBoth.get('mapLat')).toBe('37.56661')
+    expect(withBoth.get('mapLng')).toBe('126.97839')
+    expect(withBoth.get('mapZoom')).toBe('14.00')
+    expect(withBoth.get('complexId')).toBe('17')
+    expect(withBoth.get('announcementId')).toBe('42')
+    expect(current.toString()).toBe(
+      'mapLat=37.56661&mapLng=126.97839&mapZoom=14.00&complexId=17&announcementId=42',
+    )
+  })
+
+  it('각 enum 배열을 반복 query로 직렬화하고 다시 복원한다', () => {
+    const complexSearch = setComplexSearchFilters(
+      new URLSearchParams(),
+      COMPLEX_COMMON_FILTERS,
+    )
+    const announcementSearch = setAnnouncementSearchFilters(
+      new URLSearchParams(),
+      ANNOUNCEMENT_FILTERS,
+    )
+
+    expect(complexSearch.getAll('complexRentalTypes')).toEqual([
+      'NATIONAL_RENTAL',
+      'HAPPY_HOUSING',
+    ])
+    expect(complexSearch.getAll('complexApplicationStatuses')).toEqual([
+      'BEFORE_APPLICATION',
+      'APPLYING',
+    ])
+    expect(complexSearch.getAll('complexAgencyCodes')).toEqual(['LH', 'GH'])
+    expect(complexSearch.getAll('complexRecruitmentTypes')).toEqual([
+      'NEW',
+      'WAITLIST',
+    ])
+    expect(parseComplexSearchFilters(complexSearch)).toEqual(
+      COMPLEX_COMMON_FILTERS,
+    )
+
+    expect(announcementSearch.getAll('announcementRentalTypes')).toEqual([
+      'PERMANENT_RENTAL',
+      'PUBLIC_RENTAL_50Y',
+    ])
+    expect(
+      announcementSearch.getAll('announcementApplicationStatuses'),
+    ).toEqual(['APPLYING', 'CLOSED'])
+    expect(announcementSearch.getAll('announcementAgencyCodes')).toEqual([
+      'SH',
+      'ETC',
+    ])
+    expect(
+      announcementSearch.getAll('announcementRecruitmentTypes'),
+    ).toEqual(['WAITLIST', 'ETC'])
+    expect(parseAnnouncementSearchFilters(announcementSearch)).toEqual(
+      ANNOUNCEMENT_FILTERS,
+    )
+  })
+
+  it('단지의 금액, 면적과 준공년도 범위를 왕복한다', () => {
+    const filters = {
+      builtYearFrom: 1987,
+      builtYearTo: 2026,
+      maxDeposit: 30_000_000,
+      maxExclusiveArea: 84.99,
+      maxMonthlyRent: 750_000,
+      minDeposit: 0,
+      minExclusiveArea: 16.5,
+      minMonthlyRent: 0,
+    } satisfies ComplexSearchFilters
+
+    const search = setComplexSearchFilters(new URLSearchParams(), filters)
+
+    expect(search.get('complexMinDeposit')).toBe('0')
+    expect(search.get('complexMaxDeposit')).toBe('30000000')
+    expect(search.get('complexMinMonthlyRent')).toBe('0')
+    expect(search.get('complexMaxMonthlyRent')).toBe('750000')
+    expect(search.get('complexMinExclusiveArea')).toBe('16.5')
+    expect(search.get('complexMaxExclusiveArea')).toBe('84.99')
+    expect(search.get('complexBuiltYearFrom')).toBe('1987')
+    expect(search.get('complexBuiltYearTo')).toBe('2026')
+    expect(parseComplexSearchFilters(search)).toEqual(filters)
+  })
+
+  it.each([
+    ['아주 작은 소수', '0.0000001', 0.0000001],
+    ['일반 소수', '36.12', 36.12],
+    ['아주 큰 유한수', '1000000000000000000000', 1e21],
+  ])(
+    '면적의 %s를 지수 표기 없이 직렬화하고 같은 값으로 복원한다',
+    (_caseName, queryValue, expectedValue) => {
+      const parsed = parseComplexSearchFilters(
+        new URLSearchParams(`complexMinExclusiveArea=${queryValue}`),
+      )
+
+      expect(parsed).toEqual({ minExclusiveArea: expectedValue })
+
+      const serialized = setComplexSearchFilters(
+        new URLSearchParams(),
+        parsed,
+      )
+
+      expect(serialized.get('complexMinExclusiveArea')).toBe(queryValue)
+      expect(parseComplexSearchFilters(serialized)).toEqual(parsed)
+    },
+  )
+
+  it('잘못된 enum, 지역, 숫자와 연도는 API 필터로 복원하지 않는다', () => {
+    const search = new URLSearchParams(
+      [
+        'complexRegionCode=1A',
+        'complexRentalTypes=NATIONAL_RENTAL',
+        'complexRentalTypes=UNKNOWN_RENTAL',
+        'complexApplicationStatuses=CANCELLED',
+        'complexAgencyCodes=INVALID_AGENCY',
+        'complexRecruitmentTypes=OLD',
+        'complexMinDeposit=-1',
+        'complexMaxDeposit=1.5',
+        'complexMinMonthlyRent=01',
+        'complexMaxMonthlyRent=9007199254740992',
+        'complexMinExclusiveArea=NaN',
+        'complexMaxExclusiveArea=.5',
+        'complexBuiltYearFrom=0',
+        'complexBuiltYearTo=10000',
+        'announcementRegionCode=1234',
+        'announcementRentalTypes=UNKNOWN_RENTAL',
+        'announcementApplicationStatuses=CANCELLED',
+        'announcementAgencyCodes=INVALID_AGENCY',
+        'announcementRecruitmentTypes=OLD',
+      ].join('&'),
+    )
+
+    expect(parseComplexSearchFilters(search)).toEqual({
+      rentalTypes: ['NATIONAL_RENTAL'],
+    })
+    expect(parseAnnouncementSearchFilters(search)).toEqual({})
+  })
+
+  it('최솟값이 최댓값보다 큰 범위는 양쪽 모두 복원하지 않는다', () => {
+    const search = new URLSearchParams(
+      [
+        'complexMinDeposit=20000000',
+        'complexMaxDeposit=10000000',
+        'complexMinMonthlyRent=500000',
+        'complexMaxMonthlyRent=100000',
+        'complexMinExclusiveArea=84.5',
+        'complexMaxExclusiveArea=36.5',
+        'complexBuiltYearFrom=2026',
+        'complexBuiltYearTo=2000',
+      ].join('&'),
+    )
+
+    expect(parseComplexSearchFilters(search)).toEqual({})
+  })
+
+  it('각 namespace 초기화는 다른 namespace와 기존 query를 보존한다', () => {
+    const withBoth = setAnnouncementSearchFilters(
+      setComplexSearchFilters(
+        new URLSearchParams('mapZoom=14.00&complexId=17'),
+        COMPLEX_COMMON_FILTERS,
+      ),
+      ANNOUNCEMENT_FILTERS,
+    )
+
+    const withoutComplex = setComplexSearchFilters(withBoth, {})
+    expect(parseComplexSearchFilters(withoutComplex)).toEqual({})
+    expect(parseAnnouncementSearchFilters(withoutComplex)).toEqual(
+      ANNOUNCEMENT_FILTERS,
+    )
+    expect(withoutComplex.get('mapZoom')).toBe('14.00')
+    expect(withoutComplex.get('complexId')).toBe('17')
+
+    const withoutAnnouncement = setAnnouncementSearchFilters(withBoth, {})
+    expect(parseAnnouncementSearchFilters(withoutAnnouncement)).toEqual({})
+    expect(parseComplexSearchFilters(withoutAnnouncement)).toEqual(
+      COMPLEX_COMMON_FILTERS,
+    )
+    expect(withoutAnnouncement.get('mapZoom')).toBe('14.00')
+    expect(withoutAnnouncement.get('complexId')).toBe('17')
+  })
+})

--- a/frontend/src/public-housing/filters/searchFilterLocation.ts
+++ b/frontend/src/public-housing/filters/searchFilterLocation.ts
@@ -1,0 +1,318 @@
+import type {
+  AgencyCodeFilter,
+  AnnouncementSearchFilters,
+  ApplicationStatusFilter,
+  ComplexSearchFilters,
+  RecruitmentTypeFilter,
+  RentalTypeFilter,
+  SharedSearchFilters,
+} from '../api/publicHousingRepository.ts'
+
+const RENTAL_TYPES = [
+  'HAPPY_HOUSING',
+  'NATIONAL_RENTAL',
+  'PERMANENT_RENTAL',
+  'PUBLIC_RENTAL_50Y',
+  'INTEGRATED_PUBLIC_RENTAL',
+  'REDEVELOPMENT_RENTAL',
+  'ETC',
+] as const satisfies readonly RentalTypeFilter[]
+
+const APPLICATION_STATUSES = [
+  'BEFORE_APPLICATION',
+  'APPLYING',
+  'CLOSED',
+] as const satisfies readonly ApplicationStatusFilter[]
+
+const AGENCY_CODES = [
+  'LH',
+  'SH',
+  'GH',
+  'ETC',
+] as const satisfies readonly AgencyCodeFilter[]
+
+const RECRUITMENT_TYPES = [
+  'NEW',
+  'WAITLIST',
+  'ETC',
+] as const satisfies readonly RecruitmentTypeFilter[]
+
+const COMPLEX_KEYS = [
+  'complexRegionCode',
+  'complexRentalTypes',
+  'complexApplicationStatuses',
+  'complexAgencyCodes',
+  'complexRecruitmentTypes',
+  'complexMinDeposit',
+  'complexMaxDeposit',
+  'complexMinMonthlyRent',
+  'complexMaxMonthlyRent',
+  'complexMinExclusiveArea',
+  'complexMaxExclusiveArea',
+  'complexBuiltYearFrom',
+  'complexBuiltYearTo',
+] as const
+
+const ANNOUNCEMENT_KEYS = [
+  'announcementRegionCode',
+  'announcementRentalTypes',
+  'announcementApplicationStatuses',
+  'announcementAgencyCodes',
+  'announcementRecruitmentTypes',
+] as const
+
+export function parseComplexSearchFilters(
+  search: URLSearchParams,
+): ComplexSearchFilters {
+  const shared = parseSharedFilters(search, 'complex')
+  const [minDeposit, maxDeposit] = validRange(
+    nonNegativeInteger(search.get('complexMinDeposit')),
+    nonNegativeInteger(search.get('complexMaxDeposit')),
+  )
+  const [minMonthlyRent, maxMonthlyRent] = validRange(
+    nonNegativeInteger(search.get('complexMinMonthlyRent')),
+    nonNegativeInteger(search.get('complexMaxMonthlyRent')),
+  )
+  const [minExclusiveArea, maxExclusiveArea] = validRange(
+    nonNegativeDecimal(search.get('complexMinExclusiveArea')),
+    nonNegativeDecimal(search.get('complexMaxExclusiveArea')),
+  )
+  const [builtYearFrom, builtYearTo] = validRange(
+    year(search.get('complexBuiltYearFrom')),
+    year(search.get('complexBuiltYearTo')),
+  )
+
+  return {
+    ...shared,
+    ...optionalNumber('minDeposit', minDeposit),
+    ...optionalNumber('maxDeposit', maxDeposit),
+    ...optionalNumber('minMonthlyRent', minMonthlyRent),
+    ...optionalNumber('maxMonthlyRent', maxMonthlyRent),
+    ...optionalNumber('minExclusiveArea', minExclusiveArea),
+    ...optionalNumber('maxExclusiveArea', maxExclusiveArea),
+    ...optionalNumber('builtYearFrom', builtYearFrom),
+    ...optionalNumber('builtYearTo', builtYearTo),
+  }
+}
+
+export function parseAnnouncementSearchFilters(
+  search: URLSearchParams,
+): AnnouncementSearchFilters {
+  return parseSharedFilters(search, 'announcement')
+}
+
+export function setComplexSearchFilters(
+  current: URLSearchParams,
+  filters: ComplexSearchFilters,
+) {
+  const next = new URLSearchParams(current)
+  COMPLEX_KEYS.forEach((key) => next.delete(key))
+  appendSharedFilters(next, 'complex', filters)
+  setOptionalNumber(next, 'complexMinDeposit', filters.minDeposit)
+  setOptionalNumber(next, 'complexMaxDeposit', filters.maxDeposit)
+  setOptionalNumber(next, 'complexMinMonthlyRent', filters.minMonthlyRent)
+  setOptionalNumber(next, 'complexMaxMonthlyRent', filters.maxMonthlyRent)
+  setOptionalNumber(next, 'complexMinExclusiveArea', filters.minExclusiveArea)
+  setOptionalNumber(next, 'complexMaxExclusiveArea', filters.maxExclusiveArea)
+  setOptionalNumber(next, 'complexBuiltYearFrom', filters.builtYearFrom)
+  setOptionalNumber(next, 'complexBuiltYearTo', filters.builtYearTo)
+  return next
+}
+
+export function setAnnouncementSearchFilters(
+  current: URLSearchParams,
+  filters: AnnouncementSearchFilters,
+) {
+  const next = new URLSearchParams(current)
+  ANNOUNCEMENT_KEYS.forEach((key) => next.delete(key))
+  appendSharedFilters(next, 'announcement', filters)
+  return next
+}
+
+export function searchFiltersSignature(filters: ComplexSearchFilters) {
+  return JSON.stringify([
+    filters.regionCode ?? null,
+    filters.rentalTypes ?? [],
+    filters.applicationStatuses ?? [],
+    filters.agencyCodes ?? [],
+    filters.recruitmentTypes ?? [],
+    filters.minDeposit ?? null,
+    filters.maxDeposit ?? null,
+    filters.minMonthlyRent ?? null,
+    filters.maxMonthlyRent ?? null,
+    filters.minExclusiveArea ?? null,
+    filters.maxExclusiveArea ?? null,
+    filters.builtYearFrom ?? null,
+    filters.builtYearTo ?? null,
+  ])
+}
+
+export function hasSearchFilters(filters: ComplexSearchFilters) {
+  return Boolean(
+    filters.regionCode
+    || filters.rentalTypes?.length
+    || filters.applicationStatuses?.length
+    || filters.agencyCodes?.length
+    || filters.recruitmentTypes?.length
+    || filters.minDeposit != null
+    || filters.maxDeposit != null
+    || filters.minMonthlyRent != null
+    || filters.maxMonthlyRent != null
+    || filters.minExclusiveArea != null
+    || filters.maxExclusiveArea != null
+    || filters.builtYearFrom != null
+    || filters.builtYearTo != null
+  )
+}
+
+function parseSharedFilters(
+  search: URLSearchParams,
+  prefix: 'announcement' | 'complex',
+): SharedSearchFilters {
+  const regionCode = validRegionCode(search.get(`${prefix}RegionCode`))
+  const rentalTypes = enumValues(
+    search,
+    `${prefix}RentalTypes`,
+    RENTAL_TYPES,
+  )
+  const applicationStatuses = enumValues(
+    search,
+    `${prefix}ApplicationStatuses`,
+    APPLICATION_STATUSES,
+  )
+  const agencyCodes = enumValues(
+    search,
+    `${prefix}AgencyCodes`,
+    AGENCY_CODES,
+  )
+  const recruitmentTypes = enumValues(
+    search,
+    `${prefix}RecruitmentTypes`,
+    RECRUITMENT_TYPES,
+  )
+
+  return {
+    ...(regionCode === null ? {} : { regionCode }),
+    ...(rentalTypes.length === 0 ? {} : { rentalTypes }),
+    ...(applicationStatuses.length === 0 ? {} : { applicationStatuses }),
+    ...(agencyCodes.length === 0 ? {} : { agencyCodes }),
+    ...(recruitmentTypes.length === 0 ? {} : { recruitmentTypes }),
+  }
+}
+
+function appendSharedFilters(
+  search: URLSearchParams,
+  prefix: 'announcement' | 'complex',
+  filters: SharedSearchFilters,
+) {
+  if (filters.regionCode) {
+    search.set(`${prefix}RegionCode`, filters.regionCode)
+  }
+  appendRepeated(search, `${prefix}RentalTypes`, filters.rentalTypes)
+  appendRepeated(
+    search,
+    `${prefix}ApplicationStatuses`,
+    filters.applicationStatuses,
+  )
+  appendRepeated(search, `${prefix}AgencyCodes`, filters.agencyCodes)
+  appendRepeated(
+    search,
+    `${prefix}RecruitmentTypes`,
+    filters.recruitmentTypes,
+  )
+}
+
+function enumValues<T extends string>(
+  search: URLSearchParams,
+  key: string,
+  allowed: readonly T[],
+) {
+  const allowedValues = new Set<string>(allowed)
+  return [...new Set(search.getAll(key))]
+    .filter((value): value is T => allowedValues.has(value))
+}
+
+function appendRepeated(
+  search: URLSearchParams,
+  key: string,
+  values: readonly string[] | undefined,
+) {
+  values?.forEach((value) => search.append(key, value))
+}
+
+function setOptionalNumber(
+  search: URLSearchParams,
+  key: string,
+  value: number | null | undefined,
+) {
+  if (value !== null && value !== undefined) {
+    search.set(key, plainDecimal(value))
+  }
+}
+
+function plainDecimal(value: number) {
+  if (Object.is(value, -0)) {
+    return '0'
+  }
+
+  const serialized = String(value)
+  const exponentSeparator = serialized.indexOf('e')
+  if (exponentSeparator === -1) {
+    return serialized
+  }
+
+  const coefficient = serialized.slice(0, exponentSeparator)
+  const exponent = Number(serialized.slice(exponentSeparator + 1))
+  const sign = coefficient.startsWith('-') ? '-' : ''
+  const unsignedCoefficient = sign ? coefficient.slice(1) : coefficient
+  const [integerPart, fractionPart = ''] = unsignedCoefficient.split('.')
+  const digits = `${integerPart}${fractionPart}`
+  const decimalPosition = integerPart.length + exponent
+
+  if (decimalPosition <= 0) {
+    return `${sign}0.${'0'.repeat(-decimalPosition)}${digits}`
+  }
+  if (decimalPosition >= digits.length) {
+    return `${sign}${digits}${'0'.repeat(decimalPosition - digits.length)}`
+  }
+  return `${sign}${digits.slice(0, decimalPosition)}.${digits.slice(decimalPosition)}`
+}
+
+function validRegionCode(value: string | null) {
+  return value !== null && /^(?:\d{2}|\d{5})$/.test(value) ? value : null
+}
+
+function nonNegativeInteger(value: string | null) {
+  if (value === null || !/^(?:0|[1-9]\d*)$/.test(value)) {
+    return null
+  }
+  const parsed = Number(value)
+  return Number.isSafeInteger(parsed) ? parsed : null
+}
+
+function nonNegativeDecimal(value: string | null) {
+  if (value === null || !/^(?:0|[1-9]\d*)(?:\.\d+)?$/.test(value)) {
+    return null
+  }
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+function year(value: string | null) {
+  const parsed = nonNegativeInteger(value)
+  return parsed !== null && parsed >= 1 && parsed <= 9999 ? parsed : null
+}
+
+function validRange(
+  minimum: number | null,
+  maximum: number | null,
+): readonly [number | null, number | null] {
+  if (minimum !== null && maximum !== null && minimum > maximum) {
+    return [null, null]
+  }
+  return [minimum, maximum]
+}
+
+function optionalNumber<Key extends string>(key: Key, value: number | null) {
+  return value === null ? {} : { [key]: value } as Record<Key, number>
+}

--- a/frontend/src/public-housing/model/publicHousingRegion.ts
+++ b/frontend/src/public-housing/model/publicHousingRegion.ts
@@ -1,0 +1,57 @@
+export const PUBLIC_HOUSING_PROVINCE_OPTIONS = [
+  ['11', '서울특별시'],
+  ['12', '전남광주통합특별시'],
+  ['26', '부산광역시'],
+  ['27', '대구광역시'],
+  ['28', '인천광역시'],
+  ['30', '대전광역시'],
+  ['31', '울산광역시'],
+  ['36', '세종특별자치시'],
+  ['41', '경기도'],
+  ['43', '충청북도'],
+  ['44', '충청남도'],
+  ['47', '경상북도'],
+  ['48', '경상남도'],
+  ['50', '제주특별자치도'],
+  ['51', '강원특별자치도'],
+  ['52', '전북특별자치도'],
+] as const
+
+export interface PublicHousingRegion {
+  readonly regionCode: string
+  readonly provinceName: string
+  readonly districtName: string | null
+  readonly displayName: string
+}
+
+export function districtRegionOptionsForProvince(
+  regions: readonly PublicHousingRegion[],
+  provinceCode: string,
+): readonly PublicHousingRegion[] {
+  const provinceDistricts = regions.filter((region) =>
+    region.regionCode.length === 5
+    && region.regionCode.startsWith(provinceCode),
+  )
+
+  return provinceDistricts.filter((candidate) =>
+    !provinceDistricts.some((parent) => isParentCity(parent, candidate)),
+  )
+}
+
+function isParentCity(
+  parent: PublicHousingRegion,
+  candidate: PublicHousingRegion,
+) {
+  return parent.regionCode !== candidate.regionCode
+    && parent.regionCode.endsWith('0')
+    && parent.regionCode.slice(0, 4) === candidate.regionCode.slice(0, 4)
+    && parent.districtName !== null
+    && candidate.districtName !== null
+    && candidate.districtName.startsWith(`${parent.districtName} `)
+}
+
+export function provinceNameForRegionCode(regionCode: string) {
+  return PUBLIC_HOUSING_PROVINCE_OPTIONS.find(
+    ([code]) => code === regionCode.slice(0, 2),
+  )?.[1] ?? null
+}

--- a/frontend/src/public-housing/testing/minimalPublicHousingSnapshot.ts
+++ b/frontend/src/public-housing/testing/minimalPublicHousingSnapshot.ts
@@ -2,6 +2,9 @@ import type { PublicHousingSnapshotV1 } from '../api/snapshotPublicHousingReposi
 
 export const MINIMAL_PUBLIC_HOUSING_SNAPSHOT = {
   version: 1,
+  complexRegionCodes: { 17: '11140' },
+  announcementRegionCodes: { 201: ['11140'] },
+  regionCodeDescendants: {},
   complexListItems: [
     {
       complexId: 17,


### PR DESCRIPTION
## 관련 이슈
Closes #81

## 작업 목적
- 단지와 공고에 각각 독립적인 검색 필터를 제공한다.

## 작업 내역
- 단지/공고별 필터와 URL 상태를 분리해 구현했다.
- 2단계 지역, 금액/면적 슬라이더, 준공년도 선택 UI를 추가했다.
- 단지 지도/목록과 공고 목록 조회에 각 필터를 연동했다.

## 리뷰 포인트
- 단지·공고 필터 상태와 API 요청이 서로 분리되는지 확인한다.