### PR TITLE
feat(housing): 지도 클러스터링 단계 정책 추가 (#95)

### DIFF
--- a/backend/src/main/java/com/toadzip/backend/housing/domain/MapClusteringPolicyVersion.java
+++ b/backend/src/main/java/com/toadzip/backend/housing/domain/MapClusteringPolicyVersion.java
@@ -1,0 +1,19 @@
+package com.toadzip.backend.housing.domain;
+
+public record MapClusteringPolicyVersion(
+        String policyVersion,
+        String regionDatasetVersion
+) {
+
+    public MapClusteringPolicyVersion {
+        requireValue(policyVersion, "policyVersion");
+        requireValue(regionDatasetVersion, "regionDatasetVersion");
+    }
+
+    private static void requireValue(String value, String fieldName) {
+        if (value != null && !value.isBlank()) {
+            return;
+        }
+        throw new IllegalArgumentException(fieldName + " is required");
+    }
+}

--- a/backend/src/main/java/com/toadzip/backend/housing/domain/MapClusteringStage.java
+++ b/backend/src/main/java/com/toadzip/backend/housing/domain/MapClusteringStage.java
@@ -1,0 +1,47 @@
+package com.toadzip.backend.housing.domain;
+
+import java.util.List;
+import java.util.Optional;
+
+public enum MapClusteringStage {
+
+    SERVICE_ZONE(1),
+    METROPOLITAN(2),
+    BASIC_REGION(3),
+    INDIVIDUAL(4);
+
+    private static final List<MapClusteringStage> ORDERED_STAGES = List.of(values());
+
+    private final int number;
+
+    MapClusteringStage(int number) {
+        this.number = number;
+    }
+
+    public static MapClusteringStage fromNumber(int number) {
+        return ORDERED_STAGES.stream()
+                .filter(stage -> stage.number == number)
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Unknown map clustering stage: " + number));
+    }
+
+    public int number() {
+        return number;
+    }
+
+    public Optional<MapClusteringStage> next() {
+        int nextIndex = ordinal() + 1;
+        if (nextIndex >= ORDERED_STAGES.size()) {
+            return Optional.empty();
+        }
+        return Optional.of(ORDERED_STAGES.get(nextIndex));
+    }
+
+    boolean isAdjacentTo(MapClusteringStage other) {
+        return Math.abs(number - other.number) == 1;
+    }
+
+    boolean isAfter(MapClusteringStage other) {
+        return number > other.number;
+    }
+}

--- a/backend/src/main/java/com/toadzip/backend/housing/domain/MapClusteringStageResolver.java
+++ b/backend/src/main/java/com/toadzip/backend/housing/domain/MapClusteringStageResolver.java
@@ -1,0 +1,66 @@
+package com.toadzip.backend.housing.domain;
+
+import java.math.BigDecimal;
+
+final class MapClusteringStageResolver {
+
+    private final MapClusteringTransitions transitions;
+
+    MapClusteringStageResolver(MapClusteringTransitions transitions) {
+        this.transitions = transitions;
+    }
+
+    MapClusteringStage resolve(BigDecimal zoom, MapClusteringStage previousStage) {
+        requireZoom(zoom);
+        MapClusteringStage baseline = transitions.baseline(zoom);
+        if (previousStage == null || previousStage == baseline) {
+            return baseline;
+        }
+        if (!previousStage.isAdjacentTo(baseline)) {
+            return baseline;
+        }
+        return resolveAdjacent(zoom, previousStage, baseline);
+    }
+
+    private MapClusteringStage resolveAdjacent(
+            BigDecimal zoom,
+            MapClusteringStage previousStage,
+            MapClusteringStage baseline
+    ) {
+        if (baseline.isAfter(previousStage)) {
+            return resolveZoomIn(zoom, previousStage, baseline);
+        }
+        return resolveZoomOut(zoom, previousStage, baseline);
+    }
+
+    private MapClusteringStage resolveZoomIn(
+            BigDecimal zoom,
+            MapClusteringStage previousStage,
+            MapClusteringStage baseline
+    ) {
+        BigDecimal enterZoom = transitions.from(previousStage).enterZoom();
+        if (zoom.compareTo(enterZoom) < 0) {
+            return previousStage;
+        }
+        return baseline;
+    }
+
+    private MapClusteringStage resolveZoomOut(
+            BigDecimal zoom,
+            MapClusteringStage previousStage,
+            MapClusteringStage baseline
+    ) {
+        BigDecimal exitZoom = transitions.to(previousStage).exitZoom();
+        if (zoom.compareTo(exitZoom) >= 0) {
+            return previousStage;
+        }
+        return baseline;
+    }
+
+    private static void requireZoom(BigDecimal zoom) {
+        if (zoom != null && zoom.signum() >= 0) {
+            return;
+        }
+        throw new IllegalArgumentException("zoom must not be null or negative");
+    }
+}

--- a/backend/src/main/java/com/toadzip/backend/housing/domain/MapClusteringTransition.java
+++ b/backend/src/main/java/com/toadzip/backend/housing/domain/MapClusteringTransition.java
@@ -1,0 +1,68 @@
+package com.toadzip.backend.housing.domain;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+
+public record MapClusteringTransition(
+        MapClusteringStage fromStage,
+        MapClusteringStage toStage,
+        BigDecimal boundaryZoom,
+        BigDecimal hysteresis,
+        BigDecimal expansionZoom
+) {
+
+    private static final BigDecimal ZERO = BigDecimal.ZERO;
+
+    public MapClusteringTransition {
+        Objects.requireNonNull(fromStage, "fromStage");
+        Objects.requireNonNull(toStage, "toStage");
+        Objects.requireNonNull(boundaryZoom, "boundaryZoom");
+        Objects.requireNonNull(hysteresis, "hysteresis");
+        Objects.requireNonNull(expansionZoom, "expansionZoom");
+        requireAdjacent(fromStage, toStage);
+        requireNonNegative(boundaryZoom, "boundaryZoom");
+        requireNonNegative(hysteresis, "hysteresis");
+        requirePositiveExitZoom(boundaryZoom, hysteresis);
+        requireExpansionZoom(boundaryZoom, hysteresis, expansionZoom);
+    }
+
+    BigDecimal enterZoom() {
+        return boundaryZoom.add(hysteresis);
+    }
+
+    BigDecimal exitZoom() {
+        return boundaryZoom.subtract(hysteresis);
+    }
+
+    private static void requireAdjacent(MapClusteringStage fromStage, MapClusteringStage toStage) {
+        if (fromStage.next().filter(toStage::equals).isPresent()) {
+            return;
+        }
+        throw new IllegalArgumentException("Map clustering transitions must connect adjacent stages");
+    }
+
+    private static void requireNonNegative(BigDecimal value, String fieldName) {
+        if (value.compareTo(ZERO) >= 0) {
+            return;
+        }
+        throw new IllegalArgumentException(fieldName + " must not be negative");
+    }
+
+    private static void requirePositiveExitZoom(BigDecimal boundaryZoom, BigDecimal hysteresis) {
+        if (boundaryZoom.compareTo(hysteresis) > 0) {
+            return;
+        }
+        throw new IllegalArgumentException("hysteresis must be less than boundaryZoom");
+    }
+
+    private static void requireExpansionZoom(
+            BigDecimal boundaryZoom,
+            BigDecimal hysteresis,
+            BigDecimal expansionZoom
+    ) {
+        if (expansionZoom.compareTo(boundaryZoom.add(hysteresis)) >= 0) {
+            return;
+        }
+        throw new IllegalArgumentException("expansionZoom must enter the next stage safe range");
+    }
+}

--- a/backend/src/main/java/com/toadzip/backend/housing/domain/MapClusteringTransitionPolicyValidator.java
+++ b/backend/src/main/java/com/toadzip/backend/housing/domain/MapClusteringTransitionPolicyValidator.java
@@ -1,0 +1,82 @@
+package com.toadzip.backend.housing.domain;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.stream.IntStream;
+
+final class MapClusteringTransitionPolicyValidator {
+
+    private static final int EXPECTED_TRANSITION_COUNT = 3;
+
+    private final List<MapClusteringTransition> transitions;
+
+    MapClusteringTransitionPolicyValidator(List<MapClusteringTransition> transitions) {
+        this.transitions = transitions;
+    }
+
+    void validate() {
+        requireCount();
+        requireComplete();
+        requireSeparatedHysteresisRanges();
+        requireExpansionTargets();
+    }
+
+    private void requireCount() {
+        if (transitions.size() == EXPECTED_TRANSITION_COUNT) {
+            return;
+        }
+        throw new IllegalArgumentException("Exactly three map clustering transitions are required");
+    }
+
+    private void requireComplete() {
+        aggregateStages().forEach(this::transitionFrom);
+    }
+
+    private List<MapClusteringStage> aggregateStages() {
+        return List.of(
+                MapClusteringStage.SERVICE_ZONE,
+                MapClusteringStage.METROPOLITAN,
+                MapClusteringStage.BASIC_REGION
+        );
+    }
+
+    private void requireSeparatedHysteresisRanges() {
+        IntStream.range(0, transitions.size() - 1)
+                .forEach(this::requireSeparatedHysteresisRange);
+    }
+
+    private void requireSeparatedHysteresisRange(int index) {
+        BigDecimal currentEnterZoom = transitions.get(index).enterZoom();
+        BigDecimal nextExitZoom = transitions.get(index + 1).exitZoom();
+        if (currentEnterZoom.compareTo(nextExitZoom) < 0) {
+            return;
+        }
+        throw new IllegalArgumentException("Map clustering hysteresis ranges must not overlap");
+    }
+
+    private void requireExpansionTargets() {
+        transitions.forEach(this::requireExpansionTarget);
+    }
+
+    private void requireExpansionTarget(MapClusteringTransition transition) {
+        if (baseline(transition.expansionZoom()) == transition.toStage()) {
+            return;
+        }
+        throw new IllegalArgumentException("expansionZoom must target exactly the next stage");
+    }
+
+    private MapClusteringStage baseline(BigDecimal zoom) {
+        return transitions.stream()
+                .filter(transition -> zoom.compareTo(transition.boundaryZoom()) < 0)
+                .findFirst()
+                .map(MapClusteringTransition::fromStage)
+                .orElse(MapClusteringStage.INDIVIDUAL);
+    }
+
+    private MapClusteringTransition transitionFrom(MapClusteringStage stage) {
+        return transitions.stream()
+                .filter(transition -> transition.fromStage() == stage)
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Missing transition from " + stage));
+    }
+}

--- a/backend/src/main/java/com/toadzip/backend/housing/domain/MapClusteringTransitions.java
+++ b/backend/src/main/java/com/toadzip/backend/housing/domain/MapClusteringTransitions.java
@@ -1,0 +1,55 @@
+package com.toadzip.backend.housing.domain;
+
+import java.math.BigDecimal;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+
+final class MapClusteringTransitions {
+
+    private final List<MapClusteringTransition> values;
+
+    MapClusteringTransitions(List<MapClusteringTransition> transitions) {
+        requireTransitions(transitions);
+        values = transitions.stream()
+                .sorted(Comparator.comparingInt(transition -> transition.fromStage().number()))
+                .toList();
+        new MapClusteringTransitionPolicyValidator(values).validate();
+    }
+
+    MapClusteringStage baseline(BigDecimal zoom) {
+        return values.stream()
+                .filter(transition -> zoom.compareTo(transition.boundaryZoom()) < 0)
+                .findFirst()
+                .map(MapClusteringTransition::fromStage)
+                .orElse(MapClusteringStage.INDIVIDUAL);
+    }
+
+    MapClusteringTransition from(MapClusteringStage stage) {
+        return values.stream()
+                .filter(transition -> transition.fromStage() == stage)
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Missing transition from " + stage));
+    }
+
+    MapClusteringTransition to(MapClusteringStage stage) {
+        return values.stream()
+                .filter(transition -> transition.toStage() == stage)
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Missing transition to " + stage));
+    }
+
+    Optional<BigDecimal> expansionZoom(MapClusteringStage stage) {
+        return values.stream()
+                .filter(transition -> transition.fromStage() == stage)
+                .map(MapClusteringTransition::expansionZoom)
+                .findFirst();
+    }
+
+    private static void requireTransitions(List<MapClusteringTransition> transitions) {
+        if (transitions != null) {
+            return;
+        }
+        throw new IllegalArgumentException("Map clustering transitions are required");
+    }
+}

--- a/backend/src/main/java/com/toadzip/backend/housing/domain/MapClusteringZoomPolicy.java
+++ b/backend/src/main/java/com/toadzip/backend/housing/domain/MapClusteringZoomPolicy.java
@@ -1,0 +1,47 @@
+package com.toadzip.backend.housing.domain;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+public final class MapClusteringZoomPolicy {
+
+    private final MapClusteringPolicyVersion version;
+    private final MapClusteringTransitions transitions;
+    private final MapClusteringStageResolver stageResolver;
+
+    private MapClusteringZoomPolicy(
+            MapClusteringPolicyVersion version,
+            MapClusteringTransitions transitions
+    ) {
+        this.version = version;
+        this.transitions = transitions;
+        stageResolver = new MapClusteringStageResolver(transitions);
+    }
+
+    public static MapClusteringZoomPolicy of(
+            MapClusteringPolicyVersion version,
+            List<MapClusteringTransition> transitions
+    ) {
+        Objects.requireNonNull(version, "version");
+        return new MapClusteringZoomPolicy(version, new MapClusteringTransitions(transitions));
+    }
+
+    public MapClusteringStage resolveStage(BigDecimal zoom, MapClusteringStage previousStage) {
+        return stageResolver.resolve(zoom, previousStage);
+    }
+
+    public Optional<BigDecimal> expansionZoom(MapClusteringStage stage) {
+        Objects.requireNonNull(stage, "stage");
+        return transitions.expansionZoom(stage);
+    }
+
+    public String policyVersion() {
+        return version.policyVersion();
+    }
+
+    public String regionDatasetVersion() {
+        return version.regionDatasetVersion();
+    }
+}

--- a/backend/src/main/java/com/toadzip/backend/housing/repository/CsvMapClusteringZoomPolicyRepository.java
+++ b/backend/src/main/java/com/toadzip/backend/housing/repository/CsvMapClusteringZoomPolicyRepository.java
@@ -1,0 +1,23 @@
+package com.toadzip.backend.housing.repository;
+
+import com.toadzip.backend.housing.domain.MapClusteringZoomPolicy;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
+import org.springframework.stereotype.Component;
+
+@Component
+public final class CsvMapClusteringZoomPolicyRepository implements MapClusteringZoomPolicyRepository {
+
+    private final MapClusteringZoomPolicy currentPolicy;
+
+    public CsvMapClusteringZoomPolicyRepository(
+            @Value("classpath:map-clustering/stage-transitions.csv") Resource resource
+    ) {
+        currentPolicy = new MapClusteringZoomPolicyCsvReader().read(resource);
+    }
+
+    @Override
+    public MapClusteringZoomPolicy current() {
+        return currentPolicy;
+    }
+}

--- a/backend/src/main/java/com/toadzip/backend/housing/repository/MapClusteringPolicyCsvException.java
+++ b/backend/src/main/java/com/toadzip/backend/housing/repository/MapClusteringPolicyCsvException.java
@@ -1,0 +1,57 @@
+package com.toadzip.backend.housing.repository;
+
+import java.io.IOException;
+import org.springframework.core.io.Resource;
+
+final class MapClusteringPolicyCsvException {
+
+    private MapClusteringPolicyCsvException() {
+    }
+
+    static IllegalStateException invalidHeader(Resource resource) {
+        return new IllegalStateException("Invalid map clustering CSV header in " + resource.getDescription());
+    }
+
+    static IllegalStateException invalidColumnCount(Resource resource, int lineNumber, int expected) {
+        return invalidRow(resource, lineNumber, "expected " + expected + " columns", null);
+    }
+
+    static IllegalStateException blankColumn(Resource resource, int lineNumber, String name) {
+        return invalidRow(resource, lineNumber, "blank required column '" + name + "'", null);
+    }
+
+    static IllegalStateException inconsistentVersion(Resource resource, int lineNumber) {
+        return invalidRow(resource, lineNumber, "policyVersion or regionDatasetVersion differs", null);
+    }
+
+    static IllegalStateException noData(Resource resource) {
+        return new IllegalStateException("Map clustering CSV has no data rows: " + resource.getDescription());
+    }
+
+    static IllegalStateException invalidRow(Resource resource, int lineNumber, IllegalArgumentException cause) {
+        return invalidRow(resource, lineNumber, cause.getMessage(), cause);
+    }
+
+    static IllegalStateException invalidPolicy(Resource resource, IllegalArgumentException cause) {
+        return new IllegalStateException(
+                "Invalid map clustering policy in " + resource.getDescription() + ": " + cause.getMessage(),
+                cause
+        );
+    }
+
+    static IllegalStateException readFailure(Resource resource, IOException cause) {
+        return new IllegalStateException("Failed to read map clustering CSV: " + resource.getDescription(), cause);
+    }
+
+    private static IllegalStateException invalidRow(
+            Resource resource,
+            int lineNumber,
+            String reason,
+            Throwable cause
+    ) {
+        return new IllegalStateException(
+                "Invalid map clustering CSV " + resource.getDescription() + " at line " + lineNumber + ": " + reason,
+                cause
+        );
+    }
+}

--- a/backend/src/main/java/com/toadzip/backend/housing/repository/MapClusteringPolicyCsvRow.java
+++ b/backend/src/main/java/com/toadzip/backend/housing/repository/MapClusteringPolicyCsvRow.java
@@ -1,0 +1,86 @@
+package com.toadzip.backend.housing.repository;
+
+import com.toadzip.backend.housing.domain.MapClusteringPolicyVersion;
+import com.toadzip.backend.housing.domain.MapClusteringStage;
+import com.toadzip.backend.housing.domain.MapClusteringTransition;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.stream.IntStream;
+import org.springframework.core.io.Resource;
+
+record MapClusteringPolicyCsvRow(
+        MapClusteringPolicyVersion version,
+        MapClusteringTransition transition,
+        int lineNumber
+) {
+
+    private static final List<String> COLUMN_NAMES = List.of(
+            "policyVersion",
+            "regionDatasetVersion",
+            "fromStage",
+            "toStage",
+            "boundaryZoom",
+            "hysteresis",
+            "expansionZoom"
+    );
+
+    static MapClusteringPolicyCsvRow parse(String line, int lineNumber, Resource resource) {
+        List<String> cells = List.of(line.split(",", -1));
+        validateCells(cells, lineNumber, resource);
+        try {
+            return create(cells, lineNumber);
+        } catch (IllegalArgumentException exception) {
+            throw MapClusteringPolicyCsvException.invalidRow(resource, lineNumber, exception);
+        }
+    }
+
+    private static MapClusteringPolicyCsvRow create(List<String> cells, int lineNumber) {
+        MapClusteringPolicyVersion version = new MapClusteringPolicyVersion(cells.get(0), cells.get(1));
+        return new MapClusteringPolicyCsvRow(version, transition(cells), lineNumber);
+    }
+
+    private static MapClusteringTransition transition(List<String> cells) {
+        return new MapClusteringTransition(
+                stage(cells.get(2), "fromStage"),
+                stage(cells.get(3), "toStage"),
+                decimal(cells.get(4), "boundaryZoom"),
+                decimal(cells.get(5), "hysteresis"),
+                decimal(cells.get(6), "expansionZoom")
+        );
+    }
+
+    private static MapClusteringStage stage(String value, String columnName) {
+        return MapClusteringStage.fromNumber(integer(value, columnName));
+    }
+
+    private static int integer(String value, String columnName) {
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException exception) {
+            throw new IllegalArgumentException(columnName + " must be an integer", exception);
+        }
+    }
+
+    private static BigDecimal decimal(String value, String columnName) {
+        try {
+            return new BigDecimal(value);
+        } catch (NumberFormatException exception) {
+            throw new IllegalArgumentException(columnName + " must be a decimal", exception);
+        }
+    }
+
+    private static void validateCells(List<String> cells, int lineNumber, Resource resource) {
+        if (cells.size() != COLUMN_NAMES.size()) {
+            throw MapClusteringPolicyCsvException.invalidColumnCount(resource, lineNumber, COLUMN_NAMES.size());
+        }
+        IntStream.range(0, cells.size())
+                .forEach(index -> validateCell(cells.get(index), COLUMN_NAMES.get(index), lineNumber, resource));
+    }
+
+    private static void validateCell(String value, String name, int lineNumber, Resource resource) {
+        if (!value.isBlank()) {
+            return;
+        }
+        throw MapClusteringPolicyCsvException.blankColumn(resource, lineNumber, name);
+    }
+}

--- a/backend/src/main/java/com/toadzip/backend/housing/repository/MapClusteringPolicyCsvRows.java
+++ b/backend/src/main/java/com/toadzip/backend/housing/repository/MapClusteringPolicyCsvRows.java
@@ -1,0 +1,49 @@
+package com.toadzip.backend.housing.repository;
+
+import com.toadzip.backend.housing.domain.MapClusteringPolicyVersion;
+import com.toadzip.backend.housing.domain.MapClusteringZoomPolicy;
+import java.util.List;
+import org.springframework.core.io.Resource;
+
+final class MapClusteringPolicyCsvRows {
+
+    private final List<MapClusteringPolicyCsvRow> rows;
+    private final Resource resource;
+
+    MapClusteringPolicyCsvRows(List<MapClusteringPolicyCsvRow> rows, Resource resource) {
+        requireRows(rows, resource);
+        this.rows = rows;
+        this.resource = resource;
+        validateVersions();
+    }
+
+    MapClusteringZoomPolicy toPolicy() {
+        try {
+            return MapClusteringZoomPolicy.of(
+                    rows.getFirst().version(),
+                    rows.stream().map(MapClusteringPolicyCsvRow::transition).toList()
+            );
+        } catch (IllegalArgumentException exception) {
+            throw MapClusteringPolicyCsvException.invalidPolicy(resource, exception);
+        }
+    }
+
+    private void validateVersions() {
+        MapClusteringPolicyVersion expected = rows.getFirst().version();
+        rows.forEach(row -> validateVersion(row, expected));
+    }
+
+    private void validateVersion(MapClusteringPolicyCsvRow row, MapClusteringPolicyVersion expected) {
+        if (row.version().equals(expected)) {
+            return;
+        }
+        throw MapClusteringPolicyCsvException.inconsistentVersion(resource, row.lineNumber());
+    }
+
+    private static void requireRows(List<MapClusteringPolicyCsvRow> rows, Resource resource) {
+        if (!rows.isEmpty()) {
+            return;
+        }
+        throw MapClusteringPolicyCsvException.noData(resource);
+    }
+}

--- a/backend/src/main/java/com/toadzip/backend/housing/repository/MapClusteringZoomPolicyCsvReader.java
+++ b/backend/src/main/java/com/toadzip/backend/housing/repository/MapClusteringZoomPolicyCsvReader.java
@@ -1,0 +1,53 @@
+package com.toadzip.backend.housing.repository;
+
+import com.toadzip.backend.housing.domain.MapClusteringZoomPolicy;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.stream.IntStream;
+import org.springframework.core.io.Resource;
+
+final class MapClusteringZoomPolicyCsvReader {
+
+    private static final String EXPECTED_HEADER = "policyVersion,regionDatasetVersion,fromStage,toStage,"
+            + "boundaryZoom,hysteresis,expansionZoom";
+
+    MapClusteringZoomPolicy read(Resource resource) {
+        List<String> lines = readLines(resource);
+        validateHeader(lines, resource);
+        return rows(lines, resource).toPolicy();
+    }
+
+    private List<MapClusteringPolicyCsvRow> readRows(List<String> lines, Resource resource) {
+        return IntStream.range(1, lines.size())
+                .filter(index -> isDataRow(lines.get(index)))
+                .mapToObj(index -> MapClusteringPolicyCsvRow.parse(lines.get(index), index + 1, resource))
+                .toList();
+    }
+
+    private MapClusteringPolicyCsvRows rows(List<String> lines, Resource resource) {
+        return new MapClusteringPolicyCsvRows(readRows(lines, resource), resource);
+    }
+
+    private List<String> readLines(Resource resource) {
+        try (BufferedReader reader = new BufferedReader(
+                new InputStreamReader(resource.getInputStream(), StandardCharsets.UTF_8))) {
+            return reader.lines().toList();
+        } catch (IOException exception) {
+            throw MapClusteringPolicyCsvException.readFailure(resource, exception);
+        }
+    }
+
+    private void validateHeader(List<String> lines, Resource resource) {
+        if (!lines.isEmpty() && EXPECTED_HEADER.equals(lines.getFirst())) {
+            return;
+        }
+        throw MapClusteringPolicyCsvException.invalidHeader(resource);
+    }
+
+    private boolean isDataRow(String line) {
+        return !line.isBlank() && !line.startsWith("#");
+    }
+}

--- a/backend/src/main/java/com/toadzip/backend/housing/repository/MapClusteringZoomPolicyRepository.java
+++ b/backend/src/main/java/com/toadzip/backend/housing/repository/MapClusteringZoomPolicyRepository.java
@@ -1,0 +1,8 @@
+package com.toadzip.backend.housing.repository;
+
+import com.toadzip.backend.housing.domain.MapClusteringZoomPolicy;
+
+public interface MapClusteringZoomPolicyRepository {
+
+    MapClusteringZoomPolicy current();
+}

--- a/backend/src/main/resources/map-clustering/stage-transitions.csv
+++ b/backend/src/main/resources/map-clustering/stage-transitions.csv
@@ -1,0 +1,6 @@
+policyVersion,regionDatasetVersion,fromStage,toStage,boundaryZoom,hysteresis,expansionZoom
+# source=https://github.com/woowacourse-teams/2026-toadzip/issues/95
+# status=provisional-until-desktop-map-validation
+2026-09-02-v1,2026-07-01,1,2,7.50,0.20,8.50
+2026-09-02-v1,2026-07-01,2,3,10.00,0.20,11.00
+2026-09-02-v1,2026-07-01,3,4,13.00,0.20,14.00

--- a/backend/src/test/java/com/toadzip/backend/housing/domain/MapClusteringZoomPolicyTest.java
+++ b/backend/src/test/java/com/toadzip/backend/housing/domain/MapClusteringZoomPolicyTest.java
@@ -1,0 +1,163 @@
+package com.toadzip.backend.housing.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class MapClusteringZoomPolicyTest {
+
+    @ParameterizedTest
+    @CsvSource({
+            "0, SERVICE_ZONE",
+            "7.49, SERVICE_ZONE",
+            "7.50, METROPOLITAN",
+            "9.99, METROPOLITAN",
+            "10.00, BASIC_REGION",
+            "12.99, BASIC_REGION",
+            "13.00, INDIVIDUAL",
+            "25.00, INDIVIDUAL"
+    })
+    void 이전_단계가_없으면_기본_zoom_경계로_단계를_결정한다(
+            String zoom,
+            MapClusteringStage expected
+    ) {
+        assertEquals(expected, policy().resolveStage(decimal(zoom), null));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "SERVICE_ZONE, 7.69, SERVICE_ZONE",
+            "SERVICE_ZONE, 7.70, METROPOLITAN",
+            "METROPOLITAN, 7.30, METROPOLITAN",
+            "METROPOLITAN, 7.29, SERVICE_ZONE",
+            "METROPOLITAN, 10.19, METROPOLITAN",
+            "METROPOLITAN, 10.20, BASIC_REGION",
+            "BASIC_REGION, 9.80, BASIC_REGION",
+            "BASIC_REGION, 9.79, METROPOLITAN",
+            "BASIC_REGION, 13.19, BASIC_REGION",
+            "BASIC_REGION, 13.20, INDIVIDUAL",
+            "INDIVIDUAL, 12.80, INDIVIDUAL",
+            "INDIVIDUAL, 12.79, BASIC_REGION"
+    })
+    void 인접_단계의_완충_구간에서는_직전_단계를_유지한다(
+            MapClusteringStage previous,
+            String zoom,
+            MapClusteringStage expected
+    ) {
+        assertEquals(expected, policy().resolveStage(decimal(zoom), previous));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "SERVICE_ZONE, 10.00, BASIC_REGION",
+            "SERVICE_ZONE, 13.00, INDIVIDUAL",
+            "INDIVIDUAL, 9.00, METROPOLITAN",
+            "INDIVIDUAL, 7.00, SERVICE_ZONE"
+    })
+    void zoom을_크게_바꾸면_중간_단계를_강제하지_않는다(
+            MapClusteringStage previous,
+            String zoom,
+            MapClusteringStage expected
+    ) {
+        assertEquals(expected, policy().resolveStage(decimal(zoom), previous));
+    }
+
+    @Test
+    void 단계별_클릭_zoom은_정확히_다음_단계의_안전_구간에_있다() {
+        MapClusteringZoomPolicy policy = policy();
+
+        assertEquals(Optional.of(decimal("8.50")), policy.expansionZoom(MapClusteringStage.SERVICE_ZONE));
+        assertEquals(Optional.of(decimal("11.00")), policy.expansionZoom(MapClusteringStage.METROPOLITAN));
+        assertEquals(Optional.of(decimal("14.00")), policy.expansionZoom(MapClusteringStage.BASIC_REGION));
+        assertEquals(Optional.empty(), policy.expansionZoom(MapClusteringStage.INDIVIDUAL));
+    }
+
+    @Test
+    void 잘못된_zoom을_거부한다() {
+        assertThrows(IllegalArgumentException.class, () -> policy().resolveStage(decimal("-0.01"), null));
+        assertThrows(IllegalArgumentException.class, () -> policy().resolveStage(null, null));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"0.20", "0.30"})
+    void hysteresis가_경계와_같거나_더_크면_전환을_생성하지_않는다(String hysteresis) {
+        assertThrows(IllegalArgumentException.class, () -> new MapClusteringTransition(
+                MapClusteringStage.SERVICE_ZONE,
+                MapClusteringStage.METROPOLITAN,
+                decimal("0.20"),
+                decimal(hysteresis),
+                decimal("1.00")
+        ));
+    }
+
+    @Test
+    void 모든_인접_단계의_전환이_없으면_정책을_생성하지_않는다() {
+        List<MapClusteringTransition> incomplete = transitions().subList(0, 2);
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> MapClusteringZoomPolicy.of(version(), incomplete)
+        );
+    }
+
+    @Test
+    void 클릭_zoom이_다음_단계를_건너뛰면_정책을_생성하지_않는다() {
+        List<MapClusteringTransition> skippingExpansion = List.of(
+                transition(MapClusteringStage.SERVICE_ZONE, MapClusteringStage.METROPOLITAN, "7.50", "13.00"),
+                transition(MapClusteringStage.METROPOLITAN, MapClusteringStage.BASIC_REGION, "10.00", "11.00"),
+                transition(MapClusteringStage.BASIC_REGION, MapClusteringStage.INDIVIDUAL, "13.00", "14.00")
+        );
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> MapClusteringZoomPolicy.of(version(), skippingExpansion)
+        );
+    }
+
+    @Test
+    void 인접한_완충_구간이_겹치면_정책을_생성하지_않는다() {
+        List<MapClusteringTransition> overlapping = List.of(
+                transition(MapClusteringStage.SERVICE_ZONE, MapClusteringStage.METROPOLITAN, "9.90", "10.10"),
+                transition(MapClusteringStage.METROPOLITAN, MapClusteringStage.BASIC_REGION, "10.00", "11.00"),
+                transition(MapClusteringStage.BASIC_REGION, MapClusteringStage.INDIVIDUAL, "13.00", "14.00")
+        );
+
+        assertThrows(IllegalArgumentException.class, () -> MapClusteringZoomPolicy.of(version(), overlapping));
+    }
+
+    private static MapClusteringZoomPolicy policy() {
+        return MapClusteringZoomPolicy.of(version(), transitions());
+    }
+
+    private static MapClusteringPolicyVersion version() {
+        return new MapClusteringPolicyVersion("2026-09-02-v1", "2026-07-01");
+    }
+
+    private static List<MapClusteringTransition> transitions() {
+        return List.of(
+                transition(MapClusteringStage.SERVICE_ZONE, MapClusteringStage.METROPOLITAN, "7.50", "8.50"),
+                transition(MapClusteringStage.METROPOLITAN, MapClusteringStage.BASIC_REGION, "10.00", "11.00"),
+                transition(MapClusteringStage.BASIC_REGION, MapClusteringStage.INDIVIDUAL, "13.00", "14.00")
+        );
+    }
+
+    private static MapClusteringTransition transition(
+            MapClusteringStage from,
+            MapClusteringStage to,
+            String boundaryZoom,
+            String expansionZoom
+    ) {
+        return new MapClusteringTransition(from, to, decimal(boundaryZoom), decimal("0.20"), decimal(expansionZoom));
+    }
+
+    private static BigDecimal decimal(String value) {
+        return new BigDecimal(value);
+    }
+}

--- a/backend/src/test/java/com/toadzip/backend/housing/repository/CsvMapClusteringZoomPolicyRepositoryTest.java
+++ b/backend/src/test/java/com/toadzip/backend/housing/repository/CsvMapClusteringZoomPolicyRepositoryTest.java
@@ -1,0 +1,99 @@
+package com.toadzip.backend.housing.repository;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.toadzip.backend.housing.domain.MapClusteringStage;
+import java.math.BigDecimal;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.ClassPathResource;
+
+class CsvMapClusteringZoomPolicyRepositoryTest {
+
+    private static final String HEADER = "policyVersion,regionDatasetVersion,fromStage,toStage,"
+            + "boundaryZoom,hysteresis,expansionZoom";
+
+    @Test
+    void CSV에서_버전과_단계_전환_정책을_읽는다() {
+        CsvMapClusteringZoomPolicyRepository repository = repository(validCsv());
+
+        assertEquals("2026-09-02-v1", repository.current().policyVersion());
+        assertEquals("2026-07-01", repository.current().regionDatasetVersion());
+        assertEquals(
+                MapClusteringStage.INDIVIDUAL,
+                repository.current().resolveStage(new BigDecimal("13.20"), MapClusteringStage.BASIC_REGION)
+        );
+    }
+
+    @Test
+    void 배포용_정책_CSV를_읽는다() {
+        CsvMapClusteringZoomPolicyRepository repository = new CsvMapClusteringZoomPolicyRepository(
+                new ClassPathResource("map-clustering/stage-transitions.csv")
+        );
+
+        assertEquals("2026-09-02-v1", repository.current().policyVersion());
+        assertEquals("2026-07-01", repository.current().regionDatasetVersion());
+    }
+
+    @Test
+    void 잘못된_header를_거부한다() {
+        IllegalStateException exception = assertThrows(
+                IllegalStateException.class,
+                () -> repository("wrong,header\n")
+        );
+
+        assertTrue(exception.getMessage().contains("header"));
+    }
+
+    @Test
+    void 행마다_policy_version이_다르면_거부한다() {
+        String inconsistent = validCsv().replaceFirst("2026-09-02-v1,2026-07-01,2,3", "other,2026-07-01,2,3");
+
+        IllegalStateException exception = assertThrows(
+                IllegalStateException.class,
+                () -> repository(inconsistent)
+        );
+
+        assertTrue(exception.getMessage().contains("line 3"));
+        assertTrue(exception.getMessage().contains("policyVersion"));
+    }
+
+    @Test
+    void 숫자로_해석할_수_없는_zoom과_행_번호를_알린다() {
+        String invalidZoom = validCsv().replaceFirst(",10.00,0.20,11.00", ",zoom,0.20,11.00");
+
+        IllegalStateException exception = assertThrows(
+                IllegalStateException.class,
+                () -> repository(invalidZoom)
+        );
+
+        assertTrue(exception.getMessage().contains("line 3"));
+        assertTrue(exception.getMessage().contains("boundaryZoom"));
+    }
+
+    @Test
+    void hysteresis가_경계보다_작지_않은_CSV_행을_거부한다() {
+        String invalidRange = validCsv().replaceFirst(",7.50,0.20,8.50", ",0.20,0.20,8.50");
+
+        IllegalStateException exception = assertThrows(
+                IllegalStateException.class,
+                () -> repository(invalidRange)
+        );
+
+        assertTrue(exception.getMessage().contains("line 2"));
+        assertTrue(exception.getMessage().contains("hysteresis"));
+    }
+
+    private static CsvMapClusteringZoomPolicyRepository repository(String csv) {
+        return new CsvMapClusteringZoomPolicyRepository(new ByteArrayResource(csv.getBytes()));
+    }
+
+    private static String validCsv() {
+        return HEADER + "\n"
+                + "2026-09-02-v1,2026-07-01,1,2,7.50,0.20,8.50\n"
+                + "2026-09-02-v1,2026-07-01,2,3,10.00,0.20,11.00\n"
+                + "2026-09-02-v1,2026-07-01,3,4,13.00,0.20,14.00\n";
+    }
+}


### PR DESCRIPTION
## 관련 이슈

Refs #95

## 작업 목적

지도 클러스터링 개선 작업 중, 백엔드가 지도 확대 수준에 따라 보여줄 클러스터링 단계를 결정하는 정책을 먼저 추가합니다.

## 작업 내역

- 지도 확대 수준에 따라 서비스 권역, 광역자치단체, 시/군/자치구, 개별 단지의 네 단계로 구분합니다.
- 줌 경계가 실수로 이루어져 있기 때문에, 마커가 1.0 경계에서 연속해서 바뀌지 않도록 클러스터링 단계 전환에 여유 구간을 둡니다.
- 지역 마커를 클릭하면 다음 클러스터링 단계가 보이는 확대 수준으로 이동하도록 기준을 정합니다.
- 단계별 기준값은 CSV 파일에서 읽습니다. 값이 빠졌거나 규칙에 맞지 않으면 애플리케이션을 시작할 때 오류를 발생시킵니다.
- 현재 사용 중인 v1 지도 조회와 단지 검색 및 필터 기능은 변경하지 않습니다.

이번에 정한 확대 수준은 데스크톱 지도에서 직접 확인하기 전까지 사용할 임시값입니다.

지역별 묶음 기준과 마커 위치, 필터가 적용된 단지 수 집계, 서버 응답과 프론트 화면 연결은 후속 PR에서 진행합니다.

## 리뷰 포인트

- 지도를 확대하거나 축소할 때 클러스터링 단계가 정해진 시점에 바뀌는지
- 확대 수준이 경계 근처에서 오갈 때 마커가 연속해서 바뀌지 않는지
- 정책 파일의 값이 빠졌거나 잘못된 경우 애플리케이션 시작 과정에서 오류를 발견하는지

## 검증 결과

- 클러스터링 정책 테스트 37건 통과: `./gradlew test --tests '*MapClustering*'`
- 백엔드 전체 테스트 865건 통과: `./gradlew clean check`
- 저장소 기본 검사 통과: `sh scripts/validate-harness.sh`