### PR TITLE
feat(ingest): 공고 원천 수명주기 관리 (#91)

### DIFF
--- a/backend/docs/README.md
+++ b/backend/docs/README.md
@@ -23,6 +23,7 @@
 | HTTP API | [api-conventions.md](api-conventions.md) | 요청, 응답, 호환성 |
 | 예외 처리 | [exception-handling.md](exception-handling.md) | 예외 소유권, Advice, 오류 계약 |
 | DB 변경 | [persistence.md](persistence.md) | 모델, 쿼리, 트랜잭션 |
+| 공고 원천 수명주기 | [announcement-source-lifecycle.md](announcement-source-lifecycle.md) | 미조회 정책과 스키마 배포 |
 | 테스트 | [testing.md](testing.md) | 테스트 범위와 대역 기준 |
 | 보안 변경 | [security.md](security.md) | 인증, 인가, 개인정보, 비밀 |
 | 운영 변경 | [observability.md](observability.md) | 로그, 메트릭, 트레이스 |

--- a/backend/docs/announcement-source-lifecycle.md
+++ b/backend/docs/announcement-source-lifecycle.md
@@ -1,0 +1,30 @@
+# Announcement Source Lifecycle
+
+## 정책
+
+- 마이홈 공고 수집 한 번에 UUID 형식의 `runId`를 하나 발급한다.
+- 조회된 원천은 `lastSeenRunId`와 기존 `collectedAt`을 마지막 확인 실행과 시각으로 기록한다.
+- 모든 공급유형의 전체 페이지가 성공한 실행만 미조회 횟수를 증가시킨다.
+- 한 번 미조회된 원천은 활성 상태를 유지하고, 두 번 연속 미조회되면 비활성화한다.
+- 비활성 원천이 다시 조회되면 활성화하고 미조회 횟수를 0으로 초기화한다.
+- 비활성화는 원천과 정제 공고를 삭제하지 않으며 과거 공고 상세 조회를 유지한다.
+
+## 스키마 배포
+
+운영은 `ddl-auto=validate`이므로 애플리케이션 배포 전에 다음 SQL을 실행한다.
+
+```text
+src/main/resources/db/migration/V20260902_01__add_myhome_announcement_source_lifecycle.sql
+```
+
+```bash
+psql "$DATABASE_URL" --set ON_ERROR_STOP=1 \
+  --file src/main/resources/db/migration/V20260902_01__add_myhome_announcement_source_lifecycle.sql
+```
+
+SQL은 기존 행을 활성·미조회 0회로 backfill한다. 이전 애플리케이션은 추가 컬럼을 사용하지 않으므로
+SQL을 먼저 적용하는 동안 호환된다.
+
+배포 후 `last_seen_run_id`, `consecutive_miss_count`, `active` 컬럼과 `NOT NULL` 제약을 확인한다.
+롤백 시에는 이전 애플리케이션을 다시 배포하고 추가 컬럼은 보존한다. 컬럼 삭제는 이력 손실을
+수반하므로 별도 백업과 승인 없이 수행하지 않는다.

--- a/backend/src/main/java/com/toadzip/backend/ingest/domain/MyHomeAnnouncementSource.java
+++ b/backend/src/main/java/com/toadzip/backend/ingest/domain/MyHomeAnnouncementSource.java
@@ -18,6 +18,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = PROTECTED)
 public class MyHomeAnnouncementSource {
 
+    private static final int INACTIVE_AFTER_CONSECUTIVE_MISSES = 2;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -26,6 +28,15 @@ public class MyHomeAnnouncementSource {
     private String sourceKey;
 
     private Instant collectedAt;
+
+    @Column(length = 100)
+    private String lastSeenRunId;
+
+    @Column(nullable = false)
+    private int consecutiveMissCount;
+
+    @Column(nullable = false)
+    private boolean active;
 
     private Integer sourceOrder;
 
@@ -74,6 +85,8 @@ public class MyHomeAnnouncementSource {
 
     private MyHomeAnnouncementSource(int sourceOrder, MyHomeAnnouncementSourceData data) {
         this.sourceOrder = sourceOrder;
+        consecutiveMissCount = 0;
+        active = true;
         sourceKey = sourceKeyOf(data);
         replaceWith(data);
     }
@@ -124,6 +137,26 @@ public class MyHomeAnnouncementSource {
             throw new IllegalArgumentException("수집 시각은 필수입니다.");
         }
         this.collectedAt = collectedAt;
+    }
+
+    public void markSeen(String runId, Instant seenAt) {
+        if (runId == null || runId.isBlank()) {
+            throw new IllegalArgumentException("수집 실행 ID는 필수입니다.");
+        }
+        if (seenAt == null) {
+            throw new IllegalArgumentException("마지막 확인 시각은 필수입니다.");
+        }
+        lastSeenRunId = runId;
+        consecutiveMissCount = 0;
+        active = true;
+        markCollectedAt(seenAt);
+    }
+
+    public void markMissed() {
+        consecutiveMissCount++;
+        if (consecutiveMissCount >= INACTIVE_AFTER_CONSECUTIVE_MISSES) {
+            active = false;
+        }
     }
 
     private static String keyPart(Object raw) {

--- a/backend/src/main/java/com/toadzip/backend/ingest/repository/MyHomeAnnouncementCollectionExecutionLock.java
+++ b/backend/src/main/java/com/toadzip/backend/ingest/repository/MyHomeAnnouncementCollectionExecutionLock.java
@@ -1,0 +1,79 @@
+package com.toadzip.backend.ingest.repository;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Optional;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Supplier;
+import javax.sql.DataSource;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+
+@Slf4j
+@Repository
+public class MyHomeAnnouncementCollectionExecutionLock {
+
+    private static final long LOCK_KEY = 8_432_026_082_800_017L;
+
+    private static final String TRY_LOCK_SQL = "SELECT pg_try_advisory_lock(?)";
+
+    private static final String UNLOCK_SQL = "SELECT pg_advisory_unlock(?)";
+
+    private final ReentrantLock localLock = new ReentrantLock();
+
+    private final DataSource dataSource;
+
+    public MyHomeAnnouncementCollectionExecutionLock(DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    public <T> Optional<T> tryRun(Supplier<T> operation) {
+        if (!localLock.tryLock()) {
+            return Optional.empty();
+        }
+        try (Connection connection = dataSource.getConnection()) {
+            if (!executeLockQuery(connection, TRY_LOCK_SQL)) {
+                return Optional.empty();
+            }
+            try {
+                return Optional.of(operation.get());
+            }
+            finally {
+                releaseDatabaseLock(connection);
+            }
+        }
+        catch (SQLException exception) {
+            throw new IllegalStateException(
+                    "마이홈 공고 수집 실행 잠금을 처리하지 못했습니다.",
+                    exception
+            );
+        }
+        finally {
+            localLock.unlock();
+        }
+    }
+
+    private boolean executeLockQuery(Connection connection, String sql) throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setLong(1, LOCK_KEY);
+            try (ResultSet result = statement.executeQuery()) {
+                return result.next() && result.getBoolean(1);
+            }
+        }
+    }
+
+    private void releaseDatabaseLock(Connection connection) {
+        try {
+            executeLockQuery(connection, UNLOCK_SQL);
+        }
+        catch (SQLException exception) {
+            log.error(
+                    "마이홈 공고 수집 실행 잠금 해제에 실패했습니다. "
+                            + "DB 연결 종료 시 잠금이 해제됩니다.",
+                    exception
+            );
+        }
+    }
+}

--- a/backend/src/main/java/com/toadzip/backend/ingest/repository/MyHomeAnnouncementSourceRepository.java
+++ b/backend/src/main/java/com/toadzip/backend/ingest/repository/MyHomeAnnouncementSourceRepository.java
@@ -12,6 +12,14 @@ public interface MyHomeAnnouncementSourceRepository extends JpaRepository<MyHome
 
     List<MyHomeAnnouncementSource> findAllBySourceKeyIn(Collection<String> sourceKeys);
 
+    @Query("""
+            select source
+            from MyHomeAnnouncementSource source
+            where source.active = true
+              and (source.lastSeenRunId is null or source.lastSeenRunId <> :runId)
+            """)
+    List<MyHomeAnnouncementSource> findAllActiveNotSeenInRun(String runId);
+
     List<MyHomeAnnouncementSource> findByIdGreaterThanOrderByIdAsc(Long id, Pageable pageable);
 
     @Query("select coalesce(max(source.sourceOrder), -1) from MyHomeAnnouncementSource source")

--- a/backend/src/main/java/com/toadzip/backend/ingest/repository/MyHomeSourceStore.java
+++ b/backend/src/main/java/com/toadzip/backend/ingest/repository/MyHomeSourceStore.java
@@ -1,8 +1,8 @@
 package com.toadzip.backend.ingest.repository;
 
-import java.util.ArrayList;
 import java.time.Clock;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -11,10 +11,10 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.toadzip.backend.ingest.domain.MyHomeComplexSource;
 import com.toadzip.backend.ingest.domain.MyHomeAnnouncementSource;
-import com.toadzip.backend.ingest.dto.MyHomeComplexSourceItem;
+import com.toadzip.backend.ingest.domain.MyHomeComplexSource;
 import com.toadzip.backend.ingest.dto.MyHomeAnnouncementSourceItem;
+import com.toadzip.backend.ingest.dto.MyHomeComplexSourceItem;
 import com.toadzip.backend.ingest.dto.MyHomeRegion;
 
 @Repository
@@ -70,8 +70,8 @@ public class MyHomeSourceStore {
     }
 
     @Transactional
-    public int storeAnnouncements(List<MyHomeAnnouncementSourceItem> items) {
-        Instant collectedAt = clock.instant();
+    public int storeAnnouncements(String runId, List<MyHomeAnnouncementSourceItem> items) {
+        Instant seenAt = clock.instant();
         Map<String, MyHomeAnnouncementSourceItem> unique = new LinkedHashMap<>();
         for (MyHomeAnnouncementSourceItem item : items) {
             unique.put(MyHomeAnnouncementSource.sourceKeyOf(item.toSourceData()), item);
@@ -89,12 +89,19 @@ public class MyHomeSourceStore {
                 source = MyHomeAnnouncementSource.from(sourceOrder, item.toSourceData());
             }
             source.replaceWith(item.toSourceData());
-            source.markCollectedAt(collectedAt);
+            source.markSeen(runId, seenAt);
             sources.add(source);
             sourceOrder++;
         }
         announcementRepository.saveAll(sources);
         return sources.size();
+    }
+
+    @Transactional
+    public void completeAnnouncementCollection(String runId) {
+        List<MyHomeAnnouncementSource> missedSources = announcementRepository
+                .findAllActiveNotSeenInRun(runId);
+        missedSources.forEach(MyHomeAnnouncementSource::markMissed);
     }
 
     private void validateRegion(MyHomeRegion region, List<MyHomeComplexSourceItem> items) {

--- a/backend/src/main/java/com/toadzip/backend/ingest/service/MyHomeAnnouncementCollectionService.java
+++ b/backend/src/main/java/com/toadzip/backend/ingest/service/MyHomeAnnouncementCollectionService.java
@@ -2,6 +2,7 @@ package com.toadzip.backend.ingest.service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
@@ -11,6 +12,8 @@ import com.toadzip.backend.ingest.dto.ExternalDataResponse;
 import com.toadzip.backend.ingest.dto.MyHomeAnnouncementCollectionRequest;
 import com.toadzip.backend.ingest.dto.MyHomeAnnouncementSourceItem;
 import com.toadzip.backend.ingest.dto.MyHomeAnnouncementSupplyType;
+import com.toadzip.backend.ingest.exception.exception.IngestAlreadyRunningException;
+import com.toadzip.backend.ingest.repository.MyHomeAnnouncementCollectionExecutionLock;
 import com.toadzip.backend.ingest.repository.MyHomeAnnouncementExternalRepository;
 import com.toadzip.backend.ingest.repository.MyHomeSourceStore;
 import com.toadzip.backend.ingest.repository.external.DataGoKrOpenApiClient;
@@ -28,6 +31,8 @@ public class MyHomeAnnouncementCollectionService {
 
     private final MyHomeAnnouncementExternalRepository externalRepository;
 
+    private final MyHomeAnnouncementCollectionExecutionLock executionLock;
+
     private final MyHomeSourceStore sourceStore;
 
     private final ExternalDataFailureRecorder failureRecorder;
@@ -37,30 +42,43 @@ public class MyHomeAnnouncementCollectionService {
     public MyHomeAnnouncementCollectionService(
             ObjectMapper objectMapper,
             MyHomeAnnouncementExternalRepository externalRepository,
+            MyHomeAnnouncementCollectionExecutionLock executionLock,
             MyHomeSourceStore sourceStore,
             ExternalDataFailureRecorder failureRecorder,
             ExternalDataRetryExecutor retryExecutor
     ) {
         this.objectMapper = objectMapper;
         this.externalRepository = externalRepository;
+        this.executionLock = executionLock;
         this.sourceStore = sourceStore;
         this.failureRecorder = failureRecorder;
         this.retryExecutor = retryExecutor;
     }
 
     public ExternalDataCollectionReport collect(MyHomeAnnouncementCollectionRequest request) {
+        return executionLock.tryRun(() -> collectUnlocked(request))
+                .orElseThrow(this::alreadyRunning);
+    }
+
+    private ExternalDataCollectionReport collectUnlocked(MyHomeAnnouncementCollectionRequest request) {
+        String runId = UUID.randomUUID().toString();
         log.info(
-                "마이홈 공고 수집을 시작합니다: pageSize={}, maxPages={}",
+                "마이홈 공고 수집을 시작합니다: runId={}, pageSize={}, maxPages={}",
+                runId,
                 request.pageSize(),
                 request.maxPages()
         );
         ExternalDataCollectionReport report = ExternalDataCollectionReport.empty("myhome-announcement");
         for (MyHomeAnnouncementSupplyType supplyType : MyHomeAnnouncementSupplyType.values()) {
-            report = report.plus(collectSupplyType(supplyType, request));
+            report = report.plus(collectSupplyType(runId, supplyType, request));
+        }
+        if (report.failedRequestCount() == 0) {
+            sourceStore.completeAnnouncementCollection(runId);
         }
         log.info(
-                "마이홈 공고 수집을 완료했습니다: storedRowCount={}, failedRequestCount={}, "
+                "마이홈 공고 수집을 완료했습니다: runId={}, storedRowCount={}, failedRequestCount={}, "
                         + "externalApiCallCount={}",
+                runId,
                 report.storedRowCount(),
                 report.failedRequestCount(),
                 report.externalApiCallCount()
@@ -68,7 +86,13 @@ public class MyHomeAnnouncementCollectionService {
         return report;
     }
 
+    private IngestAlreadyRunningException alreadyRunning() {
+        log.warn("마이홈 공고 수집이 이미 실행 중이므로 중복 실행을 건너뜁니다.");
+        return new IngestAlreadyRunningException("마이홈 공고 수집이 이미 실행 중입니다.");
+    }
+
     private ExternalDataCollectionReport collectSupplyType(
+            String runId,
             MyHomeAnnouncementSupplyType supplyType,
             MyHomeAnnouncementCollectionRequest request
     ) {
@@ -87,7 +111,7 @@ public class MyHomeAnnouncementCollectionService {
             );
             return new ExternalDataCollectionReport("myhome-announcement", 0, 1, callCounter.count());
         }
-        int storedRowCount = sourceStore.storeAnnouncements(items);
+        int storedRowCount = sourceStore.storeAnnouncements(runId, items);
         return new ExternalDataCollectionReport("myhome-announcement", storedRowCount, 0, callCounter.count());
     }
 

--- a/backend/src/main/resources/db/migration/V20260902_01__add_myhome_announcement_source_lifecycle.sql
+++ b/backend/src/main/resources/db/migration/V20260902_01__add_myhome_announcement_source_lifecycle.sql
@@ -1,0 +1,18 @@
+BEGIN;
+
+ALTER TABLE myhome_announcement_source
+    ADD COLUMN IF NOT EXISTS last_seen_run_id VARCHAR(100),
+    ADD COLUMN IF NOT EXISTS consecutive_miss_count INTEGER,
+    ADD COLUMN IF NOT EXISTS active BOOLEAN;
+
+UPDATE myhome_announcement_source
+SET consecutive_miss_count = COALESCE(consecutive_miss_count, 0),
+    active = COALESCE(active, TRUE);
+
+ALTER TABLE myhome_announcement_source
+    ALTER COLUMN consecutive_miss_count SET DEFAULT 0,
+    ALTER COLUMN consecutive_miss_count SET NOT NULL,
+    ALTER COLUMN active SET DEFAULT TRUE,
+    ALTER COLUMN active SET NOT NULL;
+
+COMMIT;

--- a/backend/src/test/java/com/toadzip/backend/ingest/repository/MyHomeAnnouncementCollectionExecutionLockTest.java
+++ b/backend/src/test/java/com/toadzip/backend/ingest/repository/MyHomeAnnouncementCollectionExecutionLockTest.java
@@ -1,0 +1,68 @@
+package com.toadzip.backend.ingest.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.concurrent.atomic.AtomicBoolean;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MyHomeAnnouncementCollectionExecutionLockTest {
+
+    @Mock
+    private DataSource dataSource;
+
+    @Mock
+    private Connection connection;
+
+    @Mock
+    private PreparedStatement statement;
+
+    @Mock
+    private ResultSet resultSet;
+
+    private MyHomeAnnouncementCollectionExecutionLock executionLock;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        when(dataSource.getConnection()).thenReturn(connection);
+        when(connection.prepareStatement(anyString())).thenReturn(statement);
+        when(statement.executeQuery()).thenReturn(resultSet);
+        when(resultSet.next()).thenReturn(true);
+        when(resultSet.getBoolean(1)).thenReturn(true);
+        executionLock = new MyHomeAnnouncementCollectionExecutionLock(dataSource);
+    }
+
+    @Test
+    void DB_실행_잠금을_획득하면_수집을_실행하고_잠금을_해제한다() throws Exception {
+        var result = executionLock.tryRun(() -> "completed");
+
+        assertThat(result).contains("completed");
+        verify(statement, org.mockito.Mockito.times(2)).setLong(1, 8_432_026_082_800_017L);
+    }
+
+    @Test
+    void 다른_인스턴스가_DB_실행_잠금을_보유하면_수집을_실행하지_않는다() throws Exception {
+        AtomicBoolean operationExecuted = new AtomicBoolean();
+        when(resultSet.getBoolean(1)).thenReturn(false);
+
+        var result = executionLock.tryRun(() -> {
+            operationExecuted.set(true);
+            return "duplicate";
+        });
+
+        assertThat(result).isEmpty();
+        assertThat(operationExecuted).isFalse();
+        verify(statement).setLong(1, 8_432_026_082_800_017L);
+    }
+}

--- a/backend/src/test/java/com/toadzip/backend/ingest/repository/MyHomeAnnouncementLifecycleMigrationTest.java
+++ b/backend/src/test/java/com/toadzip/backend/ingest/repository/MyHomeAnnouncementLifecycleMigrationTest.java
@@ -1,0 +1,104 @@
+package com.toadzip.backend.ingest.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.jdbc.datasource.init.ScriptUtils;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class MyHomeAnnouncementLifecycleMigrationTest {
+
+    private static final String SCHEMA = "myhome_announcement_lifecycle_migration_test";
+
+    private static final String MIGRATION =
+            "db/migration/V20260902_01__add_myhome_announcement_source_lifecycle.sql";
+
+    @Autowired
+    private DataSource dataSource;
+
+    @Test
+    void 기존_원천_테이블에_수명주기_컬럼을_추가하고_기본값을_backfill한다() throws Exception {
+        try (Connection connection = dataSource.getConnection()) {
+            prepareLegacySchema(connection);
+            try {
+                ScriptUtils.executeSqlScript(connection, new ClassPathResource(MIGRATION));
+
+                assertLifecycleValues(connection);
+                assertLifecycleConstraints(connection);
+            }
+            finally {
+                dropTestSchema(connection);
+            }
+        }
+    }
+
+    private void prepareLegacySchema(Connection connection) throws Exception {
+        try (Statement statement = connection.createStatement()) {
+            statement.execute("DROP SCHEMA IF EXISTS " + SCHEMA + " CASCADE");
+            statement.execute("CREATE SCHEMA " + SCHEMA);
+            statement.execute("SET search_path TO " + SCHEMA);
+            statement.execute("""
+                    CREATE TABLE myhome_announcement_source (
+                        id BIGSERIAL PRIMARY KEY,
+                        source_key VARCHAR(500) NOT NULL,
+                        collected_at TIMESTAMPTZ
+                    )
+                    """);
+            statement.execute("""
+                    INSERT INTO myhome_announcement_source (source_key, collected_at)
+                    VALUES ('legacy-source', TIMESTAMPTZ '2026-09-01 00:00:00+00')
+                    """);
+        }
+    }
+
+    private void assertLifecycleValues(Connection connection) throws Exception {
+        try (Statement statement = connection.createStatement();
+                ResultSet result = statement.executeQuery("""
+                        SELECT last_seen_run_id, consecutive_miss_count, active
+                        FROM myhome_announcement_source
+                        WHERE source_key = 'legacy-source'
+                        """)) {
+            assertThat(result.next()).isTrue();
+            assertThat(result.getString("last_seen_run_id")).isNull();
+            assertThat(result.getInt("consecutive_miss_count")).isZero();
+            assertThat(result.getBoolean("active")).isTrue();
+        }
+    }
+
+    private void assertLifecycleConstraints(Connection connection) throws Exception {
+        try (Statement statement = connection.createStatement();
+                ResultSet result = statement.executeQuery("""
+                        SELECT column_name, is_nullable, column_default
+                        FROM information_schema.columns
+                        WHERE table_schema = current_schema()
+                          AND table_name = 'myhome_announcement_source'
+                          AND column_name IN ('consecutive_miss_count', 'active')
+                        ORDER BY column_name
+                        """)) {
+            assertThat(result.next()).isTrue();
+            assertThat(result.getString("column_name")).isEqualTo("active");
+            assertThat(result.getString("is_nullable")).isEqualTo("NO");
+            assertThat(result.getString("column_default")).isEqualTo("true");
+            assertThat(result.next()).isTrue();
+            assertThat(result.getString("column_name")).isEqualTo("consecutive_miss_count");
+            assertThat(result.getString("is_nullable")).isEqualTo("NO");
+            assertThat(result.getString("column_default")).isEqualTo("0");
+        }
+    }
+
+    private void dropTestSchema(Connection connection) throws Exception {
+        try (Statement statement = connection.createStatement()) {
+            statement.execute("RESET search_path");
+            statement.execute("DROP SCHEMA IF EXISTS " + SCHEMA + " CASCADE");
+        }
+    }
+}

--- a/backend/src/test/java/com/toadzip/backend/ingest/repository/MyHomeSourceStoreTest.java
+++ b/backend/src/test/java/com/toadzip/backend/ingest/repository/MyHomeSourceStoreTest.java
@@ -72,9 +72,9 @@ class MyHomeSourceStoreTest {
 
     @Test
     void 같은_마이홈_공고_식별자는_새_행을_추가하지_않고_컬럼을_갱신한다() {
-        store.storeAnnouncements(List.of(announcement("공고명")));
+        store.storeAnnouncements("run-1", List.of(announcement("공고명")));
 
-        store.storeAnnouncements(List.of(announcement("변경 공고명")));
+        store.storeAnnouncements("run-2", List.of(announcement("변경 공고명")));
 
         assertThat(announcementRepository.findAll()).singleElement().satisfies(source -> {
             assertThat(source.getPblancId()).isEqualTo("21026");
@@ -85,7 +85,7 @@ class MyHomeSourceStoreTest {
 
     @Test
     void 새_마이홈_공고의_원천_순서는_기존_행_다음부터_이어진다() {
-        store.storeAnnouncements(List.of(announcement("첫 공고")));
+        store.storeAnnouncements("run-1", List.of(announcement("첫 공고")));
 
         MyHomeAnnouncementSourceItem second = new MyHomeAnnouncementSourceItem(
                 "21027", 2, "일반공고", "두 번째 공고", "부산도시공사", "아파트", "영구임대",
@@ -94,7 +94,7 @@ class MyHomeSourceStoreTest {
                 "부산광역시 영도구", null, null, "2620012100105100000", "중앙난방", null,
                 300, 2_160_000L, 432_000L, 1_728_000L, 42_800L
         );
-        store.storeAnnouncements(List.of(second));
+        store.storeAnnouncements("run-2", List.of(second));
 
         assertThat(announcementRepository.findAll())
                 .extracting(source -> source.getSourceOrder())
@@ -103,7 +103,7 @@ class MyHomeSourceStoreTest {
 
     @Test
     void 마이홈_공고를_ID_키셋_방식으로_일정한_크기만큼_조회한다() {
-        store.storeAnnouncements(List.of(
+        store.storeAnnouncements("run-1", List.of(
                 announcement("21026", 1, "첫 공고"),
                 announcement("21027", 2, "둘째 공고"),
                 announcement("21028", 3, "셋째 공고")
@@ -124,6 +124,50 @@ class MyHomeSourceStoreTest {
                 .containsExactly("21028");
     }
 
+    @Test
+    void 마이홈_공고는_한_번_미조회되면_활성_상태를_유지한다() {
+        store.storeAnnouncements("run-1", List.of(announcement("공고명")));
+
+        store.completeAnnouncementCollection("run-2");
+
+        assertThat(announcementRepository.findAll()).singleElement().satisfies(source -> {
+            assertThat(source.isActive()).isTrue();
+            assertThat(source.getConsecutiveMissCount()).isOne();
+            assertThat(source.getLastSeenRunId()).isEqualTo("run-1");
+            assertThat(source.getCollectedAt()).isEqualTo(COLLECTED_AT);
+        });
+    }
+
+    @Test
+    void 마이홈_공고는_두_번_연속_미조회되면_비활성화한다() {
+        store.storeAnnouncements("run-1", List.of(announcement("공고명")));
+        store.completeAnnouncementCollection("run-2");
+
+        store.completeAnnouncementCollection("run-3");
+
+        assertThat(announcementRepository.findAll()).singleElement().satisfies(source -> {
+            assertThat(source.isActive()).isFalse();
+            assertThat(source.getConsecutiveMissCount()).isEqualTo(2);
+        });
+    }
+
+    @Test
+    void 비활성화된_마이홈_공고가_다시_조회되면_활성화하고_최신_원천값을_반영한다() {
+        store.storeAnnouncements("run-1", List.of(announcement("공고명")));
+        store.completeAnnouncementCollection("run-2");
+        store.completeAnnouncementCollection("run-3");
+
+        store.storeAnnouncements("run-4", List.of(announcement("취소공고", "취소된 공고")));
+
+        assertThat(announcementRepository.findAll()).singleElement().satisfies(source -> {
+            assertThat(source.isActive()).isTrue();
+            assertThat(source.getConsecutiveMissCount()).isZero();
+            assertThat(source.getLastSeenRunId()).isEqualTo("run-4");
+            assertThat(source.getSttusNm()).isEqualTo("취소공고");
+            assertThat(source.getPblancNm()).isEqualTo("취소된 공고");
+        });
+    }
+
     private MyHomeComplexSourceItem complex(Long hsmpSn, String styleName, BigDecimal exclusiveArea) {
         return new MyHomeComplexSourceItem(
                 hsmpSn, "LH서울", "11", "서울특별시", "140", "중구", "서울특별시 중구",
@@ -138,8 +182,16 @@ class MyHomeSourceStoreTest {
     }
 
     private MyHomeAnnouncementSourceItem announcement(String pblancId, int houseSn, String name) {
+        return announcement(pblancId, houseSn, "일반공고", name);
+    }
+
+    private MyHomeAnnouncementSourceItem announcement(String status, String name) {
+        return announcement("21026", 1, status, name);
+    }
+
+    private MyHomeAnnouncementSourceItem announcement(String pblancId, int houseSn, String status, String name) {
         return new MyHomeAnnouncementSourceItem(
-                pblancId, houseSn, "일반공고", name, "부산도시공사", "아파트", "영구임대",
+                pblancId, houseSn, status, name, "부산도시공사", "아파트", "영구임대",
                 null, "20260813", "20261106", "20260824", "20260831", null,
                 "https://example.com", null, null, "동삼2", "부산광역시", "영도구",
                 "부산광역시 영도구", null, null, "2620012100105100000", "중앙난방", null,

--- a/backend/src/test/java/com/toadzip/backend/ingest/service/MyHomeAnnouncementCollectionServiceTest.java
+++ b/backend/src/test/java/com/toadzip/backend/ingest/service/MyHomeAnnouncementCollectionServiceTest.java
@@ -3,12 +3,17 @@ package com.toadzip.backend.ingest.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,10 +22,13 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.toadzip.backend.ingest.dto.ExternalDataCollectionReport;
 import com.toadzip.backend.ingest.dto.ExternalDataResponse;
 import com.toadzip.backend.ingest.dto.MyHomeAnnouncementCollectionRequest;
 import com.toadzip.backend.ingest.dto.MyHomeAnnouncementSourceItem;
 import com.toadzip.backend.ingest.dto.MyHomeAnnouncementSupplyType;
+import com.toadzip.backend.ingest.exception.exception.IngestAlreadyRunningException;
+import com.toadzip.backend.ingest.repository.MyHomeAnnouncementCollectionExecutionLock;
 import com.toadzip.backend.ingest.repository.MyHomeAnnouncementExternalRepository;
 import com.toadzip.backend.ingest.repository.MyHomeSourceStore;
 import com.toadzip.backend.ingest.repository.external.ExternalDataRequestException;
@@ -33,6 +41,9 @@ class MyHomeAnnouncementCollectionServiceTest {
     private MyHomeAnnouncementExternalRepository externalRepository;
 
     @Mock
+    private MyHomeAnnouncementCollectionExecutionLock executionLock;
+
+    @Mock
     private MyHomeSourceStore sourceStore;
 
     @Mock
@@ -41,14 +52,32 @@ class MyHomeAnnouncementCollectionServiceTest {
     private MyHomeAnnouncementCollectionService service;
 
     @BeforeEach
+    @SuppressWarnings("unchecked")
     void setUp() {
+        lenient().when(executionLock.tryRun(any())).thenAnswer(invocation -> {
+            Supplier<ExternalDataCollectionReport> operation = invocation.getArgument(0);
+            return Optional.of(operation.get());
+        });
         service = new MyHomeAnnouncementCollectionService(
                 JsonMapper.builder().build(),
                 externalRepository,
+                executionLock,
                 sourceStore,
                 failureRecorder,
                 new ExternalDataRetryExecutor(Duration.ZERO)
         );
+    }
+
+    @Test
+    @DisplayName("이미 실행 중이면 중복 수집을 거절한다")
+    void rejectsConcurrentCollection() {
+        doReturn(Optional.empty()).when(executionLock).tryRun(any());
+
+        assertThatThrownBy(() -> service.collect(new MyHomeAnnouncementCollectionRequest(2, 10)))
+                .isInstanceOf(IngestAlreadyRunningException.class)
+                .hasMessage("마이홈 공고 수집이 이미 실행 중입니다.");
+
+        verify(externalRepository, never()).fetch(any(), any(), org.mockito.ArgumentMatchers.anyInt());
     }
 
     @Test
@@ -62,16 +91,20 @@ class MyHomeAnnouncementCollectionServiceTest {
             }
             return response("[]");
         });
-        when(sourceStore.storeAnnouncements(any())).thenAnswer(invocation -> {
-            List<?> items = invocation.getArgument(0);
+        when(sourceStore.storeAnnouncements(anyString(), any())).thenAnswer(invocation -> {
+            List<?> items = invocation.getArgument(1);
             return items.size();
         });
 
         var result = service.collect(request);
 
+        ArgumentCaptor<String> runIds = ArgumentCaptor.captor();
         ArgumentCaptor<List<MyHomeAnnouncementSourceItem>> items = ArgumentCaptor.captor();
         verify(sourceStore, org.mockito.Mockito.times(MyHomeAnnouncementSupplyType.values().length))
-                .storeAnnouncements(items.capture());
+                .storeAnnouncements(runIds.capture(), items.capture());
+        String runId = runIds.getAllValues().getFirst();
+        assertThat(runIds.getAllValues()).containsOnly(runId);
+        verify(sourceStore).completeAnnouncementCollection(runId);
         assertThat(items.getAllValues()).filteredOn(value -> !value.isEmpty())
                 .singleElement()
                 .extracting(List::getFirst)
@@ -92,8 +125,27 @@ class MyHomeAnnouncementCollectionServiceTest {
 
         verify(failureRecorder, org.mockito.Mockito.times(MyHomeAnnouncementSupplyType.values().length))
                 .record(any(), any(), any(), any(), any());
+        verify(sourceStore, never()).completeAnnouncementCollection(anyString());
         assertThat(result.storedRowCount()).isZero();
         assertThat(result.failedRequestCount()).isEqualTo(MyHomeAnnouncementSupplyType.values().length);
+    }
+
+    @Test
+    @DisplayName("일부 공급유형 조회가 실패하면 미조회 공고를 판정하지 않는다")
+    void skipsLifecycleCompletionWhenAnySupplyTypeFails() {
+        MyHomeAnnouncementCollectionRequest request = new MyHomeAnnouncementCollectionRequest(2, 10);
+        when(externalRepository.fetch(any(), any(), org.mockito.ArgumentMatchers.anyInt())).thenAnswer(invocation -> {
+            MyHomeAnnouncementSupplyType supplyType = invocation.getArgument(0);
+            if (supplyType == MyHomeAnnouncementSupplyType.PERMANENT_RENTAL) {
+                throw new ExternalDataRequestException("영구임대 조회 실패");
+            }
+            return response("[]");
+        });
+
+        var result = service.collect(request);
+
+        verify(sourceStore, never()).completeAnnouncementCollection(anyString());
+        assertThat(result.failedRequestCount()).isOne();
     }
 
     @Test
@@ -102,7 +154,7 @@ class MyHomeAnnouncementCollectionServiceTest {
         MyHomeAnnouncementCollectionRequest request = new MyHomeAnnouncementCollectionRequest(2, 10);
         when(externalRepository.fetch(any(), any(), org.mockito.ArgumentMatchers.anyInt()))
                 .thenReturn(response("[]"));
-        when(sourceStore.storeAnnouncements(any())).thenThrow(new IllegalStateException("DB 저장 실패"));
+        when(sourceStore.storeAnnouncements(anyString(), any())).thenThrow(new IllegalStateException("DB 저장 실패"));
 
         assertThatThrownBy(() -> service.collect(request))
                 .isInstanceOf(IllegalStateException.class)

--- a/backend/src/test/java/com/toadzip/backend/ingest/service/MyHomeAnnouncementMappingServiceTest.java
+++ b/backend/src/test/java/com/toadzip/backend/ingest/service/MyHomeAnnouncementMappingServiceTest.java
@@ -4,11 +4,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.toadzip.backend.announcement.domain.Announcement;
 import com.toadzip.backend.announcement.domain.AnnouncementPublicationType;
+import com.toadzip.backend.announcement.domain.ApplicationStatus;
 import com.toadzip.backend.announcement.domain.SupplyRow;
 import com.toadzip.backend.announcement.domain.SupplyTarget;
 import com.toadzip.backend.announcement.repository.AnnouncementRepository;
 import com.toadzip.backend.announcement.repository.SupplyRowRepository;
 import com.toadzip.backend.announcement.repository.SupplyTargetRepository;
+import com.toadzip.backend.announcement.service.AnnouncementQueryService;
 import com.toadzip.backend.housing.domain.Address;
 import com.toadzip.backend.housing.domain.HousingComplex;
 import com.toadzip.backend.housing.domain.HousingType;
@@ -54,6 +56,9 @@ class MyHomeAnnouncementMappingServiceTest {
 
     @Autowired
     private AnnouncementRepository announcementRepository;
+
+    @Autowired
+    private AnnouncementQueryService announcementQueryService;
 
     @Autowired
     private SupplyRowRepository supplyRowRepository;
@@ -163,6 +168,40 @@ class MyHomeAnnouncementMappingServiceTest {
         assertThat(correction.getStatus()).isEqualTo(AnnouncementPublicationType.CORRECTION);
         assertThat(correction.getPreviousSourceAnnouncementIdentifier()).isEqualTo("21026");
         assertThat(correction.getPreviousAnnouncement()).isNotNull();
+    }
+
+    @Test
+    void 비활성화된_원공고의_상세를_유지하고_재수집된_취소공고를_반영한다() {
+        saveMappedComplex();
+        MyHomeAnnouncementSource originalSource = source(
+                0,
+                data("21026", 1, "LH서울", "동삼2")
+        );
+        sourceRepository.save(originalSource);
+        service.mapAll();
+        Announcement original = announcementRepository
+                .findBySourceAnnouncementIdentifier("21026")
+                .orElseThrow();
+        originalSource.markMissed();
+        originalSource.markMissed();
+        sourceRepository.save(originalSource);
+        sourceRepository.save(source(
+                1,
+                withCancellation(data("21027", 2, "LH서울", "동삼2"), "21026")
+        ));
+
+        service.mapAll();
+
+        Announcement cancellation = announcementRepository
+                .findBySourceAnnouncementIdentifier("21027")
+                .orElseThrow();
+        assertThat(sourceRepository.findById(originalSource.getId()).orElseThrow().isActive()).isFalse();
+        assertThat(cancellation.getStatus()).isEqualTo(AnnouncementPublicationType.CANCELLATION);
+        assertThat(cancellation.getPreviousSourceAnnouncementIdentifier()).isEqualTo("21026");
+        assertThat(announcementQueryService.getAnnouncement(cancellation.getId()).applicationStatus())
+                .isEqualTo(ApplicationStatus.CANCELLED);
+        assertThat(announcementQueryService.getAnnouncement(original.getId()).announcementId())
+                .isEqualTo(original.getId());
     }
 
     @Test
@@ -577,6 +616,20 @@ class MyHomeAnnouncementMappingServiceTest {
     private MyHomeAnnouncementSourceData withPrevious(MyHomeAnnouncementSourceData data, String previousIdentifier) {
         return new MyHomeAnnouncementSourceData(
                 data.pblancId(), data.houseSn(), "정정공고", data.pblancNm(), data.suplyInsttNm(),
+                data.houseTyNm(), data.suplyTyNm(), previousIdentifier, data.rcritPblancDe(),
+                data.przwnerPresnatnDe(), data.beginDe(), data.endDe(), data.refrnc(), data.url(),
+                data.pcUrl(), data.mobileUrl(), data.hsmpNm(), data.brtcNm(), data.signguNm(),
+                data.fullAdres(), data.rnCodeNm(), data.refrnLegaldongNm(), data.pnu(), data.heatMthdNm(),
+                data.totHshldCo(), data.sumSuplyCo(), data.rentGtn(), data.enty(), data.surlus(), data.mtRntchrg()
+        );
+    }
+
+    private MyHomeAnnouncementSourceData withCancellation(
+            MyHomeAnnouncementSourceData data,
+            String previousIdentifier
+    ) {
+        return new MyHomeAnnouncementSourceData(
+                data.pblancId(), data.houseSn(), "취소공고", data.pblancNm(), data.suplyInsttNm(),
                 data.houseTyNm(), data.suplyTyNm(), previousIdentifier, data.rcritPblancDe(),
                 data.przwnerPresnatnDe(), data.beginDe(), data.endDe(), data.refrnc(), data.url(),
                 data.pcUrl(), data.mobileUrl(), data.hsmpNm(), data.brtcNm(), data.signguNm(),


### PR DESCRIPTION
## 관련 이슈

Closes #91

## 작업 목적

- 반복 수집 결과로 공고 원천의 최신 여부를 안전하게 관리합니다.

## 작업 내역

- 실행별 확인 이력과 연속 미조회 비활성화 정책 추가
- 전체 수집 성공 시에만 미조회 판정
- 중복 수집 잠금과 운영 DB 마이그레이션 추가

## 리뷰 포인트

- 2회 연속 미조회 시 비활성화하며 원천과 정제 공고는 보존합니다.

## 검증 결과

- `./gradlew --rerun-tasks check` 통과
