### PR TITLE
refactor(housing): 서버 클러스터링을 위한 검색 필터 공통화 (#95)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 ## 📚 문서
 
 - [개발 환경 설정 및 실행](docs/SETUP.md)
+- [통합 검색 API](docs/INTEGRATED_SEARCH.md)
 - [기여 가이드](CONTRIBUTING.md)
 - [백엔드 코드 컨벤션](backend/CODE_CONVENTION.md)
 

--- a/backend/src/main/java/com/toadzip/backend/housing/dto/request/HousingComplexSearchRequest.java
+++ b/backend/src/main/java/com/toadzip/backend/housing/dto/request/HousingComplexSearchRequest.java
@@ -28,6 +28,35 @@ public record HousingComplexSearchRequest(
         @Parameter(required = true) BigDecimal southWestLat,
         @Parameter(required = true) BigDecimal southWestLng,
         @Parameter(required = true) BigDecimal northEastLat,
-        @Parameter(required = true) BigDecimal northEastLng
+        @Parameter(required = true) BigDecimal northEastLng,
+        Boolean hasActiveAnnouncement
 ) {
+    public HousingComplexSearchRequest(
+            String keyword,
+            String regionCode,
+            List<RentalType> rentalTypes,
+            List<ApplicationStatus> applicationStatuses,
+            List<AgencyCode> agencyCodes,
+            List<RecruitmentType> recruitmentTypes,
+            Long minDeposit,
+            Long maxDeposit,
+            Long minMonthlyRent,
+            Long maxMonthlyRent,
+            BigDecimal minExclusiveArea,
+            BigDecimal maxExclusiveArea,
+            Integer builtYearFrom,
+            Integer builtYearTo,
+            Boolean hasElevator,
+            BigDecimal southWestLat,
+            BigDecimal southWestLng,
+            BigDecimal northEastLat,
+            BigDecimal northEastLng
+    ) {
+        this(
+                keyword, regionCode, rentalTypes, applicationStatuses, agencyCodes, recruitmentTypes,
+                minDeposit, maxDeposit, minMonthlyRent, maxMonthlyRent, minExclusiveArea, maxExclusiveArea,
+                builtYearFrom, builtYearTo, hasElevator, southWestLat, southWestLng, northEastLat, northEastLng,
+                null
+        );
+    }
 }

--- a/backend/src/main/java/com/toadzip/backend/housing/repository/ComplexSummarySqlBuilder.java
+++ b/backend/src/main/java/com/toadzip/backend/housing/repository/ComplexSummarySqlBuilder.java
@@ -121,6 +121,20 @@ final class ComplexSummarySqlBuilder {
               AND housing_complex.elevator_installed = :hasElevator
             """;
 
+    private static final String ACTIVE_ANNOUNCEMENT_FILTER = """
+              AND representative.announcement_id IS NOT NULL
+              AND representative.application_start_date <= :today
+              AND representative.application_end_date >= :today
+            """;
+
+    private static final String NO_ACTIVE_ANNOUNCEMENT_FILTER = """
+              AND (
+                    representative.announcement_id IS NULL
+                    OR representative.application_start_date > :today
+                    OR representative.application_end_date < :today
+              )
+            """;
+
     private static final String REPRESENTATIVE_REQUIRED_FILTER = """
               AND representative.announcement_id IS NOT NULL
             """;
@@ -141,6 +155,22 @@ final class ComplexSummarySqlBuilder {
 
     private static final String CLOSED_FILTER =
             "representative.application_end_date < :today";
+
+    private static final String CANCELLED_FILTER = """
+            EXISTS (
+                SELECT 1
+                FROM supply_rows cancelled_supply_row
+                JOIN announcements cancelled_announcement
+                  ON cancelled_announcement.id = cancelled_supply_row.announcement_id
+                WHERE cancelled_supply_row.housing_complex_id = housing_complex.id
+                  AND cancelled_announcement.status IN ('CANCELLATION', '취소공고')
+                  AND NOT EXISTS (
+                      SELECT 1
+                      FROM announcements cancelled_successor
+                      WHERE cancelled_successor.previous_announcement_id = cancelled_announcement.id
+                  )
+            )
+            """.strip();
 
     private static final String AREA_EXISTS_START = """
               AND EXISTS (
@@ -317,6 +347,23 @@ final class ComplexSummarySqlBuilder {
         addFilter(condition.builtYearFrom(), BUILT_YEAR_FROM_FILTER, "builtYearFrom", filters, parameters);
         addFilter(condition.builtYearTo(), BUILT_YEAR_TO_FILTER, "builtYearTo", filters, parameters);
         addFilter(condition.hasElevator(), ELEVATOR_FILTER, "hasElevator", filters, parameters);
+        addActiveAnnouncementFilter(condition, filters, parameters);
+    }
+
+    private void addActiveAnnouncementFilter(
+            HousingComplexSearchCondition condition,
+            StringBuilder filters,
+            Map<String, Object> parameters
+    ) {
+        if (condition.hasActiveAnnouncement() == null) {
+            return;
+        }
+        if (condition.hasActiveAnnouncement()) {
+            filters.append(ACTIVE_ANNOUNCEMENT_FILTER);
+        } else {
+            filters.append(NO_ACTIVE_ANNOUNCEMENT_FILTER);
+        }
+        parameters.put("today", condition.today());
     }
 
     private void addAnnouncementFilters(
@@ -327,14 +374,16 @@ final class ComplexSummarySqlBuilder {
         if (condition.recruitmentTypes().isEmpty() && condition.applicationStatuses().isEmpty()) {
             return;
         }
-        filters.append(REPRESENTATIVE_REQUIRED_FILTER);
-        addCollectionFilter(
-                storedValues(condition.recruitmentTypes()),
-                RECRUITMENT_TYPE_FILTER,
-                "recruitmentTypeValues",
-                filters,
-                parameters
-        );
+        if (!condition.recruitmentTypes().isEmpty()) {
+            filters.append(REPRESENTATIVE_REQUIRED_FILTER);
+            addCollectionFilter(
+                    storedValues(condition.recruitmentTypes()),
+                    RECRUITMENT_TYPE_FILTER,
+                    "recruitmentTypeValues",
+                    filters,
+                    parameters
+            );
+        }
         addApplicationStatusFilter(condition, filters, parameters);
     }
 
@@ -363,9 +412,7 @@ final class ComplexSummarySqlBuilder {
             case BEFORE_APPLICATION -> BEFORE_APPLICATION_FILTER;
             case APPLYING -> APPLYING_FILTER;
             case CLOSED -> CLOSED_FILTER;
-            case CANCELLED -> throw new IllegalArgumentException(
-                    "취소 상태는 단지 검색 조건으로 사용할 수 없다."
-            );
+            case CANCELLED -> CANCELLED_FILTER;
         };
     }
 

--- a/backend/src/main/java/com/toadzip/backend/housing/repository/ComplexSummarySqlBuilder.java
+++ b/backend/src/main/java/com/toadzip/backend/housing/repository/ComplexSummarySqlBuilder.java
@@ -1,15 +1,10 @@
 package com.toadzip.backend.housing.repository;
 
+import java.util.EnumSet;
 import java.util.HashMap;
-import java.util.Locale;
 import java.util.Map;
-import java.util.Set;
-import java.util.StringJoiner;
-import java.util.stream.Collectors;
 import org.springframework.stereotype.Component;
 
-import com.toadzip.backend.announcement.domain.ApplicationStatus;
-import com.toadzip.backend.global.persistence.LegacyStoredValue;
 import com.toadzip.backend.housing.domain.ComplexSort;
 import com.toadzip.backend.housing.domain.MapBounds;
 
@@ -86,149 +81,23 @@ final class ComplexSummarySqlBuilder {
               AND housing_complex.longitude BETWEEN :southWestLng AND :northEastLng
             """;
 
-    private static final String KEYWORD_FILTER = """
-              AND (
-                    LOWER(housing_complex.name) LIKE :keywordPattern ESCAPE '\\'
-                    OR LOWER(housing_complex.road_address) LIKE :keywordPattern ESCAPE '\\'
-              )
-            """;
-
-    private static final String PROVINCE_FILTER = """
-              AND housing_complex.province_code = :provinceCode
-            """;
-
-    private static final String DISTRICT_FILTER = """
-              AND housing_complex.city_county_district_code IN (:districtCodes)
-            """;
-
-    private static final String RENTAL_TYPE_FILTER = """
-              AND housing_complex.supply_type IN (:rentalTypeValues)
-            """;
-
-    private static final String AGENCY_CODE_FILTER = """
-              AND housing_complex.provider IN (:agencyCodeValues)
-            """;
-
-    private static final String BUILT_YEAR_FROM_FILTER = """
-              AND EXTRACT(YEAR FROM housing_complex.completion_date) >= :builtYearFrom
-            """;
-
-    private static final String BUILT_YEAR_TO_FILTER = """
-              AND EXTRACT(YEAR FROM housing_complex.completion_date) <= :builtYearTo
-            """;
-
-    private static final String ELEVATOR_FILTER = """
-              AND housing_complex.elevator_installed = :hasElevator
-            """;
-
-    private static final String ACTIVE_ANNOUNCEMENT_FILTER = """
-              AND representative.announcement_id IS NOT NULL
-              AND representative.application_start_date <= :today
-              AND representative.application_end_date >= :today
-            """;
-
-    private static final String NO_ACTIVE_ANNOUNCEMENT_FILTER = """
-              AND (
-                    representative.announcement_id IS NULL
-                    OR representative.application_start_date > :today
-                    OR representative.application_end_date < :today
-              )
-            """;
-
-    private static final String REPRESENTATIVE_REQUIRED_FILTER = """
-              AND representative.announcement_id IS NOT NULL
-            """;
-
-    private static final String RECRUITMENT_TYPE_FILTER = """
-              AND representative.recruitment_type IN (:recruitmentTypeValues)
-            """;
-
-    private static final String BEFORE_APPLICATION_FILTER =
-            "representative.application_start_date > :today";
-
-    private static final String APPLYING_FILTER = """
-            (
-                representative.application_start_date <= :today
-                AND representative.application_end_date >= :today
-            )
-            """.strip();
-
-    private static final String CLOSED_FILTER =
-            "representative.application_end_date < :today";
-
-    private static final String CANCELLED_FILTER = """
-            EXISTS (
-                SELECT 1
-                FROM supply_rows cancelled_supply_row
-                JOIN announcements cancelled_announcement
-                  ON cancelled_announcement.id = cancelled_supply_row.announcement_id
-                WHERE cancelled_supply_row.housing_complex_id = housing_complex.id
-                  AND cancelled_announcement.status IN ('CANCELLATION', '취소공고')
-                  AND NOT EXISTS (
-                      SELECT 1
-                      FROM announcements cancelled_successor
-                      WHERE cancelled_successor.previous_announcement_id = cancelled_announcement.id
-                  )
-            )
-            """.strip();
-
-    private static final String AREA_EXISTS_START = """
-              AND EXISTS (
-                    SELECT 1
-                    FROM housing_types matched_housing_type
-                    WHERE matched_housing_type.housing_complex_id = housing_complex.id
-            """;
-
-    private static final String SUPPLY_TARGET_EXISTS_START = """
-              AND EXISTS (
-                    SELECT 1
-                    FROM supply_rows matched_supply_row
-                    JOIN supply_targets matched_supply_target
-                      ON matched_supply_target.supply_row_id = matched_supply_row.id
-                    LEFT JOIN housing_types matched_housing_type
-                      ON matched_housing_type.id = matched_supply_row.housing_type_id
-                    WHERE matched_supply_row.housing_complex_id = housing_complex.id
-                      AND matched_supply_row.announcement_id = representative.announcement_id
-            """;
-
-    private static final String EXISTS_END = """
-              )
-            """;
-
-    private static final String MIN_DEPOSIT_FILTER = """
-                      AND matched_supply_target.rental_deposit >= :minDeposit
-            """;
-
-    private static final String MAX_DEPOSIT_FILTER = """
-                      AND matched_supply_target.rental_deposit <= :maxDeposit
-            """;
-
-    private static final String MIN_MONTHLY_RENT_FILTER = """
-                      AND matched_supply_target.monthly_rent >= :minMonthlyRent
-            """;
-
-    private static final String MAX_MONTHLY_RENT_FILTER = """
-                      AND matched_supply_target.monthly_rent <= :maxMonthlyRent
-            """;
-
-    private static final String MIN_EXCLUSIVE_AREA_FILTER = """
-                      AND matched_housing_type.exclusive_area >= :minExclusiveArea
-            """;
-
-    private static final String MAX_EXCLUSIVE_AREA_FILTER = """
-                      AND matched_housing_type.exclusive_area <= :maxExclusiveArea
-            """;
-
     private static final String MAP_ORDER = """
             ORDER BY housing_complex.id
             """;
 
+    private static final Map<Direction, String> COMPARISON_OPERATORS = comparisonOperators();
+
+    private static final Map<ComplexSort, SortSpec> SORT_SPECS = sortSpecs();
+
+    private final HousingComplexFilterPredicateBuilder filterPredicateBuilder;
+
+    ComplexSummarySqlBuilder(HousingComplexFilterPredicateBuilder filterPredicateBuilder) {
+        this.filterPredicateBuilder = filterPredicateBuilder;
+    }
+
     ComplexSummarySqlQuery buildMapQuery(HousingComplexSearchCondition condition) {
-        Map<String, Object> parameters = new HashMap<>(boundsParameters(condition.bounds()));
-        return new ComplexSummarySqlQuery(
-                BASE_SUMMARY_QUERY + filters(condition, parameters) + MAP_ORDER,
-                parameters
-        );
+        FilteredSummaryQuery query = filteredQuery(condition);
+        return new ComplexSummarySqlQuery(query.sql() + MAP_ORDER, query.parameters());
     }
 
     ComplexSummarySqlQuery buildListQuery(
@@ -237,19 +106,34 @@ final class ComplexSummarySqlBuilder {
             ComplexSummaryCursor cursor,
             int limit
     ) {
-        Map<String, Object> parameters = new HashMap<>(boundsParameters(condition.bounds()));
-        String filteredQuery = BASE_SUMMARY_QUERY + filters(condition, parameters);
-        SortSpec sortSpec = sortSpec(sort);
+        FilteredSummaryQuery query = filteredQuery(condition);
+        Map<String, Object> parameters = new HashMap<>(query.parameters());
         parameters.put("limit", limit);
+        return pageQuery(query.sql(), parameters, sortSpec(sort), cursor);
+    }
+
+    private FilteredSummaryQuery filteredQuery(HousingComplexSearchCondition condition) {
+        HousingComplexFilterPredicate predicate = filterPredicateBuilder.build(condition.filters());
+        Map<String, Object> parameters = new HashMap<>(boundsParameters(condition.bounds()));
+        parameters.putAll(predicate.parameters());
+        return new FilteredSummaryQuery(BASE_SUMMARY_QUERY + predicate.sql(), parameters);
+    }
+
+    private ComplexSummarySqlQuery pageQuery(
+            String sql,
+            Map<String, Object> parameters,
+            SortSpec sortSpec,
+            ComplexSummaryCursor cursor
+    ) {
         if (cursor == null) {
-            return new ComplexSummarySqlQuery(filteredQuery + firstPage(sortSpec), parameters);
+            return new ComplexSummarySqlQuery(sql + firstPage(sortSpec), parameters);
         }
         parameters.put("cursorComplexId", cursor.complexId());
         if (cursor.primaryValue() == null) {
-            return new ComplexSummarySqlQuery(filteredQuery + pageAfterNull(sortSpec), parameters);
+            return new ComplexSummarySqlQuery(sql + pageAfterNull(sortSpec), parameters);
         }
         parameters.put("cursorValue", cursor.primaryValue().jdbcValue());
-        return new ComplexSummarySqlQuery(filteredQuery + pageAfterValue(sortSpec), parameters);
+        return new ComplexSummarySqlQuery(sql + pageAfterValue(sortSpec), parameters);
     }
 
     private String firstPage(SortSpec sortSpec) {
@@ -275,10 +159,7 @@ final class ComplexSummarySqlBuilder {
     }
 
     private String comparisonOperator(Direction direction) {
-        return switch (direction) {
-            case ASC -> ">";
-            case DESC -> "<";
-        };
+        return COMPARISON_OPERATORS.get(direction);
     }
 
     private String orderBy(SortSpec sortSpec) {
@@ -287,245 +168,7 @@ final class ComplexSummarySqlBuilder {
     }
 
     private SortSpec sortSpec(ComplexSort sort) {
-        return switch (sort) {
-            case LATEST_ANNOUNCEMENT -> new SortSpec("representative.posted_date", Direction.DESC);
-            case DEPOSIT_ASC -> new SortSpec("price_range.deposit_min", Direction.ASC);
-            case MONTHLY_RENT_ASC -> new SortSpec("price_range.monthly_rent_min", Direction.ASC);
-            case AREA_DESC -> new SortSpec("area_range.exclusive_area_max", Direction.DESC);
-            case COMPLETION_DATE_DESC -> new SortSpec("housing_complex.completion_date", Direction.DESC);
-        };
-    }
-
-    private String filters(HousingComplexSearchCondition condition, Map<String, Object> parameters) {
-        StringBuilder filters = new StringBuilder();
-        addKeywordFilter(condition, filters, parameters);
-        addDirectComplexFilters(condition, filters, parameters);
-        addAnnouncementFilters(condition, filters, parameters);
-        addPriceAreaFilters(condition, filters, parameters);
-        return filters.toString();
-    }
-
-    private void addKeywordFilter(
-            HousingComplexSearchCondition condition,
-            StringBuilder filters,
-            Map<String, Object> parameters
-    ) {
-        if (condition.keyword() == null) {
-            return;
-        }
-        filters.append(KEYWORD_FILTER);
-        parameters.put("keywordPattern", keywordPattern(condition.keyword()));
-    }
-
-    private void addDirectComplexFilters(
-            HousingComplexSearchCondition condition,
-            StringBuilder filters,
-            Map<String, Object> parameters
-    ) {
-        addFilter(condition.provinceCode(), PROVINCE_FILTER, "provinceCode", filters, parameters);
-        addCollectionFilter(
-                condition.cityCountyDistrictCodes(),
-                DISTRICT_FILTER,
-                "districtCodes",
-                filters,
-                parameters
-        );
-        addCollectionFilter(
-                storedValues(condition.rentalTypes()),
-                RENTAL_TYPE_FILTER,
-                "rentalTypeValues",
-                filters,
-                parameters
-        );
-        addCollectionFilter(
-                storedValues(condition.agencyCodes()),
-                AGENCY_CODE_FILTER,
-                "agencyCodeValues",
-                filters,
-                parameters
-        );
-        addFilter(condition.builtYearFrom(), BUILT_YEAR_FROM_FILTER, "builtYearFrom", filters, parameters);
-        addFilter(condition.builtYearTo(), BUILT_YEAR_TO_FILTER, "builtYearTo", filters, parameters);
-        addFilter(condition.hasElevator(), ELEVATOR_FILTER, "hasElevator", filters, parameters);
-        addActiveAnnouncementFilter(condition, filters, parameters);
-    }
-
-    private void addActiveAnnouncementFilter(
-            HousingComplexSearchCondition condition,
-            StringBuilder filters,
-            Map<String, Object> parameters
-    ) {
-        if (condition.hasActiveAnnouncement() == null) {
-            return;
-        }
-        if (condition.hasActiveAnnouncement()) {
-            filters.append(ACTIVE_ANNOUNCEMENT_FILTER);
-        } else {
-            filters.append(NO_ACTIVE_ANNOUNCEMENT_FILTER);
-        }
-        parameters.put("today", condition.today());
-    }
-
-    private void addAnnouncementFilters(
-            HousingComplexSearchCondition condition,
-            StringBuilder filters,
-            Map<String, Object> parameters
-    ) {
-        if (condition.recruitmentTypes().isEmpty() && condition.applicationStatuses().isEmpty()) {
-            return;
-        }
-        if (!condition.recruitmentTypes().isEmpty()) {
-            filters.append(REPRESENTATIVE_REQUIRED_FILTER);
-            addCollectionFilter(
-                    storedValues(condition.recruitmentTypes()),
-                    RECRUITMENT_TYPE_FILTER,
-                    "recruitmentTypeValues",
-                    filters,
-                    parameters
-            );
-        }
-        addApplicationStatusFilter(condition, filters, parameters);
-    }
-
-    private void addApplicationStatusFilter(
-            HousingComplexSearchCondition condition,
-            StringBuilder filters,
-            Map<String, Object> parameters
-    ) {
-        if (condition.applicationStatuses().isEmpty()) {
-            return;
-        }
-        StringJoiner statusFilters = new StringJoiner(
-                "\n                    OR ",
-                "              AND (\n                    ",
-                "\n              )\n"
-        );
-        condition.applicationStatuses().stream()
-                .map(this::applicationStatusFilter)
-                .forEach(statusFilters::add);
-        filters.append(statusFilters);
-        parameters.put("today", condition.today());
-    }
-
-    private String applicationStatusFilter(ApplicationStatus status) {
-        return switch (status) {
-            case BEFORE_APPLICATION -> BEFORE_APPLICATION_FILTER;
-            case APPLYING -> APPLYING_FILTER;
-            case CLOSED -> CLOSED_FILTER;
-            case CANCELLED -> CANCELLED_FILTER;
-        };
-    }
-
-    private void addPriceAreaFilters(
-            HousingComplexSearchCondition condition,
-            StringBuilder filters,
-            Map<String, Object> parameters
-    ) {
-        if (hasPriceFilter(condition)) {
-            addSupplyTargetExists(condition, filters, parameters);
-            return;
-        }
-        if (hasAreaFilter(condition)) {
-            addAreaExists(condition, filters, parameters);
-        }
-    }
-
-    private void addSupplyTargetExists(
-            HousingComplexSearchCondition condition,
-            StringBuilder filters,
-            Map<String, Object> parameters
-    ) {
-        filters.append(SUPPLY_TARGET_EXISTS_START);
-        addFilter(condition.minDeposit(), MIN_DEPOSIT_FILTER, "minDeposit", filters, parameters);
-        addFilter(condition.maxDeposit(), MAX_DEPOSIT_FILTER, "maxDeposit", filters, parameters);
-        addFilter(condition.minMonthlyRent(), MIN_MONTHLY_RENT_FILTER, "minMonthlyRent", filters, parameters);
-        addFilter(condition.maxMonthlyRent(), MAX_MONTHLY_RENT_FILTER, "maxMonthlyRent", filters, parameters);
-        addAreaBounds(condition, filters, parameters);
-        filters.append(EXISTS_END);
-    }
-
-    private void addAreaExists(
-            HousingComplexSearchCondition condition,
-            StringBuilder filters,
-            Map<String, Object> parameters
-    ) {
-        filters.append(AREA_EXISTS_START);
-        addAreaBounds(condition, filters, parameters);
-        filters.append(EXISTS_END);
-    }
-
-    private void addAreaBounds(
-            HousingComplexSearchCondition condition,
-            StringBuilder filters,
-            Map<String, Object> parameters
-    ) {
-        addFilter(
-                condition.minExclusiveArea(),
-                MIN_EXCLUSIVE_AREA_FILTER,
-                "minExclusiveArea",
-                filters,
-                parameters
-        );
-        addFilter(
-                condition.maxExclusiveArea(),
-                MAX_EXCLUSIVE_AREA_FILTER,
-                "maxExclusiveArea",
-                filters,
-                parameters
-        );
-    }
-
-    private boolean hasPriceFilter(HousingComplexSearchCondition condition) {
-        return condition.minDeposit() != null
-                || condition.maxDeposit() != null
-                || condition.minMonthlyRent() != null
-                || condition.maxMonthlyRent() != null;
-    }
-
-    private boolean hasAreaFilter(HousingComplexSearchCondition condition) {
-        return condition.minExclusiveArea() != null || condition.maxExclusiveArea() != null;
-    }
-
-    private void addFilter(
-            Object value,
-            String sql,
-            String parameterName,
-            StringBuilder filters,
-            Map<String, Object> parameters
-    ) {
-        if (value == null) {
-            return;
-        }
-        filters.append(sql);
-        parameters.put(parameterName, value);
-    }
-
-    private void addCollectionFilter(
-            Set<?> values,
-            String sql,
-            String parameterName,
-            StringBuilder filters,
-            Map<String, Object> parameters
-    ) {
-        if (values.isEmpty()) {
-            return;
-        }
-        filters.append(sql);
-        parameters.put(parameterName, values);
-    }
-
-    private Set<String> storedValues(Set<? extends LegacyStoredValue> values) {
-        return values.stream()
-                .flatMap(value -> value.storedValues().stream())
-                .collect(Collectors.toUnmodifiableSet());
-    }
-
-    private String keywordPattern(String keyword) {
-        String escaped = keyword.toLowerCase(Locale.ROOT)
-                .replace("\\", "\\\\")
-                .replace("%", "\\%")
-                .replace("_", "\\_");
-        return "%" + escaped + "%";
+        return SORT_SPECS.get(sort);
     }
 
     private Map<String, Object> boundsParameters(MapBounds bounds) {
@@ -537,11 +180,49 @@ final class ComplexSummarySqlBuilder {
         );
     }
 
+    private static Map<Direction, String> comparisonOperators() {
+        Map<Direction, String> operators = Map.of(
+                Direction.ASC, ">",
+                Direction.DESC, "<"
+        );
+        requireCompleteDirections(operators);
+        return operators;
+    }
+
+    private static void requireCompleteDirections(Map<Direction, String> operators) {
+        if (operators.keySet().equals(EnumSet.allOf(Direction.class))) {
+            return;
+        }
+        throw new IllegalStateException("모든 정렬 방향의 비교 연산자가 필요합니다.");
+    }
+
+    private static Map<ComplexSort, SortSpec> sortSpecs() {
+        Map<ComplexSort, SortSpec> specifications = Map.of(
+                ComplexSort.LATEST_ANNOUNCEMENT, new SortSpec("representative.posted_date", Direction.DESC),
+                ComplexSort.DEPOSIT_ASC, new SortSpec("price_range.deposit_min", Direction.ASC),
+                ComplexSort.MONTHLY_RENT_ASC, new SortSpec("price_range.monthly_rent_min", Direction.ASC),
+                ComplexSort.AREA_DESC, new SortSpec("area_range.exclusive_area_max", Direction.DESC),
+                ComplexSort.COMPLETION_DATE_DESC, new SortSpec("housing_complex.completion_date", Direction.DESC)
+        );
+        requireCompleteSortSpecifications(specifications);
+        return specifications;
+    }
+
+    private static void requireCompleteSortSpecifications(Map<ComplexSort, SortSpec> specifications) {
+        if (specifications.keySet().equals(EnumSet.allOf(ComplexSort.class))) {
+            return;
+        }
+        throw new IllegalStateException("모든 단지 정렬의 SQL 명세가 필요합니다.");
+    }
+
     private enum Direction {
         ASC,
         DESC
     }
 
     private record SortSpec(String expression, Direction direction) {
+    }
+
+    private record FilteredSummaryQuery(String sql, Map<String, Object> parameters) {
     }
 }

--- a/backend/src/main/java/com/toadzip/backend/housing/repository/HousingComplexFilterCondition.java
+++ b/backend/src/main/java/com/toadzip/backend/housing/repository/HousingComplexFilterCondition.java
@@ -1,0 +1,39 @@
+package com.toadzip.backend.housing.repository;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Set;
+
+import com.toadzip.backend.announcement.domain.ApplicationStatus;
+import com.toadzip.backend.announcement.domain.RecruitmentType;
+import com.toadzip.backend.housing.domain.AgencyCode;
+import com.toadzip.backend.housing.domain.RentalType;
+
+public record HousingComplexFilterCondition(
+        String keyword,
+        String provinceCode,
+        Set<String> cityCountyDistrictCodes,
+        Set<RentalType> rentalTypes,
+        Set<ApplicationStatus> applicationStatuses,
+        Set<AgencyCode> agencyCodes,
+        Set<RecruitmentType> recruitmentTypes,
+        BigDecimal minDeposit,
+        BigDecimal maxDeposit,
+        BigDecimal minMonthlyRent,
+        BigDecimal maxMonthlyRent,
+        BigDecimal minExclusiveArea,
+        BigDecimal maxExclusiveArea,
+        Integer builtYearFrom,
+        Integer builtYearTo,
+        Boolean hasElevator,
+        Boolean hasActiveAnnouncement,
+        LocalDate today
+) {
+    public HousingComplexFilterCondition {
+        cityCountyDistrictCodes = Set.copyOf(cityCountyDistrictCodes);
+        rentalTypes = Set.copyOf(rentalTypes);
+        applicationStatuses = Set.copyOf(applicationStatuses);
+        agencyCodes = Set.copyOf(agencyCodes);
+        recruitmentTypes = Set.copyOf(recruitmentTypes);
+    }
+}

--- a/backend/src/main/java/com/toadzip/backend/housing/repository/HousingComplexFilterPredicate.java
+++ b/backend/src/main/java/com/toadzip/backend/housing/repository/HousingComplexFilterPredicate.java
@@ -1,0 +1,10 @@
+package com.toadzip.backend.housing.repository;
+
+import java.util.Map;
+
+record HousingComplexFilterPredicate(String sql, Map<String, Object> parameters) {
+
+    HousingComplexFilterPredicate {
+        parameters = Map.copyOf(parameters);
+    }
+}

--- a/backend/src/main/java/com/toadzip/backend/housing/repository/HousingComplexFilterPredicateBuilder.java
+++ b/backend/src/main/java/com/toadzip/backend/housing/repository/HousingComplexFilterPredicateBuilder.java
@@ -1,0 +1,394 @@
+package com.toadzip.backend.housing.repository;
+
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.StringJoiner;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Component;
+
+import com.toadzip.backend.announcement.domain.ApplicationStatus;
+import com.toadzip.backend.global.persistence.LegacyStoredValue;
+
+@Component
+final class HousingComplexFilterPredicateBuilder {
+
+    private static final String KEYWORD_FILTER = """
+              AND (
+                    LOWER(housing_complex.name) LIKE :keywordPattern ESCAPE '\\'
+                    OR LOWER(housing_complex.road_address) LIKE :keywordPattern ESCAPE '\\'
+              )
+            """;
+
+    private static final String PROVINCE_FILTER = """
+              AND housing_complex.province_code = :provinceCode
+            """;
+
+    private static final String DISTRICT_FILTER = """
+              AND housing_complex.city_county_district_code IN (:districtCodes)
+            """;
+
+    private static final String RENTAL_TYPE_FILTER = """
+              AND housing_complex.supply_type IN (:rentalTypeValues)
+            """;
+
+    private static final String AGENCY_CODE_FILTER = """
+              AND housing_complex.provider IN (:agencyCodeValues)
+            """;
+
+    private static final String BUILT_YEAR_FROM_FILTER = """
+              AND EXTRACT(YEAR FROM housing_complex.completion_date) >= :builtYearFrom
+            """;
+
+    private static final String BUILT_YEAR_TO_FILTER = """
+              AND EXTRACT(YEAR FROM housing_complex.completion_date) <= :builtYearTo
+            """;
+
+    private static final String ELEVATOR_FILTER = """
+              AND housing_complex.elevator_installed = :hasElevator
+            """;
+
+    private static final String ACTIVE_ANNOUNCEMENT_FILTER = """
+              AND representative.announcement_id IS NOT NULL
+              AND representative.application_start_date <= :today
+              AND representative.application_end_date >= :today
+            """;
+
+    private static final String NO_ACTIVE_ANNOUNCEMENT_FILTER = """
+              AND (
+                    representative.announcement_id IS NULL
+                    OR representative.application_start_date > :today
+                    OR representative.application_end_date < :today
+              )
+            """;
+
+    private static final String REPRESENTATIVE_REQUIRED_FILTER = """
+              AND representative.announcement_id IS NOT NULL
+            """;
+
+    private static final String RECRUITMENT_TYPE_FILTER = """
+              AND representative.recruitment_type IN (:recruitmentTypeValues)
+            """;
+
+    private static final String BEFORE_APPLICATION_FILTER =
+            "representative.application_start_date > :today";
+
+    private static final String APPLYING_FILTER = """
+            (
+                representative.application_start_date <= :today
+                AND representative.application_end_date >= :today
+            )
+            """.strip();
+
+    private static final String CLOSED_FILTER =
+            "representative.application_end_date < :today";
+
+    private static final String CANCELLED_FILTER = """
+            EXISTS (
+                SELECT 1
+                FROM supply_rows cancelled_supply_row
+                JOIN announcements cancelled_announcement
+                  ON cancelled_announcement.id = cancelled_supply_row.announcement_id
+                WHERE cancelled_supply_row.housing_complex_id = housing_complex.id
+                  AND cancelled_announcement.status IN ('CANCELLATION', '취소공고')
+                  AND NOT EXISTS (
+                      SELECT 1
+                      FROM announcements cancelled_successor
+                      WHERE cancelled_successor.previous_announcement_id = cancelled_announcement.id
+                  )
+            )
+            """.strip();
+
+    private static final String AREA_EXISTS_START = """
+              AND EXISTS (
+                    SELECT 1
+                    FROM housing_types matched_housing_type
+                    WHERE matched_housing_type.housing_complex_id = housing_complex.id
+            """;
+
+    private static final String SUPPLY_TARGET_EXISTS_START = """
+              AND EXISTS (
+                    SELECT 1
+                    FROM supply_rows matched_supply_row
+                    JOIN supply_targets matched_supply_target
+                      ON matched_supply_target.supply_row_id = matched_supply_row.id
+                    LEFT JOIN housing_types matched_housing_type
+                      ON matched_housing_type.id = matched_supply_row.housing_type_id
+                    WHERE matched_supply_row.housing_complex_id = housing_complex.id
+                      AND matched_supply_row.announcement_id = representative.announcement_id
+            """;
+
+    private static final String EXISTS_END = """
+              )
+            """;
+
+    private static final String MIN_DEPOSIT_FILTER = """
+                      AND matched_supply_target.rental_deposit >= :minDeposit
+            """;
+
+    private static final String MAX_DEPOSIT_FILTER = """
+                      AND matched_supply_target.rental_deposit <= :maxDeposit
+            """;
+
+    private static final String MIN_MONTHLY_RENT_FILTER = """
+                      AND matched_supply_target.monthly_rent >= :minMonthlyRent
+            """;
+
+    private static final String MAX_MONTHLY_RENT_FILTER = """
+                      AND matched_supply_target.monthly_rent <= :maxMonthlyRent
+            """;
+
+    private static final String MIN_EXCLUSIVE_AREA_FILTER = """
+                      AND matched_housing_type.exclusive_area >= :minExclusiveArea
+            """;
+
+    private static final String MAX_EXCLUSIVE_AREA_FILTER = """
+                      AND matched_housing_type.exclusive_area <= :maxExclusiveArea
+            """;
+
+    private static final Map<ApplicationStatus, String> APPLICATION_STATUS_FILTERS = applicationStatusFilters();
+
+    HousingComplexFilterPredicate build(HousingComplexFilterCondition condition) {
+        StringBuilder sql = new StringBuilder();
+        Map<String, Object> parameters = new HashMap<>();
+        addKeywordFilter(condition, sql, parameters);
+        addDirectComplexFilters(condition, sql, parameters);
+        addAnnouncementFilters(condition, sql, parameters);
+        addPriceAreaFilters(condition, sql, parameters);
+        return new HousingComplexFilterPredicate(sql.toString(), parameters);
+    }
+
+    private void addKeywordFilter(
+            HousingComplexFilterCondition condition,
+            StringBuilder sql,
+            Map<String, Object> parameters
+    ) {
+        if (condition.keyword() == null) {
+            return;
+        }
+        sql.append(KEYWORD_FILTER);
+        parameters.put("keywordPattern", keywordPattern(condition.keyword()));
+    }
+
+    private void addDirectComplexFilters(
+            HousingComplexFilterCondition condition,
+            StringBuilder sql,
+            Map<String, Object> parameters
+    ) {
+        addFilter(condition.provinceCode(), PROVINCE_FILTER, "provinceCode", sql, parameters);
+        addCollectionFilter(condition.cityCountyDistrictCodes(), DISTRICT_FILTER, "districtCodes", sql, parameters);
+        addStoredValueFilter(condition.rentalTypes(), RENTAL_TYPE_FILTER, "rentalTypeValues", sql, parameters);
+        addStoredValueFilter(condition.agencyCodes(), AGENCY_CODE_FILTER, "agencyCodeValues", sql, parameters);
+        addFilter(condition.builtYearFrom(), BUILT_YEAR_FROM_FILTER, "builtYearFrom", sql, parameters);
+        addFilter(condition.builtYearTo(), BUILT_YEAR_TO_FILTER, "builtYearTo", sql, parameters);
+        addFilter(condition.hasElevator(), ELEVATOR_FILTER, "hasElevator", sql, parameters);
+        addActiveAnnouncementFilter(condition, sql, parameters);
+    }
+
+    private void addActiveAnnouncementFilter(
+            HousingComplexFilterCondition condition,
+            StringBuilder sql,
+            Map<String, Object> parameters
+    ) {
+        Boolean hasActiveAnnouncement = condition.hasActiveAnnouncement();
+        if (hasActiveAnnouncement == null) {
+            return;
+        }
+        parameters.put("today", condition.today());
+        appendActiveAnnouncementFilter(hasActiveAnnouncement, sql);
+    }
+
+    private void appendActiveAnnouncementFilter(Boolean hasActiveAnnouncement, StringBuilder sql) {
+        if (hasActiveAnnouncement) {
+            sql.append(ACTIVE_ANNOUNCEMENT_FILTER);
+            return;
+        }
+        sql.append(NO_ACTIVE_ANNOUNCEMENT_FILTER);
+    }
+
+    private void addAnnouncementFilters(
+            HousingComplexFilterCondition condition,
+            StringBuilder sql,
+            Map<String, Object> parameters
+    ) {
+        if (hasNoAnnouncementFilter(condition)) {
+            return;
+        }
+        addRecruitmentTypeFilter(condition, sql, parameters);
+        addApplicationStatusFilter(condition, sql, parameters);
+    }
+
+    private boolean hasNoAnnouncementFilter(HousingComplexFilterCondition condition) {
+        return condition.recruitmentTypes().isEmpty() && condition.applicationStatuses().isEmpty();
+    }
+
+    private void addRecruitmentTypeFilter(
+            HousingComplexFilterCondition condition,
+            StringBuilder sql,
+            Map<String, Object> parameters
+    ) {
+        if (condition.recruitmentTypes().isEmpty()) {
+            return;
+        }
+        sql.append(REPRESENTATIVE_REQUIRED_FILTER);
+        addStoredValueFilter(
+                condition.recruitmentTypes(),
+                RECRUITMENT_TYPE_FILTER,
+                "recruitmentTypeValues",
+                sql,
+                parameters
+        );
+    }
+
+    private void addApplicationStatusFilter(
+            HousingComplexFilterCondition condition,
+            StringBuilder sql,
+            Map<String, Object> parameters
+    ) {
+        if (condition.applicationStatuses().isEmpty()) {
+            return;
+        }
+        sql.append(joinedApplicationStatusFilters(condition.applicationStatuses()));
+        parameters.put("today", condition.today());
+    }
+
+    private String joinedApplicationStatusFilters(Set<ApplicationStatus> statuses) {
+        StringJoiner filters = new StringJoiner(
+                "\n                    OR ",
+                "              AND (\n                    ",
+                "\n              )\n"
+        );
+        statuses.stream().map(APPLICATION_STATUS_FILTERS::get).forEach(filters::add);
+        return filters.toString();
+    }
+
+    private void addPriceAreaFilters(
+            HousingComplexFilterCondition condition,
+            StringBuilder sql,
+            Map<String, Object> parameters
+    ) {
+        if (hasPriceFilter(condition)) {
+            addSupplyTargetExists(condition, sql, parameters);
+            return;
+        }
+        if (hasAreaFilter(condition)) {
+            addAreaExists(condition, sql, parameters);
+        }
+    }
+
+    private void addSupplyTargetExists(
+            HousingComplexFilterCondition condition,
+            StringBuilder sql,
+            Map<String, Object> parameters
+    ) {
+        sql.append(SUPPLY_TARGET_EXISTS_START);
+        addFilter(condition.minDeposit(), MIN_DEPOSIT_FILTER, "minDeposit", sql, parameters);
+        addFilter(condition.maxDeposit(), MAX_DEPOSIT_FILTER, "maxDeposit", sql, parameters);
+        addFilter(condition.minMonthlyRent(), MIN_MONTHLY_RENT_FILTER, "minMonthlyRent", sql, parameters);
+        addFilter(condition.maxMonthlyRent(), MAX_MONTHLY_RENT_FILTER, "maxMonthlyRent", sql, parameters);
+        addAreaBounds(condition, sql, parameters);
+        sql.append(EXISTS_END);
+    }
+
+    private void addAreaExists(
+            HousingComplexFilterCondition condition,
+            StringBuilder sql,
+            Map<String, Object> parameters
+    ) {
+        sql.append(AREA_EXISTS_START);
+        addAreaBounds(condition, sql, parameters);
+        sql.append(EXISTS_END);
+    }
+
+    private void addAreaBounds(
+            HousingComplexFilterCondition condition,
+            StringBuilder sql,
+            Map<String, Object> parameters
+    ) {
+        addFilter(condition.minExclusiveArea(), MIN_EXCLUSIVE_AREA_FILTER, "minExclusiveArea", sql, parameters);
+        addFilter(condition.maxExclusiveArea(), MAX_EXCLUSIVE_AREA_FILTER, "maxExclusiveArea", sql, parameters);
+    }
+
+    private boolean hasPriceFilter(HousingComplexFilterCondition condition) {
+        return condition.minDeposit() != null
+                || condition.maxDeposit() != null
+                || condition.minMonthlyRent() != null
+                || condition.maxMonthlyRent() != null;
+    }
+
+    private boolean hasAreaFilter(HousingComplexFilterCondition condition) {
+        return condition.minExclusiveArea() != null || condition.maxExclusiveArea() != null;
+    }
+
+    private void addStoredValueFilter(
+            Set<? extends LegacyStoredValue> values,
+            String filter,
+            String parameterName,
+            StringBuilder sql,
+            Map<String, Object> parameters
+    ) {
+        addCollectionFilter(storedValues(values), filter, parameterName, sql, parameters);
+    }
+
+    private void addFilter(
+            Object value,
+            String filter,
+            String parameterName,
+            StringBuilder sql,
+            Map<String, Object> parameters
+    ) {
+        if (value == null) {
+            return;
+        }
+        sql.append(filter);
+        parameters.put(parameterName, value);
+    }
+
+    private void addCollectionFilter(
+            Set<?> values,
+            String filter,
+            String parameterName,
+            StringBuilder sql,
+            Map<String, Object> parameters
+    ) {
+        if (values.isEmpty()) {
+            return;
+        }
+        sql.append(filter);
+        parameters.put(parameterName, values);
+    }
+
+    private Set<String> storedValues(Set<? extends LegacyStoredValue> values) {
+        return values.stream()
+                .flatMap(value -> value.storedValues().stream())
+                .collect(Collectors.toUnmodifiableSet());
+    }
+
+    private String keywordPattern(String keyword) {
+        String escaped = keyword.toLowerCase(Locale.ROOT)
+                .replace("\\", "\\\\")
+                .replace("%", "\\%")
+                .replace("_", "\\_");
+        return "%" + escaped + "%";
+    }
+
+    private static Map<ApplicationStatus, String> applicationStatusFilters() {
+        Map<ApplicationStatus, String> filters = Map.of(
+                ApplicationStatus.BEFORE_APPLICATION, BEFORE_APPLICATION_FILTER,
+                ApplicationStatus.APPLYING, APPLYING_FILTER,
+                ApplicationStatus.CLOSED, CLOSED_FILTER,
+                ApplicationStatus.CANCELLED, CANCELLED_FILTER
+        );
+        requireCompleteApplicationStatusFilters(filters);
+        return filters;
+    }
+
+    private static void requireCompleteApplicationStatusFilters(Map<ApplicationStatus, String> filters) {
+        if (filters.keySet().equals(EnumSet.allOf(ApplicationStatus.class))) {
+            return;
+        }
+        throw new IllegalStateException("모든 접수 상태의 SQL 필터가 필요합니다.");
+    }
+}

--- a/backend/src/main/java/com/toadzip/backend/housing/repository/HousingComplexSearchCondition.java
+++ b/backend/src/main/java/com/toadzip/backend/housing/repository/HousingComplexSearchCondition.java
@@ -28,6 +28,7 @@ public record HousingComplexSearchCondition(
         Integer builtYearFrom,
         Integer builtYearTo,
         Boolean hasElevator,
+        Boolean hasActiveAnnouncement,
         LocalDate today
 ) {
     public HousingComplexSearchCondition {
@@ -36,5 +37,33 @@ public record HousingComplexSearchCondition(
         applicationStatuses = Set.copyOf(applicationStatuses);
         agencyCodes = Set.copyOf(agencyCodes);
         recruitmentTypes = Set.copyOf(recruitmentTypes);
+    }
+
+    public HousingComplexSearchCondition(
+            MapBounds bounds,
+            String keyword,
+            String provinceCode,
+            Set<String> cityCountyDistrictCodes,
+            Set<RentalType> rentalTypes,
+            Set<ApplicationStatus> applicationStatuses,
+            Set<AgencyCode> agencyCodes,
+            Set<RecruitmentType> recruitmentTypes,
+            BigDecimal minDeposit,
+            BigDecimal maxDeposit,
+            BigDecimal minMonthlyRent,
+            BigDecimal maxMonthlyRent,
+            BigDecimal minExclusiveArea,
+            BigDecimal maxExclusiveArea,
+            Integer builtYearFrom,
+            Integer builtYearTo,
+            Boolean hasElevator,
+            LocalDate today
+    ) {
+        this(
+                bounds, keyword, provinceCode, cityCountyDistrictCodes, rentalTypes, applicationStatuses,
+                agencyCodes, recruitmentTypes, minDeposit, maxDeposit, minMonthlyRent, maxMonthlyRent,
+                minExclusiveArea, maxExclusiveArea, builtYearFrom, builtYearTo, hasElevator,
+                null, today
+        );
     }
 }

--- a/backend/src/main/java/com/toadzip/backend/housing/repository/HousingComplexSearchCondition.java
+++ b/backend/src/main/java/com/toadzip/backend/housing/repository/HousingComplexSearchCondition.java
@@ -1,69 +1,9 @@
 package com.toadzip.backend.housing.repository;
 
-import java.math.BigDecimal;
-import java.time.LocalDate;
-import java.util.Set;
-
-import com.toadzip.backend.announcement.domain.ApplicationStatus;
-import com.toadzip.backend.announcement.domain.RecruitmentType;
-import com.toadzip.backend.housing.domain.AgencyCode;
 import com.toadzip.backend.housing.domain.MapBounds;
-import com.toadzip.backend.housing.domain.RentalType;
 
 public record HousingComplexSearchCondition(
         MapBounds bounds,
-        String keyword,
-        String provinceCode,
-        Set<String> cityCountyDistrictCodes,
-        Set<RentalType> rentalTypes,
-        Set<ApplicationStatus> applicationStatuses,
-        Set<AgencyCode> agencyCodes,
-        Set<RecruitmentType> recruitmentTypes,
-        BigDecimal minDeposit,
-        BigDecimal maxDeposit,
-        BigDecimal minMonthlyRent,
-        BigDecimal maxMonthlyRent,
-        BigDecimal minExclusiveArea,
-        BigDecimal maxExclusiveArea,
-        Integer builtYearFrom,
-        Integer builtYearTo,
-        Boolean hasElevator,
-        Boolean hasActiveAnnouncement,
-        LocalDate today
+        HousingComplexFilterCondition filters
 ) {
-    public HousingComplexSearchCondition {
-        cityCountyDistrictCodes = Set.copyOf(cityCountyDistrictCodes);
-        rentalTypes = Set.copyOf(rentalTypes);
-        applicationStatuses = Set.copyOf(applicationStatuses);
-        agencyCodes = Set.copyOf(agencyCodes);
-        recruitmentTypes = Set.copyOf(recruitmentTypes);
-    }
-
-    public HousingComplexSearchCondition(
-            MapBounds bounds,
-            String keyword,
-            String provinceCode,
-            Set<String> cityCountyDistrictCodes,
-            Set<RentalType> rentalTypes,
-            Set<ApplicationStatus> applicationStatuses,
-            Set<AgencyCode> agencyCodes,
-            Set<RecruitmentType> recruitmentTypes,
-            BigDecimal minDeposit,
-            BigDecimal maxDeposit,
-            BigDecimal minMonthlyRent,
-            BigDecimal maxMonthlyRent,
-            BigDecimal minExclusiveArea,
-            BigDecimal maxExclusiveArea,
-            Integer builtYearFrom,
-            Integer builtYearTo,
-            Boolean hasElevator,
-            LocalDate today
-    ) {
-        this(
-                bounds, keyword, provinceCode, cityCountyDistrictCodes, rentalTypes, applicationStatuses,
-                agencyCodes, recruitmentTypes, minDeposit, maxDeposit, minMonthlyRent, maxMonthlyRent,
-                minExclusiveArea, maxExclusiveArea, builtYearFrom, builtYearTo, hasElevator,
-                null, today
-        );
-    }
 }

--- a/backend/src/main/java/com/toadzip/backend/housing/service/HousingComplexQueryService.java
+++ b/backend/src/main/java/com/toadzip/backend/housing/service/HousingComplexQueryService.java
@@ -150,7 +150,6 @@ public class HousingComplexQueryService {
         Set<ApplicationStatus> applicationStatuses = immutableSet(request.applicationStatuses());
         Set<AgencyCode> agencyCodes = immutableSet(request.agencyCodes());
         Set<RecruitmentType> recruitmentTypes = immutableSet(request.recruitmentTypes());
-        requireAllowedApplicationStatuses(applicationStatuses);
         requireNonNegative(request.minDeposit());
         requireNonNegative(request.maxDeposit());
         requireNonNegative(request.minMonthlyRent());
@@ -182,6 +181,7 @@ public class HousingComplexQueryService {
                 request.builtYearFrom(),
                 request.builtYearTo(),
                 request.hasElevator(),
+                request.hasActiveAnnouncement(),
                 today()
         );
     }
@@ -227,12 +227,6 @@ public class HousingComplexQueryService {
             throw new InvalidComplexRequestException();
         }
         return Set.copyOf(values);
-    }
-
-    private void requireAllowedApplicationStatuses(Set<ApplicationStatus> statuses) {
-        if (statuses.contains(ApplicationStatus.CANCELLED)) {
-            throw new InvalidComplexRequestException();
-        }
     }
 
     private void requireNonNegative(Long value) {

--- a/backend/src/main/java/com/toadzip/backend/housing/service/HousingComplexQueryService.java
+++ b/backend/src/main/java/com/toadzip/backend/housing/service/HousingComplexQueryService.java
@@ -5,33 +5,26 @@ import java.time.Clock;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.List;
-import java.util.Objects;
-import java.util.Set;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.toadzip.backend.announcement.domain.ApplicationStatus;
-import com.toadzip.backend.announcement.domain.RecruitmentType;
-import com.toadzip.backend.housing.domain.AgencyCode;
 import com.toadzip.backend.housing.domain.ComplexSort;
 import com.toadzip.backend.housing.domain.MapBounds;
-import com.toadzip.backend.housing.domain.RentalType;
 import com.toadzip.backend.housing.dto.request.HousingComplexSearchRequest;
 import com.toadzip.backend.housing.dto.response.HousingComplexDetailResponse;
 import com.toadzip.backend.housing.dto.response.HousingComplexListResponse;
 import com.toadzip.backend.housing.dto.response.HousingComplexMapResponse;
 import com.toadzip.backend.housing.exception.HousingComplexNotFoundException;
 import com.toadzip.backend.housing.exception.InvalidComplexRequestException;
-import com.toadzip.backend.housing.exception.InvalidRegionCodeException;
 import com.toadzip.backend.housing.repository.ComplexDetailQueryRepository;
 import com.toadzip.backend.housing.repository.ComplexDetailRow;
 import com.toadzip.backend.housing.repository.ComplexSummaryCursor;
 import com.toadzip.backend.housing.repository.ComplexSummaryQueryRepository;
 import com.toadzip.backend.housing.repository.ComplexSummaryRow;
+import com.toadzip.backend.housing.repository.HousingComplexFilterCondition;
 import com.toadzip.backend.housing.repository.HousingComplexSearchCondition;
-import com.toadzip.backend.region.repository.RegionCodeResolver;
 
 @Service
 public class HousingComplexQueryService {
@@ -48,7 +41,7 @@ public class HousingComplexQueryService {
 
     private final HousingComplexCursorCodec cursorCodec;
 
-    private final RegionCodeResolver regionCodeResolver;
+    private final HousingComplexSearchRequestNormalizer requestNormalizer;
 
     private final Clock clock;
 
@@ -58,7 +51,7 @@ public class HousingComplexQueryService {
             HousingComplexSummaryMapper summaryMapper,
             ComplexDetailQueryRepository detailRepository,
             HousingComplexDetailMapper detailMapper,
-            RegionCodeResolver regionCodeResolver,
+            HousingComplexSearchRequestNormalizer requestNormalizer,
             Clock clock
     ) {
         this.repository = repository;
@@ -66,22 +59,24 @@ public class HousingComplexQueryService {
         this.detailRepository = detailRepository;
         this.detailMapper = detailMapper;
         this.cursorCodec = new HousingComplexCursorCodec();
-        this.regionCodeResolver = regionCodeResolver;
+        this.requestNormalizer = requestNormalizer;
         this.clock = clock;
     }
 
     HousingComplexQueryService(
             ComplexSummaryQueryRepository repository,
             HousingComplexSummaryMapper summaryMapper,
-            RegionCodeResolver regionCodeResolver,
+            HousingComplexSearchRequestNormalizer requestNormalizer,
             Clock clock
     ) {
-        this(repository, summaryMapper, null, null, regionCodeResolver, clock);
+        this(repository, summaryMapper, null, null, requestNormalizer, clock);
     }
 
     @Transactional(readOnly = true)
     public HousingComplexMapResponse getComplexesForMap(HousingComplexSearchRequest request) {
-        HousingComplexSearchCondition condition = searchCondition(request);
+        MapBounds bounds = requestNormalizer.normalizeBounds(request);
+        HousingComplexFilterCondition filters = requestNormalizer.normalizeFilters(request);
+        HousingComplexSearchCondition condition = new HousingComplexSearchCondition(bounds, filters);
         return new HousingComplexMapResponse(repository.findAll(condition).stream()
                 .map(summaryMapper::toMapItem)
                 .toList());
@@ -94,11 +89,11 @@ public class HousingComplexQueryService {
             String cursor,
             int size
     ) {
-        requireRequest(request);
-        MapBounds bounds = bounds(request);
+        MapBounds bounds = requestNormalizer.normalizeBounds(request);
         requireValidSize(size);
         ComplexSort normalizedSort = normalizedSort(sort);
-        HousingComplexSearchCondition condition = searchCondition(request, bounds);
+        HousingComplexFilterCondition filters = requestNormalizer.normalizeFilters(request);
+        HousingComplexSearchCondition condition = new HousingComplexSearchCondition(bounds, filters);
         ComplexSummaryCursor decodedCursor = decodeCursor(cursor, normalizedSort);
         List<ComplexSummaryRow> fetched = repository.findPage(
                 condition,
@@ -109,7 +104,7 @@ public class HousingComplexQueryService {
         boolean hasNext = fetched.size() > size;
         List<ComplexSummaryRow> page = fetched.stream().limit(size).toList();
         return new HousingComplexListResponse(
-                summaryMapper.toListItems(page, condition.today()),
+                summaryMapper.toListItems(page, filters.today()),
                 nextCursor(page, hasNext, normalizedSort),
                 hasNext
         );
@@ -136,147 +131,11 @@ public class HousingComplexQueryService {
         }
     }
 
-    private HousingComplexSearchCondition searchCondition(HousingComplexSearchRequest request) {
-        requireRequest(request);
-        return searchCondition(request, bounds(request));
-    }
-
-    private HousingComplexSearchCondition searchCondition(
-            HousingComplexSearchRequest request,
-            MapBounds bounds
-    ) {
-        String keyword = normalizedKeyword(request.keyword());
-        Set<RentalType> rentalTypes = immutableSet(request.rentalTypes());
-        Set<ApplicationStatus> applicationStatuses = immutableSet(request.applicationStatuses());
-        Set<AgencyCode> agencyCodes = immutableSet(request.agencyCodes());
-        Set<RecruitmentType> recruitmentTypes = immutableSet(request.recruitmentTypes());
-        requireNonNegative(request.minDeposit());
-        requireNonNegative(request.maxDeposit());
-        requireNonNegative(request.minMonthlyRent());
-        requireNonNegative(request.maxMonthlyRent());
-        requireNonNegative(request.minExclusiveArea());
-        requireNonNegative(request.maxExclusiveArea());
-        requireAscending(request.minDeposit(), request.maxDeposit());
-        requireAscending(request.minMonthlyRent(), request.maxMonthlyRent());
-        requireAscending(request.minExclusiveArea(), request.maxExclusiveArea());
-        requireValidYear(request.builtYearFrom());
-        requireValidYear(request.builtYearTo());
-        requireAscending(request.builtYearFrom(), request.builtYearTo());
-        RegionSelection region = regionSelection(request.regionCode());
-        return new HousingComplexSearchCondition(
-                bounds,
-                keyword,
-                region.provinceCode(),
-                region.districtCodes(),
-                rentalTypes,
-                applicationStatuses,
-                agencyCodes,
-                recruitmentTypes,
-                decimal(request.minDeposit()),
-                decimal(request.maxDeposit()),
-                decimal(request.minMonthlyRent()),
-                decimal(request.maxMonthlyRent()),
-                request.minExclusiveArea(),
-                request.maxExclusiveArea(),
-                request.builtYearFrom(),
-                request.builtYearTo(),
-                request.hasElevator(),
-                request.hasActiveAnnouncement(),
-                today()
-        );
-    }
-
-    private void requireRequest(HousingComplexSearchRequest request) {
-        if (request == null) {
-            throw new InvalidComplexRequestException();
-        }
-    }
-
-    private MapBounds bounds(HousingComplexSearchRequest request) {
-        return MapBounds.of(
-                request.southWestLat(),
-                request.southWestLng(),
-                request.northEastLat(),
-                request.northEastLng()
-        );
-    }
-
     private ComplexSort normalizedSort(ComplexSort sort) {
         if (sort == null) {
             return ComplexSort.LATEST_ANNOUNCEMENT;
         }
         return sort;
-    }
-
-    private String normalizedKeyword(String keyword) {
-        if (keyword == null) {
-            return null;
-        }
-        String normalized = keyword.trim();
-        if (normalized.isEmpty()) {
-            throw new InvalidComplexRequestException();
-        }
-        return normalized;
-    }
-
-    private <T> Set<T> immutableSet(List<T> values) {
-        if (values == null || values.isEmpty()) {
-            return Set.of();
-        }
-        if (values.stream().anyMatch(Objects::isNull)) {
-            throw new InvalidComplexRequestException();
-        }
-        return Set.copyOf(values);
-    }
-
-    private void requireNonNegative(Long value) {
-        if (value != null && value < 0) {
-            throw new InvalidComplexRequestException();
-        }
-    }
-
-    private void requireNonNegative(BigDecimal value) {
-        if (value != null && value.signum() < 0) {
-            throw new InvalidComplexRequestException();
-        }
-    }
-
-    private <T extends Comparable<T>> void requireAscending(T minimum, T maximum) {
-        if (minimum != null && maximum != null && minimum.compareTo(maximum) > 0) {
-            throw new InvalidComplexRequestException();
-        }
-    }
-
-    private void requireValidYear(Integer year) {
-        if (year != null && (year < 1 || year > 9999)) {
-            throw new InvalidComplexRequestException();
-        }
-    }
-
-    private RegionSelection regionSelection(String regionCode) {
-        if (regionCode == null) {
-            return new RegionSelection(null, Set.of());
-        }
-        if (regionCode.isBlank()) {
-            throw new InvalidRegionCodeException();
-        }
-        if (regionCode.matches("[0-9]{2}") || regionCode.matches("[0-9]{5}")) {
-            return filterSelection(regionCode);
-        }
-        throw new InvalidRegionCodeException();
-    }
-
-    private RegionSelection filterSelection(String regionCode) {
-        Set<String> districtCodes = regionCodeResolver.filterCodes(regionCode)
-                .orElseThrow(InvalidRegionCodeException::new);
-        return new RegionSelection(null, districtCodes);
-    }
-
-    private BigDecimal decimal(Long value) {
-        if (value == null) {
-            return null;
-        }
-        return BigDecimal.valueOf(value);
     }
 
     private ComplexSummaryCursor decodeCursor(String cursor, ComplexSort sort) {
@@ -322,11 +181,5 @@ public class HousingComplexQueryService {
 
     private LocalDate today() {
         return LocalDate.ofInstant(clock.instant(), SEOUL_ZONE);
-    }
-
-    private record RegionSelection(String provinceCode, Set<String> districtCodes) {
-        private RegionSelection {
-            districtCodes = Set.copyOf(districtCodes);
-        }
     }
 }

--- a/backend/src/main/java/com/toadzip/backend/housing/service/HousingComplexSearchRequestNormalizer.java
+++ b/backend/src/main/java/com/toadzip/backend/housing/service/HousingComplexSearchRequestNormalizer.java
@@ -1,0 +1,195 @@
+package com.toadzip.backend.housing.service;
+
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import org.springframework.stereotype.Component;
+
+import com.toadzip.backend.announcement.domain.ApplicationStatus;
+import com.toadzip.backend.announcement.domain.RecruitmentType;
+import com.toadzip.backend.housing.domain.AgencyCode;
+import com.toadzip.backend.housing.domain.MapBounds;
+import com.toadzip.backend.housing.domain.RentalType;
+import com.toadzip.backend.housing.dto.request.HousingComplexSearchRequest;
+import com.toadzip.backend.housing.exception.InvalidComplexRequestException;
+import com.toadzip.backend.housing.exception.InvalidRegionCodeException;
+import com.toadzip.backend.housing.repository.HousingComplexFilterCondition;
+import com.toadzip.backend.region.repository.RegionCodeResolver;
+
+@Component
+final class HousingComplexSearchRequestNormalizer {
+
+    private static final ZoneId SEOUL_ZONE = ZoneId.of("Asia/Seoul");
+
+    private final RegionCodeResolver regionCodeResolver;
+
+    private final Clock clock;
+
+    HousingComplexSearchRequestNormalizer(RegionCodeResolver regionCodeResolver, Clock clock) {
+        this.regionCodeResolver = regionCodeResolver;
+        this.clock = clock;
+    }
+
+    MapBounds normalizeBounds(HousingComplexSearchRequest request) {
+        requireRequest(request);
+        return MapBounds.of(
+                request.southWestLat(), request.southWestLng(),
+                request.northEastLat(), request.northEastLng()
+        );
+    }
+
+    HousingComplexFilterCondition normalizeFilters(HousingComplexSearchRequest request) {
+        requireRequest(request);
+        String keyword = normalizedKeyword(request.keyword());
+        FilterCollections collections = normalizedCollections(request);
+        requireNonNegativeValues(request);
+        requireAscendingValues(request);
+        requireValidYears(request);
+        RegionSelection region = regionSelection(request.regionCode());
+        return toFilterCondition(request, keyword, collections, region);
+    }
+
+    private HousingComplexFilterCondition toFilterCondition(HousingComplexSearchRequest request, String keyword,
+            FilterCollections collections, RegionSelection region) {
+        return new HousingComplexFilterCondition(
+                keyword, region.provinceCode(), region.districtCodes(),
+                collections.rentalTypes(), collections.applicationStatuses(),
+                collections.agencyCodes(), collections.recruitmentTypes(),
+                decimal(request.minDeposit()), decimal(request.maxDeposit()),
+                decimal(request.minMonthlyRent()), decimal(request.maxMonthlyRent()),
+                request.minExclusiveArea(), request.maxExclusiveArea(),
+                request.builtYearFrom(), request.builtYearTo(), request.hasElevator(),
+                request.hasActiveAnnouncement(), today()
+        );
+    }
+
+    private FilterCollections normalizedCollections(HousingComplexSearchRequest request) {
+        return new FilterCollections(
+                immutableSet(request.rentalTypes()),
+                immutableSet(request.applicationStatuses()),
+                immutableSet(request.agencyCodes()),
+                immutableSet(request.recruitmentTypes())
+        );
+    }
+
+    private void requireNonNegativeValues(HousingComplexSearchRequest request) {
+        requireNonNegative(request.minDeposit());
+        requireNonNegative(request.maxDeposit());
+        requireNonNegative(request.minMonthlyRent());
+        requireNonNegative(request.maxMonthlyRent());
+        requireNonNegative(request.minExclusiveArea());
+        requireNonNegative(request.maxExclusiveArea());
+    }
+
+    private void requireAscendingValues(HousingComplexSearchRequest request) {
+        requireAscending(request.minDeposit(), request.maxDeposit());
+        requireAscending(request.minMonthlyRent(), request.maxMonthlyRent());
+        requireAscending(request.minExclusiveArea(), request.maxExclusiveArea());
+    }
+
+    private void requireValidYears(HousingComplexSearchRequest request) {
+        requireValidYear(request.builtYearFrom());
+        requireValidYear(request.builtYearTo());
+        requireAscending(request.builtYearFrom(), request.builtYearTo());
+    }
+
+    private String normalizedKeyword(String keyword) {
+        if (keyword == null) {
+            return null;
+        }
+        String normalized = keyword.trim();
+        if (normalized.isEmpty()) {
+            throw new InvalidComplexRequestException();
+        }
+        return normalized;
+    }
+
+    private <T> Set<T> immutableSet(List<T> values) {
+        if (values == null || values.isEmpty()) {
+            return Set.of();
+        }
+        if (values.stream().anyMatch(Objects::isNull)) {
+            throw new InvalidComplexRequestException();
+        }
+        return Set.copyOf(values);
+    }
+
+    private void requireNonNegative(Long value) {
+        if (value != null && value < 0) {
+            throw new InvalidComplexRequestException();
+        }
+    }
+
+    private void requireNonNegative(BigDecimal value) {
+        if (value != null && value.signum() < 0) {
+            throw new InvalidComplexRequestException();
+        }
+    }
+
+    private <T extends Comparable<T>> void requireAscending(T minimum, T maximum) {
+        if (minimum != null && maximum != null && minimum.compareTo(maximum) > 0) {
+            throw new InvalidComplexRequestException();
+        }
+    }
+
+    private void requireValidYear(Integer year) {
+        if (year != null && (year < 1 || year > 9999)) {
+            throw new InvalidComplexRequestException();
+        }
+    }
+
+    private RegionSelection regionSelection(String regionCode) {
+        if (regionCode == null) {
+            return new RegionSelection(null, Set.of());
+        }
+        if (regionCode.isBlank()) {
+            throw new InvalidRegionCodeException();
+        }
+        if (regionCode.matches("[0-9]{2}") || regionCode.matches("[0-9]{5}")) {
+            return filterSelection(regionCode);
+        }
+        throw new InvalidRegionCodeException();
+    }
+
+    private RegionSelection filterSelection(String regionCode) {
+        Set<String> districtCodes = regionCodeResolver.filterCodes(regionCode)
+                .orElseThrow(InvalidRegionCodeException::new);
+        return new RegionSelection(null, districtCodes);
+    }
+
+    private BigDecimal decimal(Long value) {
+        if (value == null) {
+            return null;
+        }
+        return BigDecimal.valueOf(value);
+    }
+
+    private void requireRequest(HousingComplexSearchRequest request) {
+        if (request == null) {
+            throw new InvalidComplexRequestException();
+        }
+    }
+
+    private LocalDate today() {
+        return LocalDate.ofInstant(clock.instant(), SEOUL_ZONE);
+    }
+
+    private record FilterCollections(
+            Set<RentalType> rentalTypes,
+            Set<ApplicationStatus> applicationStatuses,
+            Set<AgencyCode> agencyCodes,
+            Set<RecruitmentType> recruitmentTypes
+    ) {
+    }
+
+    private record RegionSelection(String provinceCode, Set<String> districtCodes) {
+
+        private RegionSelection {
+            districtCodes = Set.copyOf(districtCodes);
+        }
+    }
+}

--- a/backend/src/main/java/com/toadzip/backend/region/service/RegionQueryService.java
+++ b/backend/src/main/java/com/toadzip/backend/region/service/RegionQueryService.java
@@ -15,7 +15,8 @@ public class RegionQueryService {
     }
 
     public RegionSearchResponse searchRegions(String keyword) {
-        return new RegionSearchResponse(regionSearchRepository.findByKeyword(keyword.strip())
+        String normalizedKeyword = keyword.strip().replaceAll("\\s+", " ");
+        return new RegionSearchResponse(regionSearchRepository.findByKeyword(normalizedKeyword)
                 .stream()
                 .map(region -> new RegionSearchItemResponse(
                         region.regionCode(),

--- a/backend/src/main/java/com/toadzip/backend/search/controller/IntegratedSearchController.java
+++ b/backend/src/main/java/com/toadzip/backend/search/controller/IntegratedSearchController.java
@@ -1,0 +1,30 @@
+package com.toadzip.backend.search.controller;
+
+import com.toadzip.backend.global.response.ApiResponse;
+import com.toadzip.backend.search.dto.request.IntegratedSearchRequest;
+import com.toadzip.backend.search.dto.response.IntegratedSearchResponse;
+import com.toadzip.backend.search.service.IntegratedSearchService;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(path = "/api/v1/search", produces = MediaType.APPLICATION_JSON_VALUE)
+public class IntegratedSearchController {
+
+    private final IntegratedSearchService integratedSearchService;
+
+    public IntegratedSearchController(IntegratedSearchService integratedSearchService) {
+        this.integratedSearchService = integratedSearchService;
+    }
+
+    @GetMapping
+    public ApiResponse<IntegratedSearchResponse> search(
+            @ParameterObject @ModelAttribute IntegratedSearchRequest request
+    ) {
+        return new ApiResponse<>(integratedSearchService.search(request));
+    }
+}

--- a/backend/src/main/java/com/toadzip/backend/search/controller/SearchExceptionAdvice.java
+++ b/backend/src/main/java/com/toadzip/backend/search/controller/SearchExceptionAdvice.java
@@ -1,0 +1,30 @@
+package com.toadzip.backend.search.controller;
+
+import com.toadzip.backend.global.exception.ErrorResponse;
+import com.toadzip.backend.global.exception.RequestTraceIdResolver;
+import com.toadzip.backend.search.exception.InvalidSearchRequestException;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Order(Ordered.HIGHEST_PRECEDENCE)
+@RestControllerAdvice
+public class SearchExceptionAdvice {
+
+    @ExceptionHandler(InvalidSearchRequestException.class)
+    public ResponseEntity<ErrorResponse> handleInvalidSearchRequest(
+            InvalidSearchRequestException exception,
+            HttpServletRequest request
+    ) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse(
+                        "INVALID_SEARCH_REQUEST",
+                        exception.getMessage(),
+                        RequestTraceIdResolver.resolve(request)
+                ));
+    }
+}

--- a/backend/src/main/java/com/toadzip/backend/search/domain/SearchMatch.java
+++ b/backend/src/main/java/com/toadzip/backend/search/domain/SearchMatch.java
@@ -1,0 +1,48 @@
+package com.toadzip.backend.search.domain;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+
+public record SearchMatch(String normalizedQuery, List<String> tokens) {
+
+    public static SearchMatch from(String query) {
+        if (query == null) {
+            throw new IllegalArgumentException("검색어가 필요하다.");
+        }
+        String normalized = query.strip().replaceAll("\\s+", " ");
+        if (normalized.replace(" ", "").length() < 2 || normalized.length() > 50) {
+            throw new IllegalArgumentException("검색어는 공백 제외 2자 이상 50자 이하여야 한다.");
+        }
+        return new SearchMatch(
+                normalized,
+                Arrays.stream(normalized.split(" "))
+                        .map(token -> token.toLowerCase(Locale.ROOT))
+                        .toList()
+        );
+    }
+
+    public boolean matches(String... fields) {
+        List<String> normalizedFields = normalizedFields(fields);
+        return tokens.stream().allMatch(token -> normalizedFields.stream().anyMatch(field -> field.contains(token)));
+    }
+
+    public int rank(String... fields) {
+        List<String> normalizedFields = normalizedFields(fields);
+        String query = normalizedQuery.toLowerCase(Locale.ROOT);
+        if (normalizedFields.stream().anyMatch(field -> field.equals(query))) {
+            return 0;
+        }
+        if (normalizedFields.stream().anyMatch(field -> field.startsWith(query))) {
+            return 1;
+        }
+        return 2;
+    }
+
+    private List<String> normalizedFields(String... fields) {
+        return Arrays.stream(fields)
+                .filter(java.util.Objects::nonNull)
+                .map(field -> field.toLowerCase(Locale.ROOT))
+                .toList();
+    }
+}

--- a/backend/src/main/java/com/toadzip/backend/search/domain/SearchType.java
+++ b/backend/src/main/java/com/toadzip/backend/search/domain/SearchType.java
@@ -1,0 +1,7 @@
+package com.toadzip.backend.search.domain;
+
+public enum SearchType {
+    ANNOUNCEMENT,
+    COMPLEX,
+    REGION
+}

--- a/backend/src/main/java/com/toadzip/backend/search/dto/request/IntegratedSearchRequest.java
+++ b/backend/src/main/java/com/toadzip/backend/search/dto/request/IntegratedSearchRequest.java
@@ -1,0 +1,16 @@
+package com.toadzip.backend.search.dto.request;
+
+import com.toadzip.backend.announcement.domain.ApplicationStatus;
+import com.toadzip.backend.housing.domain.RentalType;
+import java.util.List;
+
+public record IntegratedSearchRequest(
+        String query,
+        Boolean preview,
+        Integer page,
+        Integer size,
+        List<RentalType> rentalTypes,
+        List<ApplicationStatus> applicationStatuses,
+        Boolean hasActiveAnnouncement
+) {
+}

--- a/backend/src/main/java/com/toadzip/backend/search/dto/response/IntegratedSearchResponse.java
+++ b/backend/src/main/java/com/toadzip/backend/search/dto/response/IntegratedSearchResponse.java
@@ -4,16 +4,18 @@ import java.util.List;
 
 public record IntegratedSearchResponse(
         String query,
-        List<SearchResultItemResponse> housingInformation,
-        List<SearchResultItemResponse> locations,
+        List<SearchResultItemResponse> announcements,
+        List<SearchResultItemResponse> complexes,
+        List<SearchResultItemResponse> regions,
         List<SearchFailureResponse> failures,
         int page,
         int size,
         boolean hasNext
 ) {
     public IntegratedSearchResponse {
-        housingInformation = List.copyOf(housingInformation);
-        locations = List.copyOf(locations);
+        announcements = List.copyOf(announcements);
+        complexes = List.copyOf(complexes);
+        regions = List.copyOf(regions);
         failures = List.copyOf(failures);
     }
 }

--- a/backend/src/main/java/com/toadzip/backend/search/dto/response/IntegratedSearchResponse.java
+++ b/backend/src/main/java/com/toadzip/backend/search/dto/response/IntegratedSearchResponse.java
@@ -1,0 +1,19 @@
+package com.toadzip.backend.search.dto.response;
+
+import java.util.List;
+
+public record IntegratedSearchResponse(
+        String query,
+        List<SearchResultItemResponse> housingInformation,
+        List<SearchResultItemResponse> locations,
+        List<SearchFailureResponse> failures,
+        int page,
+        int size,
+        boolean hasNext
+) {
+    public IntegratedSearchResponse {
+        housingInformation = List.copyOf(housingInformation);
+        locations = List.copyOf(locations);
+        failures = List.copyOf(failures);
+    }
+}

--- a/backend/src/main/java/com/toadzip/backend/search/dto/response/SearchFailureResponse.java
+++ b/backend/src/main/java/com/toadzip/backend/search/dto/response/SearchFailureResponse.java
@@ -1,0 +1,6 @@
+package com.toadzip.backend.search.dto.response;
+
+import com.toadzip.backend.search.domain.SearchType;
+
+public record SearchFailureResponse(SearchType type, String message) {
+}

--- a/backend/src/main/java/com/toadzip/backend/search/dto/response/SearchResultItemResponse.java
+++ b/backend/src/main/java/com/toadzip/backend/search/dto/response/SearchResultItemResponse.java
@@ -9,14 +9,10 @@ public record SearchResultItemResponse(
         String id,
         String title,
         String subtitle,
-        String address,
-        String category,
         BigDecimal latitude,
         BigDecimal longitude,
         LocalDate publishedAt,
         String applicationStatus,
-        boolean cancelled,
-        String regionCode,
-        int matchRank
+        String regionCode
 ) {
 }

--- a/backend/src/main/java/com/toadzip/backend/search/dto/response/SearchResultItemResponse.java
+++ b/backend/src/main/java/com/toadzip/backend/search/dto/response/SearchResultItemResponse.java
@@ -1,0 +1,22 @@
+package com.toadzip.backend.search.dto.response;
+
+import com.toadzip.backend.search.domain.SearchType;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+public record SearchResultItemResponse(
+        SearchType type,
+        String id,
+        String title,
+        String subtitle,
+        String address,
+        String category,
+        BigDecimal latitude,
+        BigDecimal longitude,
+        LocalDate publishedAt,
+        String applicationStatus,
+        boolean cancelled,
+        String regionCode,
+        int matchRank
+) {
+}

--- a/backend/src/main/java/com/toadzip/backend/search/exception/InvalidSearchRequestException.java
+++ b/backend/src/main/java/com/toadzip/backend/search/exception/InvalidSearchRequestException.java
@@ -1,0 +1,8 @@
+package com.toadzip.backend.search.exception;
+
+public class InvalidSearchRequestException extends RuntimeException {
+
+    public InvalidSearchRequestException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/toadzip/backend/search/repository/IntegratedSearchCondition.java
+++ b/backend/src/main/java/com/toadzip/backend/search/repository/IntegratedSearchCondition.java
@@ -1,0 +1,20 @@
+package com.toadzip.backend.search.repository;
+
+import com.toadzip.backend.announcement.domain.ApplicationStatus;
+import com.toadzip.backend.housing.domain.RentalType;
+import com.toadzip.backend.search.domain.SearchMatch;
+import java.time.LocalDate;
+import java.util.Set;
+
+public record IntegratedSearchCondition(
+        SearchMatch match,
+        Set<RentalType> rentalTypes,
+        Set<ApplicationStatus> applicationStatuses,
+        Boolean hasActiveAnnouncement,
+        LocalDate today
+) {
+    public IntegratedSearchCondition {
+        rentalTypes = Set.copyOf(rentalTypes);
+        applicationStatuses = Set.copyOf(applicationStatuses);
+    }
+}

--- a/backend/src/main/java/com/toadzip/backend/search/repository/InternalSearchRepository.java
+++ b/backend/src/main/java/com/toadzip/backend/search/repository/InternalSearchRepository.java
@@ -49,7 +49,6 @@ public class InternalSearchRepository {
                        announcement.posted_date,
                        announcement.application_start_date,
                        announcement.application_end_date,
-                       announcement.status,
                        CASE
                            WHEN announcement.status IN ('CANCELLATION', '취소공고') THEN 'CANCELLED'
                            WHEN announcement.application_start_date > :today THEN 'BEFORE_APPLICATION'
@@ -264,20 +263,16 @@ public class InternalSearchRepository {
     }
 
     private SearchSourceItem mapAnnouncement(ResultSet resultSet, int rowNumber) throws SQLException {
-        String publicationType = resultSet.getString("status");
-        boolean cancelled = "CANCELLATION".equals(publicationType) || "취소공고".equals(publicationType);
         return new SearchSourceItem(
                 SearchType.ANNOUNCEMENT,
                 resultSet.getString("id"),
                 resultSet.getString("name"),
                 providerName(resultSet.getString("provider")),
                 resultSet.getString("region_names"),
-                "공고",
                 resultSet.getBigDecimal("latitude"),
                 resultSet.getBigDecimal("longitude"),
                 resultSet.getObject("posted_date", java.time.LocalDate.class),
                 resultSet.getString("application_status"),
-                cancelled,
                 null
         );
     }
@@ -289,12 +284,10 @@ public class InternalSearchRepository {
                 resultSet.getString("name"),
                 resultSet.getString("road_address"),
                 resultSet.getString("road_address"),
-                "단지",
                 resultSet.getBigDecimal("latitude"),
                 resultSet.getBigDecimal("longitude"),
                 null,
                 null,
-                false,
                 resultSet.getString("city_county_district_code")
         );
     }

--- a/backend/src/main/java/com/toadzip/backend/search/repository/InternalSearchRepository.java
+++ b/backend/src/main/java/com/toadzip/backend/search/repository/InternalSearchRepository.java
@@ -1,0 +1,342 @@
+package com.toadzip.backend.search.repository;
+
+import com.toadzip.backend.announcement.domain.ApplicationStatus;
+import com.toadzip.backend.global.persistence.LegacyStoredValue;
+import com.toadzip.backend.housing.domain.AgencyCode;
+import com.toadzip.backend.search.domain.SearchType;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.StringJoiner;
+import java.util.stream.Collectors;
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class InternalSearchRepository {
+
+    private static final String PROVIDER_NAME = """
+            CASE announcement.provider
+                WHEN 'LH' THEN '한국토지주택공사'
+                WHEN 'SH' THEN '서울주택도시공사'
+                WHEN 'GH' THEN '경기주택도시공사'
+                ELSE announcement.provider
+            END
+            """.strip();
+
+    private static final String LATEST_LEAF = """
+            NOT EXISTS (
+                SELECT 1 FROM announcements successor
+                WHERE successor.previous_announcement_id = announcement.id
+            )
+            """;
+
+    private final JdbcClient jdbcClient;
+
+    public InternalSearchRepository(JdbcClient jdbcClient) {
+        this.jdbcClient = jdbcClient;
+    }
+
+    public List<SearchSourceItem> findAnnouncements(IntegratedSearchCondition condition, int limit) {
+        Map<String, Object> parameters = baseParameters(condition, limit);
+        StringBuilder sql = new StringBuilder("""
+                SELECT announcement.id,
+                       announcement.name,
+                       announcement.provider,
+                       announcement.posted_date,
+                       announcement.application_start_date,
+                       announcement.application_end_date,
+                       announcement.status,
+                       CASE
+                           WHEN announcement.status IN ('CANCELLATION', '취소공고') THEN 'CANCELLED'
+                           WHEN announcement.application_start_date > :today THEN 'BEFORE_APPLICATION'
+                           WHEN announcement.application_end_date < :today THEN 'CLOSED'
+                           ELSE 'APPLYING'
+                       END AS application_status,
+                       COALESCE((
+                           SELECT STRING_AGG(DISTINCT complex.road_address, ' ')
+                           FROM supply_rows supply_row
+                           JOIN housing_complexes complex ON complex.id = supply_row.housing_complex_id
+                           WHERE supply_row.announcement_id = announcement.id
+                       ), '') AS region_names,
+                       (
+                           SELECT complex.latitude
+                           FROM supply_rows supply_row
+                           JOIN housing_complexes complex ON complex.id = supply_row.housing_complex_id
+                           WHERE supply_row.announcement_id = announcement.id
+                             AND complex.latitude IS NOT NULL
+                             AND complex.longitude IS NOT NULL
+                           ORDER BY supply_row.display_order, complex.id
+                           LIMIT 1
+                       ) AS latitude,
+                       (
+                           SELECT complex.longitude
+                           FROM supply_rows supply_row
+                           JOIN housing_complexes complex ON complex.id = supply_row.housing_complex_id
+                           WHERE supply_row.announcement_id = announcement.id
+                             AND complex.latitude IS NOT NULL
+                             AND complex.longitude IS NOT NULL
+                           ORDER BY supply_row.display_order, complex.id
+                           LIMIT 1
+                       ) AS longitude
+                FROM announcements announcement
+                WHERE
+                """).append(LATEST_LEAF);
+        addAnnouncementTokens(sql, parameters, condition);
+        addRentalTypes(sql, parameters, "announcement.supply_type", condition);
+        addAnnouncementStatuses(sql, parameters, condition);
+        addAnnouncementOrder(sql);
+        sql.append(", announcement.posted_date DESC, announcement.id DESC LIMIT :limit");
+        return jdbcClient.sql(sql.toString()).params(parameters).query(this::mapAnnouncement).list();
+    }
+
+    public List<SearchSourceItem> findComplexes(IntegratedSearchCondition condition, int limit) {
+        Map<String, Object> parameters = baseParameters(condition, limit);
+        StringBuilder sql = new StringBuilder("""
+                SELECT complex.id,
+                       complex.name,
+                       complex.road_address,
+                       complex.latitude,
+                       complex.longitude,
+                       complex.city_county_district_code,
+                       complex.supply_type
+                FROM housing_complexes complex
+                WHERE 1 = 1
+                """);
+        addComplexTokens(sql, parameters, condition);
+        addRentalTypes(sql, parameters, "complex.supply_type", condition);
+        addComplexAnnouncementFilter(sql, parameters, condition);
+        sql.append("""
+                 ORDER BY CASE
+                     WHEN LOWER(complex.name) = :exactQuery
+                       OR LOWER(complex.road_address) = :exactQuery THEN 0
+                     WHEN LOWER(complex.name) LIKE :prefixQuery ESCAPE '\\'
+                       OR LOWER(complex.road_address) LIKE :prefixQuery ESCAPE '\\' THEN 1
+                     ELSE 2
+                 END, complex.name ASC, complex.id ASC LIMIT :limit
+                """);
+        return jdbcClient.sql(sql.toString()).params(parameters).query(this::mapComplex).list();
+    }
+
+    private Map<String, Object> baseParameters(IntegratedSearchCondition condition, int limit) {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("today", condition.today());
+        parameters.put("limit", limit);
+        parameters.put("exactQuery", condition.match().normalizedQuery().toLowerCase(java.util.Locale.ROOT));
+        parameters.put("prefixQuery", prefixLike(condition.match().normalizedQuery()));
+        return parameters;
+    }
+
+    private void addAnnouncementTokens(
+            StringBuilder sql,
+            Map<String, Object> parameters,
+            IntegratedSearchCondition condition
+    ) {
+        for (int index = 0; index < condition.match().tokens().size(); index++) {
+            String parameter = "token" + index;
+            sql.append("""
+                     AND (
+                         LOWER(announcement.name) LIKE :%s ESCAPE '\\'
+                         OR LOWER(%s) LIKE :%s ESCAPE '\\'
+                         OR EXISTS (
+                             SELECT 1 FROM supply_rows matched_row
+                             JOIN housing_complexes matched_complex
+                               ON matched_complex.id = matched_row.housing_complex_id
+                             WHERE matched_row.announcement_id = announcement.id
+                               AND LOWER(matched_complex.road_address) LIKE :%s ESCAPE '\\'
+                         )
+                     )
+                    """.formatted(parameter, PROVIDER_NAME, parameter, parameter));
+            parameters.put(parameter, like(condition.match().tokens().get(index)));
+        }
+    }
+
+    private void addComplexTokens(
+            StringBuilder sql,
+            Map<String, Object> parameters,
+            IntegratedSearchCondition condition
+    ) {
+        for (int index = 0; index < condition.match().tokens().size(); index++) {
+            String parameter = "token" + index;
+            sql.append(" AND (LOWER(complex.name) LIKE :")
+                    .append(parameter)
+                    .append(" ESCAPE '\\' OR LOWER(complex.road_address) LIKE :")
+                    .append(parameter)
+                    .append(" ESCAPE '\\')");
+            parameters.put(parameter, like(condition.match().tokens().get(index)));
+        }
+    }
+
+    private void addRentalTypes(
+            StringBuilder sql,
+            Map<String, Object> parameters,
+            String column,
+            IntegratedSearchCondition condition
+    ) {
+        if (condition.rentalTypes().isEmpty()) {
+            return;
+        }
+        sql.append(" AND ").append(column).append(" IN (:rentalTypes)");
+        parameters.put("rentalTypes", storedValues(condition.rentalTypes()));
+    }
+
+    private void addAnnouncementStatuses(
+            StringBuilder sql,
+            Map<String, Object> parameters,
+            IntegratedSearchCondition condition
+    ) {
+        if (condition.applicationStatuses().isEmpty()) {
+            return;
+        }
+        StringJoiner filters = new StringJoiner(" OR ", " AND (", ")");
+        condition.applicationStatuses().forEach(status -> filters.add(announcementStatus(status)));
+        sql.append(filters);
+    }
+
+    private String announcementStatus(ApplicationStatus status) {
+        return switch (status) {
+            case BEFORE_APPLICATION -> "announcement.status NOT IN ('CANCELLATION', '취소공고')"
+                    + " AND announcement.application_start_date > :today";
+            case APPLYING -> "announcement.status NOT IN ('CANCELLATION', '취소공고')"
+                    + " AND announcement.application_start_date <= :today"
+                    + " AND announcement.application_end_date >= :today";
+            case CLOSED -> "announcement.status NOT IN ('CANCELLATION', '취소공고')"
+                    + " AND announcement.application_end_date < :today";
+            case CANCELLED -> "announcement.status IN ('CANCELLATION', '취소공고')";
+        };
+    }
+
+    private void addComplexAnnouncementFilter(
+            StringBuilder sql,
+            Map<String, Object> parameters,
+            IntegratedSearchCondition condition
+    ) {
+        if (condition.hasActiveAnnouncement() == null && condition.applicationStatuses().isEmpty()) {
+            return;
+        }
+        String active = activeAnnouncementExists();
+        if (Boolean.TRUE.equals(condition.hasActiveAnnouncement())) {
+            sql.append(" AND EXISTS (").append(active).append(")");
+        }
+        if (Boolean.FALSE.equals(condition.hasActiveAnnouncement())) {
+            sql.append(" AND NOT EXISTS (").append(active).append(")");
+        }
+        if (!condition.applicationStatuses().isEmpty()) {
+            StringJoiner filters = new StringJoiner(" OR ", " AND (", ")");
+            condition.applicationStatuses().stream()
+                    .filter(status -> status != ApplicationStatus.CANCELLED)
+                    .map(status -> "EXISTS (" + statusAnnouncementStart()
+                            + " AND announcement.status NOT IN ('CANCELLATION', '취소공고')"
+                            + " AND " + complexStatus(status) + ")")
+                    .forEach(filters::add);
+            if (condition.applicationStatuses().contains(ApplicationStatus.CANCELLED)) {
+                filters.add("EXISTS (" + statusAnnouncementStart()
+                        + " AND announcement.status IN ('CANCELLATION', '취소공고'))");
+            }
+            sql.append(filters);
+        }
+    }
+
+    private String activeAnnouncementExists() {
+        return statusAnnouncementStart()
+                + " AND announcement.status NOT IN ('CANCELLATION', '취소공고')"
+                + " AND announcement.application_start_date <= :today"
+                + " AND announcement.application_end_date >= :today";
+    }
+
+    private String statusAnnouncementStart() {
+        return "SELECT 1 FROM supply_rows supply_row JOIN announcements announcement"
+                + " ON announcement.id = supply_row.announcement_id"
+                + " WHERE supply_row.housing_complex_id = complex.id AND " + LATEST_LEAF;
+    }
+
+    private String complexStatus(ApplicationStatus status) {
+        return switch (status) {
+            case BEFORE_APPLICATION -> "announcement.application_start_date > :today";
+            case APPLYING -> "announcement.application_start_date <= :today"
+                    + " AND announcement.application_end_date >= :today";
+            case CLOSED -> "announcement.application_end_date < :today";
+            case CANCELLED -> "1 = 0";
+        };
+    }
+
+    private SearchSourceItem mapAnnouncement(ResultSet resultSet, int rowNumber) throws SQLException {
+        String publicationType = resultSet.getString("status");
+        boolean cancelled = "CANCELLATION".equals(publicationType) || "취소공고".equals(publicationType);
+        return new SearchSourceItem(
+                SearchType.ANNOUNCEMENT,
+                resultSet.getString("id"),
+                resultSet.getString("name"),
+                providerName(resultSet.getString("provider")),
+                resultSet.getString("region_names"),
+                "공고",
+                resultSet.getBigDecimal("latitude"),
+                resultSet.getBigDecimal("longitude"),
+                resultSet.getObject("posted_date", java.time.LocalDate.class),
+                resultSet.getString("application_status"),
+                cancelled,
+                null
+        );
+    }
+
+    private SearchSourceItem mapComplex(ResultSet resultSet, int rowNumber) throws SQLException {
+        return new SearchSourceItem(
+                SearchType.COMPLEX,
+                resultSet.getString("id"),
+                resultSet.getString("name"),
+                resultSet.getString("road_address"),
+                resultSet.getString("road_address"),
+                "단지",
+                resultSet.getBigDecimal("latitude"),
+                resultSet.getBigDecimal("longitude"),
+                null,
+                null,
+                false,
+                resultSet.getString("city_county_district_code")
+        );
+    }
+
+    private String providerName(String provider) {
+        try {
+            return AgencyCode.fromStoredValue(provider).displayName();
+        } catch (IllegalArgumentException exception) {
+            return provider;
+        }
+    }
+
+    private Set<String> storedValues(Set<? extends LegacyStoredValue> values) {
+        return values.stream()
+                .flatMap(value -> value.storedValues().stream())
+                .collect(Collectors.toUnmodifiableSet());
+    }
+
+    private String like(String token) {
+        return "%" + token.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_") + "%";
+    }
+
+    private String prefixLike(String query) {
+        return query.toLowerCase(java.util.Locale.ROOT)
+                .replace("\\", "\\\\")
+                .replace("%", "\\%")
+                .replace("_", "\\_") + "%";
+    }
+
+    private void addAnnouncementOrder(StringBuilder sql) {
+        sql.append(" ORDER BY CASE WHEN LOWER(announcement.name) = :exactQuery")
+                .append(" OR LOWER(").append(PROVIDER_NAME).append(") = :exactQuery")
+                .append(" OR EXISTS (SELECT 1 FROM supply_rows exact_row")
+                .append(" JOIN housing_complexes exact_complex ON exact_complex.id = exact_row.housing_complex_id")
+                .append(" WHERE exact_row.announcement_id = announcement.id")
+                .append(" AND LOWER(exact_complex.road_address) = :exactQuery) THEN 0")
+                .append(" WHEN LOWER(announcement.name) LIKE :prefixQuery ESCAPE '\\'")
+                .append(" OR LOWER(").append(PROVIDER_NAME).append(") LIKE :prefixQuery ESCAPE '\\'")
+                .append(" OR EXISTS (SELECT 1 FROM supply_rows prefix_row")
+                .append(" JOIN housing_complexes prefix_complex ON prefix_complex.id = prefix_row.housing_complex_id")
+                .append(" WHERE prefix_row.announcement_id = announcement.id")
+                .append(" AND LOWER(prefix_complex.road_address) LIKE :prefixQuery ESCAPE '\\') THEN 1")
+                .append(" ELSE 2 END");
+    }
+}

--- a/backend/src/main/java/com/toadzip/backend/search/repository/SearchSourceItem.java
+++ b/backend/src/main/java/com/toadzip/backend/search/repository/SearchSourceItem.java
@@ -1,0 +1,21 @@
+package com.toadzip.backend.search.repository;
+
+import com.toadzip.backend.search.domain.SearchType;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+public record SearchSourceItem(
+        SearchType type,
+        String id,
+        String title,
+        String subtitle,
+        String address,
+        String category,
+        BigDecimal latitude,
+        BigDecimal longitude,
+        LocalDate publishedAt,
+        String applicationStatus,
+        boolean cancelled,
+        String regionCode
+) {
+}

--- a/backend/src/main/java/com/toadzip/backend/search/repository/SearchSourceItem.java
+++ b/backend/src/main/java/com/toadzip/backend/search/repository/SearchSourceItem.java
@@ -10,12 +10,10 @@ public record SearchSourceItem(
         String title,
         String subtitle,
         String address,
-        String category,
         BigDecimal latitude,
         BigDecimal longitude,
         LocalDate publishedAt,
         String applicationStatus,
-        boolean cancelled,
         String regionCode
 ) {
 }

--- a/backend/src/main/java/com/toadzip/backend/search/service/IntegratedSearchService.java
+++ b/backend/src/main/java/com/toadzip/backend/search/service/IntegratedSearchService.java
@@ -1,0 +1,273 @@
+package com.toadzip.backend.search.service;
+
+import com.toadzip.backend.announcement.domain.ApplicationStatus;
+import com.toadzip.backend.housing.domain.RentalType;
+import com.toadzip.backend.region.repository.RegionSearchRepository;
+import com.toadzip.backend.search.domain.SearchMatch;
+import com.toadzip.backend.search.domain.SearchType;
+import com.toadzip.backend.search.dto.request.IntegratedSearchRequest;
+import com.toadzip.backend.search.dto.response.IntegratedSearchResponse;
+import com.toadzip.backend.search.dto.response.SearchFailureResponse;
+import com.toadzip.backend.search.dto.response.SearchResultItemResponse;
+import com.toadzip.backend.search.exception.InvalidSearchRequestException;
+import com.toadzip.backend.search.repository.IntegratedSearchCondition;
+import com.toadzip.backend.search.repository.InternalSearchRepository;
+import com.toadzip.backend.search.repository.SearchSourceItem;
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import org.springframework.stereotype.Service;
+
+@Service
+public class IntegratedSearchService {
+
+    private static final ZoneId SEOUL_ZONE = ZoneId.of("Asia/Seoul");
+    private static final int PREVIEW_TOTAL_LIMIT = 8;
+    private static final int PREVIEW_TYPE_LIMIT = 3;
+    private static final int PAGE_SIZE = 20;
+
+    private final InternalSearchRepository internalSearchRepository;
+    private final RegionSearchRepository regionSearchRepository;
+    private final Clock clock;
+
+    public IntegratedSearchService(
+            InternalSearchRepository internalSearchRepository,
+            RegionSearchRepository regionSearchRepository,
+            Clock clock
+    ) {
+        this.internalSearchRepository = internalSearchRepository;
+        this.regionSearchRepository = regionSearchRepository;
+        this.clock = clock;
+    }
+
+    public IntegratedSearchResponse search(IntegratedSearchRequest request) {
+        SearchInput input = input(request);
+        int fetchLimit = input.preview() ? PREVIEW_TYPE_LIMIT : (input.page() + 1) * PAGE_SIZE + 1;
+        IntegratedSearchCondition condition = new IntegratedSearchCondition(
+                input.match(),
+                input.rentalTypes(),
+                input.applicationStatuses(),
+                input.hasActiveAnnouncement(),
+                LocalDate.ofInstant(clock.instant(), SEOUL_ZONE)
+        );
+        List<SearchFailureResponse> failures = new ArrayList<>();
+        List<SearchSourceItem> results = new ArrayList<>();
+        addAnnouncements(results, failures, condition, fetchLimit);
+        addComplexes(results, failures, condition, fetchLimit);
+        addRegions(results, failures, input.match());
+
+        List<SearchResultItemResponse> ranked = results.stream()
+                .filter(item -> input.match().matches(item.title(), item.subtitle(), item.address()))
+                .map(item -> response(item, input.match()))
+                .sorted(resultOrder())
+                .toList();
+        Page page = input.preview() ? preview(ranked) : page(ranked, input.page());
+        return new IntegratedSearchResponse(
+                input.match().normalizedQuery(),
+                page.items().stream().filter(this::isHousingInformation).toList(),
+                page.items().stream().filter(item -> !isHousingInformation(item)).toList(),
+                failures,
+                input.page(),
+                input.preview() ? PREVIEW_TOTAL_LIMIT : PAGE_SIZE,
+                page.hasNext()
+        );
+    }
+
+    private void addAnnouncements(
+            List<SearchSourceItem> results,
+            List<SearchFailureResponse> failures,
+            IntegratedSearchCondition condition,
+            int limit
+    ) {
+        try {
+            results.addAll(internalSearchRepository.findAnnouncements(condition, limit));
+        } catch (RuntimeException exception) {
+            failures.add(failure(SearchType.ANNOUNCEMENT));
+        }
+    }
+
+    private void addComplexes(
+            List<SearchSourceItem> results,
+            List<SearchFailureResponse> failures,
+            IntegratedSearchCondition condition,
+            int limit
+    ) {
+        try {
+            results.addAll(internalSearchRepository.findComplexes(condition, limit));
+        } catch (RuntimeException exception) {
+            failures.add(failure(SearchType.COMPLEX));
+        }
+    }
+
+    private void addRegions(
+            List<SearchSourceItem> results,
+            List<SearchFailureResponse> failures,
+            SearchMatch match
+    ) {
+        try {
+            List<SearchSourceItem> regions = matchingRegions(match);
+            results.addAll(regions);
+        } catch (RuntimeException exception) {
+            failures.add(failure(SearchType.REGION));
+        }
+    }
+
+    private List<SearchSourceItem> matchingRegions(SearchMatch match) {
+        Set<String> matchingCodes = null;
+        java.util.Map<String, com.toadzip.backend.region.repository.RegionSearchResult> regions =
+                new java.util.LinkedHashMap<>();
+        for (String token : match.tokens()) {
+            List<com.toadzip.backend.region.repository.RegionSearchResult> matches =
+                    regionSearchRepository.findByKeyword(token);
+            Set<String> tokenCodes = matches.stream()
+                    .map(com.toadzip.backend.region.repository.RegionSearchResult::regionCode)
+                    .collect(java.util.stream.Collectors.toSet());
+            matches.forEach(region -> regions.put(region.regionCode(), region));
+            if (matchingCodes == null) {
+                matchingCodes = new HashSet<>(tokenCodes);
+            } else {
+                matchingCodes.retainAll(tokenCodes);
+            }
+        }
+        if (matchingCodes == null) {
+            return List.of();
+        }
+        return matchingCodes.stream()
+                .map(regions::get)
+                .filter(Objects::nonNull)
+                .map(region -> new SearchSourceItem(
+                        SearchType.REGION,
+                        region.regionCode(),
+                        region.displayName(),
+                        region.provinceName(),
+                        region.displayName(),
+                        "행정구역",
+                        null,
+                        null,
+                        null,
+                        null,
+                        false,
+                        region.regionCode()
+                ))
+                .toList();
+    }
+
+    private SearchFailureResponse failure(SearchType type) {
+        return new SearchFailureResponse(type, typeName(type) + " 검색에 실패했습니다. 다시 시도해 주세요.");
+    }
+
+    private String typeName(SearchType type) {
+        return switch (type) {
+            case ANNOUNCEMENT -> "공고";
+            case COMPLEX -> "단지";
+            case REGION -> "지역";
+        };
+    }
+
+    private SearchResultItemResponse response(SearchSourceItem item, SearchMatch match) {
+        return new SearchResultItemResponse(
+                item.type(),
+                item.id(),
+                item.title(),
+                item.subtitle(),
+                item.address(),
+                item.category(),
+                item.latitude(),
+                item.longitude(),
+                item.publishedAt(),
+                item.applicationStatus(),
+                item.cancelled(),
+                item.regionCode(),
+                match.rank(item.title(), item.subtitle(), item.address())
+        );
+    }
+
+    private Comparator<SearchResultItemResponse> resultOrder() {
+        return Comparator.comparingInt(SearchResultItemResponse::matchRank)
+                .thenComparingInt(item -> item.type().ordinal())
+                .thenComparing(SearchResultItemResponse::title)
+                .thenComparing(SearchResultItemResponse::id);
+    }
+
+    private Page preview(List<SearchResultItemResponse> ranked) {
+        java.util.Map<SearchType, Integer> counts = new java.util.EnumMap<>(SearchType.class);
+        List<SearchResultItemResponse> items = new ArrayList<>();
+        for (SearchResultItemResponse item : ranked) {
+            int count = counts.getOrDefault(item.type(), 0);
+            if (count >= PREVIEW_TYPE_LIMIT) {
+                continue;
+            }
+            counts.put(item.type(), count + 1);
+            items.add(item);
+            if (items.size() == PREVIEW_TOTAL_LIMIT) {
+                break;
+            }
+        }
+        return new Page(items, ranked.size() > items.size());
+    }
+
+    private Page page(List<SearchResultItemResponse> ranked, int page) {
+        int start = Math.min(page * PAGE_SIZE, ranked.size());
+        int end = Math.min(start + PAGE_SIZE, ranked.size());
+        return new Page(ranked.subList(start, end), end < ranked.size());
+    }
+
+    private boolean isHousingInformation(SearchResultItemResponse item) {
+        return item.type() == SearchType.ANNOUNCEMENT || item.type() == SearchType.COMPLEX;
+    }
+
+    private SearchInput input(IntegratedSearchRequest request) {
+        if (request == null) {
+            throw new InvalidSearchRequestException("검색 요청이 필요합니다.");
+        }
+        SearchMatch match;
+        try {
+            match = SearchMatch.from(request.query());
+        } catch (IllegalArgumentException exception) {
+            throw new InvalidSearchRequestException(exception.getMessage());
+        }
+        boolean preview = request.preview() == null || request.preview();
+        int page = request.page() == null ? 0 : request.page();
+        if (page < 0) {
+            throw new InvalidSearchRequestException("페이지는 0 이상이어야 합니다.");
+        }
+        if (request.size() != null && request.size() != PAGE_SIZE) {
+            throw new InvalidSearchRequestException("전체 검색은 페이지당 20개를 제공합니다.");
+        }
+        Set<RentalType> rentalTypes = immutableSet(request.rentalTypes());
+        Set<ApplicationStatus> statuses = immutableSet(request.applicationStatuses());
+        return new SearchInput(match, preview, page, rentalTypes, statuses, request.hasActiveAnnouncement());
+    }
+
+    private <T> Set<T> immutableSet(List<T> values) {
+        if (values == null || values.isEmpty()) {
+            return Set.of();
+        }
+        if (values.stream().anyMatch(Objects::isNull)) {
+            throw new InvalidSearchRequestException("검색 필터가 올바르지 않습니다.");
+        }
+        return Set.copyOf(values);
+    }
+
+    private record SearchInput(
+            SearchMatch match,
+            boolean preview,
+            int page,
+            Set<RentalType> rentalTypes,
+            Set<ApplicationStatus> applicationStatuses,
+            Boolean hasActiveAnnouncement
+    ) {
+    }
+
+    private record Page(List<SearchResultItemResponse> items, boolean hasNext) {
+        private Page {
+            items = List.copyOf(items);
+        }
+    }
+}

--- a/backend/src/main/java/com/toadzip/backend/search/service/IntegratedSearchService.java
+++ b/backend/src/main/java/com/toadzip/backend/search/service/IntegratedSearchService.java
@@ -22,15 +22,19 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 @Service
 public class IntegratedSearchService {
 
+    private static final Logger log = LoggerFactory.getLogger(IntegratedSearchService.class);
     private static final ZoneId SEOUL_ZONE = ZoneId.of("Asia/Seoul");
     private static final int PREVIEW_TOTAL_LIMIT = 8;
     private static final int PREVIEW_TYPE_LIMIT = 3;
     private static final int PAGE_SIZE = 20;
+    private static final int MAX_PAGE = 100;
 
     private final InternalSearchRepository internalSearchRepository;
     private final RegionSearchRepository regionSearchRepository;
@@ -48,7 +52,7 @@ public class IntegratedSearchService {
 
     public IntegratedSearchResponse search(IntegratedSearchRequest request) {
         SearchInput input = input(request);
-        int fetchLimit = input.preview() ? PREVIEW_TYPE_LIMIT : (input.page() + 1) * PAGE_SIZE + 1;
+        int fetchLimit = input.preview() ? PREVIEW_TYPE_LIMIT + 1 : (input.page() + 1) * PAGE_SIZE + 1;
         IntegratedSearchCondition condition = new IntegratedSearchCondition(
                 input.match(),
                 input.rentalTypes(),
@@ -64,14 +68,19 @@ public class IntegratedSearchService {
 
         List<SearchResultItemResponse> ranked = results.stream()
                 .filter(item -> input.match().matches(item.title(), item.subtitle(), item.address()))
-                .map(item -> response(item, input.match()))
+                .map(item -> new RankedItem(
+                        item,
+                        input.match().rank(item.title(), item.subtitle(), item.address())
+                ))
                 .sorted(resultOrder())
+                .map(item -> response(item.source()))
                 .toList();
         Page page = input.preview() ? preview(ranked) : page(ranked, input.page());
         return new IntegratedSearchResponse(
                 input.match().normalizedQuery(),
-                page.items().stream().filter(this::isHousingInformation).toList(),
-                page.items().stream().filter(item -> !isHousingInformation(item)).toList(),
+                itemsOfType(page, SearchType.ANNOUNCEMENT),
+                itemsOfType(page, SearchType.COMPLEX),
+                itemsOfType(page, SearchType.REGION),
                 failures,
                 input.page(),
                 input.preview() ? PREVIEW_TOTAL_LIMIT : PAGE_SIZE,
@@ -88,6 +97,7 @@ public class IntegratedSearchService {
         try {
             results.addAll(internalSearchRepository.findAnnouncements(condition, limit));
         } catch (RuntimeException exception) {
+            log.error("공고 통합 검색에 실패했습니다.", exception);
             failures.add(failure(SearchType.ANNOUNCEMENT));
         }
     }
@@ -101,6 +111,7 @@ public class IntegratedSearchService {
         try {
             results.addAll(internalSearchRepository.findComplexes(condition, limit));
         } catch (RuntimeException exception) {
+            log.error("단지 통합 검색에 실패했습니다.", exception);
             failures.add(failure(SearchType.COMPLEX));
         }
     }
@@ -114,6 +125,7 @@ public class IntegratedSearchService {
             List<SearchSourceItem> regions = matchingRegions(match);
             results.addAll(regions);
         } catch (RuntimeException exception) {
+            log.error("지역 통합 검색에 실패했습니다.", exception);
             failures.add(failure(SearchType.REGION));
         }
     }
@@ -147,12 +159,10 @@ public class IntegratedSearchService {
                         region.displayName(),
                         region.provinceName(),
                         region.displayName(),
-                        "행정구역",
                         null,
                         null,
                         null,
                         null,
-                        false,
                         region.regionCode()
                 ))
                 .toList();
@@ -170,29 +180,25 @@ public class IntegratedSearchService {
         };
     }
 
-    private SearchResultItemResponse response(SearchSourceItem item, SearchMatch match) {
+    private SearchResultItemResponse response(SearchSourceItem item) {
         return new SearchResultItemResponse(
                 item.type(),
                 item.id(),
                 item.title(),
                 item.subtitle(),
-                item.address(),
-                item.category(),
                 item.latitude(),
                 item.longitude(),
                 item.publishedAt(),
                 item.applicationStatus(),
-                item.cancelled(),
-                item.regionCode(),
-                match.rank(item.title(), item.subtitle(), item.address())
+                item.regionCode()
         );
     }
 
-    private Comparator<SearchResultItemResponse> resultOrder() {
-        return Comparator.comparingInt(SearchResultItemResponse::matchRank)
-                .thenComparingInt(item -> item.type().ordinal())
-                .thenComparing(SearchResultItemResponse::title)
-                .thenComparing(SearchResultItemResponse::id);
+    private Comparator<RankedItem> resultOrder() {
+        return Comparator.comparingInt(RankedItem::rank)
+                .thenComparingInt(item -> item.source().type().ordinal())
+                .thenComparing(item -> item.source().title())
+                .thenComparing(item -> item.source().id());
     }
 
     private Page preview(List<SearchResultItemResponse> ranked) {
@@ -218,8 +224,8 @@ public class IntegratedSearchService {
         return new Page(ranked.subList(start, end), end < ranked.size());
     }
 
-    private boolean isHousingInformation(SearchResultItemResponse item) {
-        return item.type() == SearchType.ANNOUNCEMENT || item.type() == SearchType.COMPLEX;
+    private List<SearchResultItemResponse> itemsOfType(Page page, SearchType type) {
+        return page.items().stream().filter(item -> item.type() == type).toList();
     }
 
     private SearchInput input(IntegratedSearchRequest request) {
@@ -234,8 +240,8 @@ public class IntegratedSearchService {
         }
         boolean preview = request.preview() == null || request.preview();
         int page = request.page() == null ? 0 : request.page();
-        if (page < 0) {
-            throw new InvalidSearchRequestException("페이지는 0 이상이어야 합니다.");
+        if (page < 0 || page > MAX_PAGE) {
+            throw new InvalidSearchRequestException("페이지는 0부터 100 사이여야 합니다.");
         }
         if (request.size() != null && request.size() != PAGE_SIZE) {
             throw new InvalidSearchRequestException("전체 검색은 페이지당 20개를 제공합니다.");
@@ -269,5 +275,8 @@ public class IntegratedSearchService {
         private Page {
             items = List.copyOf(items);
         }
+    }
+
+    private record RankedItem(SearchSourceItem source, int rank) {
     }
 }

--- a/backend/src/test/java/com/toadzip/backend/global/config/OpenApiDocumentationIntegrationTest.java
+++ b/backend/src/test/java/com/toadzip/backend/global/config/OpenApiDocumentationIntegrationTest.java
@@ -40,6 +40,7 @@ class OpenApiDocumentationIntegrationTest {
             "builtYearFrom",
             "builtYearTo",
             "hasElevator",
+            "hasActiveAnnouncement",
             "southWestLat",
             "southWestLng",
             "northEastLat",

--- a/backend/src/test/java/com/toadzip/backend/housing/controller/HousingComplexApiIntegrationTest.java
+++ b/backend/src/test/java/com/toadzip/backend/housing/controller/HousingComplexApiIntegrationTest.java
@@ -903,7 +903,6 @@ class HousingComplexApiIntegrationTest {
                 errorCase("역전 면적 범위", null, true, "minExclusiveArea", "2", "maxExclusiveArea", "1"),
                 errorCase("범위 밖 year", null, true, "builtYearFrom", "0"),
                 errorCase("역전 year 범위", null, true, "builtYearFrom", "2021", "builtYearTo", "2020"),
-                errorCase("CANCELLED 신청 상태", null, true, "applicationStatuses", "CANCELLED"),
                 errorCase("빈 enum 요소", null, true, "agencyCodes", "LH", "agencyCodes", ""),
                 errorCase("filter가 cursor보다 우선", null, true, "keyword", " ", "cursor", "bad!")
         );

--- a/backend/src/test/java/com/toadzip/backend/housing/repository/ComplexSummaryQueryRepositoryTest.java
+++ b/backend/src/test/java/com/toadzip/backend/housing/repository/ComplexSummaryQueryRepositoryTest.java
@@ -171,6 +171,26 @@ class ComplexSummaryQueryRepositoryTest {
     }
 
     @Test
+    void 취소_상태로_검색하면_최신_취소_공고가_연결된_단지만_조회한다() {
+        HousingComplex cancelled = persistComplex("취소 단지", "37.500000", "126.900000");
+        HousingComplex active = persistComplex("정상 단지", "37.510000", "126.910000");
+        Announcement original = persistRepresentative(
+                cancelled, "ORIGINAL", LocalDate.of(2026, 8, 1), "cancel-filter-original"
+        );
+        Announcement cancellation = persistAnnouncement(
+                original, "CANCELLATION", LocalDate.of(2026, 8, 2), "cancel-filter-leaf"
+        );
+        persistSupplyRow(cancellation, cancelled, null, "cancel-filter-row", 1);
+        persistRepresentative(active, "ORIGINAL", LocalDate.of(2026, 8, 1), "active-filter");
+        entityManager.flush();
+
+        assertBothQueryPaths(
+                integratedSearchCondition(Set.of(ApplicationStatus.CANCELLED), null),
+                cancelled.getId()
+        );
+    }
+
+    @Test
     void 최신_대표공고_게시일과_단지_ID로_안정적으로_페이지를_나눈다() {
         HousingComplex noAnnouncement = persistComplex("공고 없는 단지", "37.500000", "126.900000");
         HousingComplex cancelled = persistComplex("취소 단지", "37.500000", "126.900000");
@@ -1681,6 +1701,33 @@ class ComplexSummaryQueryRepositoryTest {
                 null,
                 null,
                 null,
+                LocalDate.of(2026, 8, 27)
+        );
+    }
+
+    private HousingComplexSearchCondition integratedSearchCondition(
+            Set<ApplicationStatus> applicationStatuses,
+            Boolean hasActiveAnnouncement
+    ) {
+        return new HousingComplexSearchCondition(
+                SEOUL_BOUNDS,
+                null,
+                null,
+                Set.of(),
+                Set.of(),
+                applicationStatuses,
+                Set.of(),
+                Set.of(),
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                hasActiveAnnouncement,
                 LocalDate.of(2026, 8, 27)
         );
     }

--- a/backend/src/test/java/com/toadzip/backend/housing/repository/ComplexSummaryQueryRepositoryTest.java
+++ b/backend/src/test/java/com/toadzip/backend/housing/repository/ComplexSummaryQueryRepositoryTest.java
@@ -38,7 +38,11 @@ import org.springframework.test.context.ActiveProfiles;
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @ActiveProfiles("test")
-@Import({ComplexSummaryQueryRepository.class, ComplexSummarySqlBuilder.class})
+@Import({
+        ComplexSummaryQueryRepository.class,
+        ComplexSummarySqlBuilder.class,
+        HousingComplexFilterPredicateBuilder.class
+})
 class ComplexSummaryQueryRepositoryTest {
 
     private static final MapBounds SEOUL_BOUNDS = MapBounds.of(
@@ -187,6 +191,36 @@ class ComplexSummaryQueryRepositoryTest {
         assertBothQueryPaths(
                 integratedSearchCondition(Set.of(ApplicationStatus.CANCELLED), null),
                 cancelled.getId()
+        );
+    }
+
+    @Test
+    void 모집_시작일과_종료일은_모집중에_포함한다() {
+        ActiveAnnouncementFixture fixture = persistActiveAnnouncementFixture();
+        entityManager.flush();
+
+        assertBothQueryPaths(integratedSearchCondition(Set.of(), true), fixture.activeComplexIds());
+    }
+
+    @Test
+    void 모집중_공고가_없는_단지는_지도와_목록에서_동일하게_조회한다() {
+        ActiveAnnouncementFixture fixture = persistActiveAnnouncementFixture();
+        entityManager.flush();
+
+        assertBothQueryPaths(
+                integratedSearchCondition(Set.of(), false),
+                fixture.inactiveComplexIds()
+        );
+    }
+
+    @Test
+    void 모집중_공고_조건이_null이면_지도와_목록_모두_제한하지_않는다() {
+        ActiveAnnouncementFixture fixture = persistActiveAnnouncementFixture();
+        entityManager.flush();
+
+        assertBothQueryPaths(
+                integratedSearchCondition(Set.of(), null),
+                fixture.allComplexIds()
         );
     }
 
@@ -1121,6 +1155,67 @@ class ComplexSummaryQueryRepositoryTest {
         );
     }
 
+    private ActiveAnnouncementFixture persistActiveAnnouncementFixture() {
+        return new ActiveAnnouncementFixture(
+                persistActiveBoundaryComplexes(),
+                persistInactiveAnnouncementComplexes()
+        );
+    }
+
+    private List<Long> persistActiveBoundaryComplexes() {
+        HousingComplex startBoundary = persistComplex("모집 시작일 경계", "37.500000", "126.900000");
+        HousingComplex endBoundary = persistComplex("모집 종료일 경계", "37.505000", "126.905000");
+        persistApplicationPeriod(startBoundary, LocalDate.of(2026, 8, 27),
+                LocalDate.of(2026, 8, 30), "start-boundary-announcement");
+        persistApplicationPeriod(endBoundary, LocalDate.of(2026, 8, 20),
+                LocalDate.of(2026, 8, 27), "end-boundary-announcement");
+        return List.of(startBoundary.getId(), endBoundary.getId());
+    }
+
+    private List<Long> persistInactiveAnnouncementComplexes() {
+        HousingComplex beforeApplication = persistComplex("접수 전", "37.510000", "126.910000");
+        HousingComplex closed = persistComplex("접수 종료", "37.520000", "126.920000");
+        HousingComplex withoutAnnouncement = persistComplex("공고 없음", "37.530000", "126.930000");
+        HousingComplex cancelled = persistComplex("취소 공고", "37.540000", "126.940000");
+        persistApplicationPeriod(beforeApplication, LocalDate.of(2026, 8, 28),
+                LocalDate.of(2026, 8, 31), "before-announcement");
+        persistApplicationPeriod(closed, LocalDate.of(2026, 8, 20),
+                LocalDate.of(2026, 8, 26), "closed-announcement");
+        persistCancelledAnnouncement(cancelled);
+        return List.of(
+                beforeApplication.getId(),
+                closed.getId(),
+                withoutAnnouncement.getId(),
+                cancelled.getId()
+        );
+    }
+
+    private void persistCancelledAnnouncement(HousingComplex complex) {
+        Announcement original = persistRepresentative(
+                complex, "ORIGINAL", LocalDate.of(2026, 8, 1), "inactive-original"
+        );
+        Announcement cancellation = persistAnnouncement(
+                original, "CANCELLATION", LocalDate.of(2026, 8, 2), "inactive-cancellation"
+        );
+        persistSupplyRow(cancellation, complex, null, "inactive-cancellation-row", 1);
+    }
+
+    private void persistApplicationPeriod(
+            HousingComplex complex,
+            LocalDate applicationStartDate,
+            LocalDate applicationEndDate,
+            String suffix
+    ) {
+        persistRepresentativeWithApplicationPeriod(
+                complex,
+                "NEW",
+                LocalDate.of(2026, 8, 1),
+                applicationStartDate,
+                applicationEndDate,
+                suffix
+        );
+    }
+
     private HousingComplex persistComplex(String name, String latitude, String longitude) {
         return persistComplex(
                 name,
@@ -1685,23 +1780,26 @@ class ComplexSummaryQueryRepositoryTest {
     private HousingComplexSearchCondition noFilters(MapBounds bounds) {
         return new HousingComplexSearchCondition(
                 bounds,
-                null,
-                null,
-                Set.of(),
-                Set.of(),
-                Set.of(),
-                Set.of(),
-                Set.of(),
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                LocalDate.of(2026, 8, 27)
+                new HousingComplexFilterCondition(
+                        null,
+                        null,
+                        Set.of(),
+                        Set.of(),
+                        Set.of(),
+                        Set.of(),
+                        Set.of(),
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        LocalDate.of(2026, 8, 27)
+                )
         );
     }
 
@@ -1711,24 +1809,26 @@ class ComplexSummaryQueryRepositoryTest {
     ) {
         return new HousingComplexSearchCondition(
                 SEOUL_BOUNDS,
-                null,
-                null,
-                Set.of(),
-                Set.of(),
-                applicationStatuses,
-                Set.of(),
-                Set.of(),
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                hasActiveAnnouncement,
-                LocalDate.of(2026, 8, 27)
+                new HousingComplexFilterCondition(
+                        null,
+                        null,
+                        Set.of(),
+                        Set.of(),
+                        applicationStatuses,
+                        Set.of(),
+                        Set.of(),
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        hasActiveAnnouncement,
+                        LocalDate.of(2026, 8, 27)
+                )
         );
     }
 
@@ -1744,23 +1844,26 @@ class ComplexSummaryQueryRepositoryTest {
     ) {
         return new HousingComplexSearchCondition(
                 SEOUL_BOUNDS,
-                keyword,
-                provinceCode,
-                cityCountyDistrictCodes,
-                rentalTypes,
-                Set.of(),
-                agencyCodes,
-                Set.of(),
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                builtYearFrom,
-                builtYearTo,
-                hasElevator,
-                LocalDate.of(2026, 8, 27)
+                new HousingComplexFilterCondition(
+                        keyword,
+                        provinceCode,
+                        cityCountyDistrictCodes,
+                        rentalTypes,
+                        Set.of(),
+                        agencyCodes,
+                        Set.of(),
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        builtYearFrom,
+                        builtYearTo,
+                        hasElevator,
+                        null,
+                        LocalDate.of(2026, 8, 27)
+                )
         );
     }
 
@@ -1770,23 +1873,26 @@ class ComplexSummaryQueryRepositoryTest {
     ) {
         return new HousingComplexSearchCondition(
                 SEOUL_BOUNDS,
-                null,
-                null,
-                Set.of(),
-                Set.of(),
-                applicationStatuses,
-                Set.of(),
-                recruitmentTypes,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                LocalDate.of(2026, 8, 27)
+                new HousingComplexFilterCondition(
+                        null,
+                        null,
+                        Set.of(),
+                        Set.of(),
+                        applicationStatuses,
+                        Set.of(),
+                        recruitmentTypes,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        LocalDate.of(2026, 8, 27)
+                )
         );
     }
 
@@ -1800,36 +1906,43 @@ class ComplexSummaryQueryRepositoryTest {
     ) {
         return new HousingComplexSearchCondition(
                 SEOUL_BOUNDS,
-                null,
-                null,
-                Set.of(),
-                Set.of(),
-                Set.of(),
-                Set.of(),
-                Set.of(),
-                minDeposit,
-                maxDeposit,
-                minMonthlyRent,
-                maxMonthlyRent,
-                minExclusiveArea,
-                maxExclusiveArea,
-                null,
-                null,
-                null,
-                LocalDate.of(2026, 8, 27)
+                new HousingComplexFilterCondition(
+                        null,
+                        null,
+                        Set.of(),
+                        Set.of(),
+                        Set.of(),
+                        Set.of(),
+                        Set.of(),
+                        minDeposit,
+                        maxDeposit,
+                        minMonthlyRent,
+                        maxMonthlyRent,
+                        minExclusiveArea,
+                        maxExclusiveArea,
+                        null,
+                        null,
+                        null,
+                        null,
+                        LocalDate.of(2026, 8, 27)
+                )
         );
     }
 
     private void assertBothQueryPaths(HousingComplexSearchCondition condition, Long... expectedIds) {
+        assertBothQueryPaths(condition, List.of(expectedIds));
+    }
+
+    private void assertBothQueryPaths(HousingComplexSearchCondition condition, List<Long> expectedIds) {
         List<Long> mapIds = ids(repository.findAll(condition));
         List<Long> listIds = ids(repository.findPage(condition, ComplexSort.LATEST_ANNOUNCEMENT, null, 100));
-        Set<Long> expected = Set.of(expectedIds);
+        Set<Long> expected = Set.copyOf(expectedIds);
 
         assertAll(
                 () -> assertEquals(expected, Set.copyOf(mapIds)),
-                () -> assertEquals(expectedIds.length, mapIds.size()),
+                () -> assertEquals(expectedIds.size(), mapIds.size()),
                 () -> assertEquals(expected, Set.copyOf(listIds)),
-                () -> assertEquals(expectedIds.length, listIds.size())
+                () -> assertEquals(expectedIds.size(), listIds.size())
         );
     }
 
@@ -1867,5 +1980,16 @@ class ComplexSummaryQueryRepositoryTest {
             HousingComplexSearchCondition condition,
             Long expectedComplexId
     ) {
+    }
+
+    private record ActiveAnnouncementFixture(
+            List<Long> activeComplexIds,
+            List<Long> inactiveComplexIds
+    ) {
+        private List<Long> allComplexIds() {
+            List<Long> allComplexIds = new ArrayList<>(activeComplexIds);
+            allComplexIds.addAll(inactiveComplexIds);
+            return List.copyOf(allComplexIds);
+        }
     }
 }

--- a/backend/src/test/java/com/toadzip/backend/housing/repository/ComplexSummarySqlBuilderIntegratedSearchTest.java
+++ b/backend/src/test/java/com/toadzip/backend/housing/repository/ComplexSummarySqlBuilderIntegratedSearchTest.java
@@ -1,0 +1,71 @@
+package com.toadzip.backend.housing.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.toadzip.backend.announcement.domain.ApplicationStatus;
+import com.toadzip.backend.housing.domain.MapBounds;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class ComplexSummarySqlBuilderIntegratedSearchTest {
+
+    private final ComplexSummarySqlBuilder builder = new ComplexSummarySqlBuilder();
+
+    @Test
+    void 모집중_공고_조건을_지도와_목록에_동일하게_적용한다() {
+        HousingComplexSearchCondition condition = condition(Set.of(), true);
+
+        ComplexSummarySqlQuery query = builder.buildMapQuery(condition);
+
+        assertThat(query.sql())
+                .contains("representative.application_start_date <= :today")
+                .contains("representative.application_end_date >= :today");
+        assertThat(query.parameters())
+                .containsEntry("today", LocalDate.of(2026, 9, 1));
+    }
+
+    @Test
+    void 취소_상태는_최신_취소_공고가_연결된_단지만_조회한다() {
+        ComplexSummarySqlQuery query = builder.buildMapQuery(
+                condition(Set.of(ApplicationStatus.CANCELLED), null)
+        );
+
+        assertThat(query.sql())
+                .contains("cancelled_announcement.status IN ('CANCELLATION', '취소공고')")
+                .contains("cancelled_successor.previous_announcement_id = cancelled_announcement.id");
+    }
+
+    private HousingComplexSearchCondition condition(
+            Set<ApplicationStatus> statuses,
+            Boolean hasActiveAnnouncement
+    ) {
+        return new HousingComplexSearchCondition(
+                MapBounds.of(
+                        new BigDecimal("37.50"),
+                        new BigDecimal("126.90"),
+                        new BigDecimal("37.60"),
+                        new BigDecimal("127.05")
+                ),
+                null,
+                null,
+                Set.of(),
+                Set.of(),
+                statuses,
+                Set.of(),
+                Set.of(),
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                hasActiveAnnouncement,
+                LocalDate.of(2026, 9, 1)
+        );
+    }
+}

--- a/backend/src/test/java/com/toadzip/backend/housing/repository/ComplexSummarySqlBuilderIntegratedSearchTest.java
+++ b/backend/src/test/java/com/toadzip/backend/housing/repository/ComplexSummarySqlBuilderIntegratedSearchTest.java
@@ -2,28 +2,32 @@ package com.toadzip.backend.housing.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.toadzip.backend.announcement.domain.ApplicationStatus;
-import com.toadzip.backend.housing.domain.MapBounds;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 
+import com.toadzip.backend.announcement.domain.ApplicationStatus;
+import com.toadzip.backend.housing.domain.ComplexSort;
+import com.toadzip.backend.housing.domain.MapBounds;
+
 class ComplexSummarySqlBuilderIntegratedSearchTest {
 
-    private final ComplexSummarySqlBuilder builder = new ComplexSummarySqlBuilder();
+    private final ComplexSummarySqlBuilder builder = new ComplexSummarySqlBuilder(
+            new HousingComplexFilterPredicateBuilder()
+    );
 
     @Test
     void 모집중_공고_조건을_지도와_목록에_동일하게_적용한다() {
         HousingComplexSearchCondition condition = condition(Set.of(), true);
 
-        ComplexSummarySqlQuery query = builder.buildMapQuery(condition);
+        ComplexSummarySqlQuery mapQuery = builder.buildMapQuery(condition);
+        ComplexSummarySqlQuery listQuery = builder.buildListQuery(
+                condition, ComplexSort.LATEST_ANNOUNCEMENT, null, 20
+        );
 
-        assertThat(query.sql())
-                .contains("representative.application_start_date <= :today")
-                .contains("representative.application_end_date >= :today");
-        assertThat(query.parameters())
-                .containsEntry("today", LocalDate.of(2026, 9, 1));
+        assertActiveAnnouncementFilter(mapQuery);
+        assertActiveAnnouncementFilter(listQuery);
     }
 
     @Test
@@ -37,17 +41,37 @@ class ComplexSummarySqlBuilderIntegratedSearchTest {
                 .contains("cancelled_successor.previous_announcement_id = cancelled_announcement.id");
     }
 
+    private void assertActiveAnnouncementFilter(ComplexSummarySqlQuery query) {
+        assertThat(query.sql())
+                .contains("representative.application_start_date <= :today")
+                .contains("representative.application_end_date >= :today");
+        assertThat(query.parameters()).containsEntry("today", LocalDate.of(2026, 9, 1));
+    }
+
     private HousingComplexSearchCondition condition(
             Set<ApplicationStatus> statuses,
             Boolean hasActiveAnnouncement
     ) {
         return new HousingComplexSearchCondition(
-                MapBounds.of(
-                        new BigDecimal("37.50"),
-                        new BigDecimal("126.90"),
-                        new BigDecimal("37.60"),
-                        new BigDecimal("127.05")
-                ),
+                bounds(),
+                filters(statuses, hasActiveAnnouncement)
+        );
+    }
+
+    private MapBounds bounds() {
+        return MapBounds.of(
+                new BigDecimal("37.50"),
+                new BigDecimal("126.90"),
+                new BigDecimal("37.60"),
+                new BigDecimal("127.05")
+        );
+    }
+
+    private HousingComplexFilterCondition filters(
+            Set<ApplicationStatus> statuses,
+            Boolean hasActiveAnnouncement
+    ) {
+        return new HousingComplexFilterCondition(
                 null,
                 null,
                 Set.of(),

--- a/backend/src/test/java/com/toadzip/backend/housing/repository/HousingComplexFilterPredicateBuilderTest.java
+++ b/backend/src/test/java/com/toadzip/backend/housing/repository/HousingComplexFilterPredicateBuilderTest.java
@@ -1,0 +1,161 @@
+package com.toadzip.backend.housing.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.util.EnumSet;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+import com.toadzip.backend.announcement.domain.ApplicationStatus;
+import com.toadzip.backend.housing.domain.AgencyCode;
+import com.toadzip.backend.housing.domain.RentalType;
+
+class HousingComplexFilterPredicateBuilderTest {
+
+    private static final LocalDate TODAY = LocalDate.of(2026, 9, 1);
+
+    private final HousingComplexFilterPredicateBuilder builder = new HousingComplexFilterPredicateBuilder();
+
+    @Test
+    void 필터가_없으면_SQL과_파라미터가_비어있다() {
+        HousingComplexFilterPredicate predicate = builder.build(noFilters());
+
+        assertThat(predicate.sql()).isEmpty();
+        assertThat(predicate.parameters()).isEmpty();
+    }
+
+    @Test
+    void 비공간_필터만_SQL과_파라미터로_만든다() {
+        HousingComplexFilterPredicate predicate = builder.build(directFilters());
+
+        assertThat(predicate.sql())
+                .containsSubsequence(
+                        "LOWER(housing_complex.name)",
+                        "housing_complex.province_code",
+                        "housing_complex.city_county_district_code",
+                        "housing_complex.supply_type",
+                        "housing_complex.provider",
+                        "EXTRACT(YEAR FROM housing_complex.completion_date)",
+                        "housing_complex.elevator_installed"
+                )
+                .doesNotContain("southWestLat", "northEastLat", "ORDER BY", "LIMIT", "cursor");
+        assertThat(predicate.parameters())
+                .containsEntry("keywordPattern", "%서울\\%단지%")
+                .containsEntry("provinceCode", "11")
+                .containsEntry("districtCodes", Set.of("11110", "11140"))
+                .containsEntry("builtYearFrom", 2020)
+                .containsEntry("hasElevator", true)
+                .doesNotContainKeys("southWestLat", "northEastLat", "limit", "cursorValue");
+    }
+
+    @Test
+    void 모집중_공고_여부에_따라_서로_다른_조건을_만든다() {
+        HousingComplexFilterPredicate active = builder.build(activeAnnouncement(true));
+        HousingComplexFilterPredicate inactive = builder.build(activeAnnouncement(false));
+
+        assertThat(active.sql())
+                .contains("representative.announcement_id IS NOT NULL")
+                .contains("representative.application_start_date <= :today");
+        assertThat(inactive.sql())
+                .contains("representative.announcement_id IS NULL")
+                .contains("representative.application_start_date > :today");
+        assertThat(active.parameters()).containsEntry("today", TODAY);
+        assertThat(inactive.parameters()).containsEntry("today", TODAY);
+    }
+
+    @Test
+    void 모든_접수상태를_SQL_조건으로_변환한다() {
+        HousingComplexFilterPredicate predicate = builder.build(applicationStatuses());
+
+        assertThat(predicate.sql())
+                .contains("representative.application_start_date > :today")
+                .contains("representative.application_start_date <= :today")
+                .contains("representative.application_end_date < :today")
+                .contains("cancelled_announcement.status IN ('CANCELLATION', '취소공고')");
+        assertThat(predicate.parameters()).containsEntry("today", TODAY);
+    }
+
+    private HousingComplexFilterCondition noFilters() {
+        return condition(null, null, Set.of(), Set.of(), Set.of(), Set.of(), null, null, null, null);
+    }
+
+    private HousingComplexFilterCondition directFilters() {
+        return condition(
+                "서울%단지",
+                "11",
+                Set.of("11110", "11140"),
+                Set.of(RentalType.HAPPY_HOUSING),
+                Set.of(),
+                Set.of(AgencyCode.LH),
+                2020,
+                null,
+                true,
+                null
+        );
+    }
+
+    private HousingComplexFilterCondition activeAnnouncement(boolean hasActiveAnnouncement) {
+        return condition(
+                null,
+                null,
+                Set.of(),
+                Set.of(),
+                Set.of(),
+                Set.of(),
+                null,
+                null,
+                null,
+                hasActiveAnnouncement
+        );
+    }
+
+    private HousingComplexFilterCondition applicationStatuses() {
+        return condition(
+                null,
+                null,
+                Set.of(),
+                Set.of(),
+                EnumSet.allOf(ApplicationStatus.class),
+                Set.of(),
+                null,
+                null,
+                null,
+                null
+        );
+    }
+
+    private HousingComplexFilterCondition condition(
+            String keyword,
+            String provinceCode,
+            Set<String> districtCodes,
+            Set<RentalType> rentalTypes,
+            Set<ApplicationStatus> applicationStatuses,
+            Set<AgencyCode> agencyCodes,
+            Integer builtYearFrom,
+            Integer builtYearTo,
+            Boolean hasElevator,
+            Boolean hasActiveAnnouncement
+    ) {
+        return new HousingComplexFilterCondition(
+                keyword,
+                provinceCode,
+                districtCodes,
+                rentalTypes,
+                applicationStatuses,
+                agencyCodes,
+                Set.of(),
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                builtYearFrom,
+                builtYearTo,
+                hasElevator,
+                hasActiveAnnouncement,
+                TODAY
+        );
+    }
+}

--- a/backend/src/test/java/com/toadzip/backend/housing/service/HousingComplexDetailQueryTest.java
+++ b/backend/src/test/java/com/toadzip/backend/housing/service/HousingComplexDetailQueryTest.java
@@ -67,7 +67,7 @@ class HousingComplexDetailQueryTest {
                 summaryMapper,
                 detailRepository,
                 detailMapper,
-                noOpSearchRegionCodeResolver,
+                new HousingComplexSearchRequestNormalizer(noOpSearchRegionCodeResolver, CLOCK),
                 CLOCK
         );
         stubDetail(complexRow("https://example.com/complex.png", "INDIVIDUAL", "APARTMENT", "STAIR"));

--- a/backend/src/test/java/com/toadzip/backend/housing/service/HousingComplexListQueryTest.java
+++ b/backend/src/test/java/com/toadzip/backend/housing/service/HousingComplexListQueryTest.java
@@ -644,9 +644,7 @@ class HousingComplexListQueryTest {
                 Arguments.of("agency null element", requestWithLists(
                         null, null, java.util.Arrays.asList(AgencyCode.LH, null), null)),
                 Arguments.of("recruitment type null element", requestWithLists(
-                        null, null, null, java.util.Arrays.asList(RecruitmentType.NEW, null))),
-                Arguments.of("cancelled status", requestWithLists(
-                        null, List.of(ApplicationStatus.CANCELLED), null, null))
+                        null, null, null, java.util.Arrays.asList(RecruitmentType.NEW, null)))
         );
     }
 

--- a/backend/src/test/java/com/toadzip/backend/housing/service/HousingComplexListQueryTest.java
+++ b/backend/src/test/java/com/toadzip/backend/housing/service/HousingComplexListQueryTest.java
@@ -31,6 +31,7 @@ import com.toadzip.backend.housing.exception.InvalidRegionCodeException;
 import com.toadzip.backend.housing.repository.ComplexSummaryCursor;
 import com.toadzip.backend.housing.repository.ComplexSummaryQueryRepository;
 import com.toadzip.backend.housing.repository.ComplexSummaryRow;
+import com.toadzip.backend.housing.repository.HousingComplexFilterCondition;
 import com.toadzip.backend.housing.repository.HousingComplexSearchCondition;
 import com.toadzip.backend.region.repository.RegionCodeResolver;
 import java.math.BigDecimal;
@@ -94,7 +95,12 @@ class HousingComplexListQueryTest {
                 new HousingComplexCodeMapper(),
                 regionCodeResolver
         );
-        service = new HousingComplexQueryService(repository, summaryMapper, regionCodeResolver, CLOCK);
+        service = new HousingComplexQueryService(
+                repository,
+                summaryMapper,
+                new HousingComplexSearchRequestNormalizer(regionCodeResolver, CLOCK),
+                CLOCK
+        );
     }
 
     @Test
@@ -117,30 +123,32 @@ class HousingComplexListQueryTest {
                 eq(21)
         );
         HousingComplexSearchCondition condition = conditionCaptor.getValue();
+        HousingComplexFilterCondition filters = condition.filters();
         assertAll(
                 () -> assertEquals(BOUNDS, condition.bounds()),
-                () -> assertEquals("행복 단지", condition.keyword()),
-                () -> assertNull(condition.provinceCode()),
-                () -> assertEquals(Set.of("11110", "11140"), condition.cityCountyDistrictCodes()),
+                () -> assertEquals("행복 단지", filters.keyword()),
+                () -> assertNull(filters.provinceCode()),
+                () -> assertEquals(Set.of("11110", "11140"), filters.cityCountyDistrictCodes()),
                 () -> assertEquals(Set.of(RentalType.HAPPY_HOUSING, RentalType.NATIONAL_RENTAL),
-                        condition.rentalTypes()),
+                        filters.rentalTypes()),
                 () -> assertEquals(Set.of(ApplicationStatus.APPLYING, ApplicationStatus.CLOSED),
-                        condition.applicationStatuses()),
-                () -> assertEquals(Set.of(AgencyCode.LH, AgencyCode.SH), condition.agencyCodes()),
+                        filters.applicationStatuses()),
+                () -> assertEquals(Set.of(AgencyCode.LH, AgencyCode.SH), filters.agencyCodes()),
                 () -> assertEquals(Set.of(RecruitmentType.NEW, RecruitmentType.WAITLIST),
-                        condition.recruitmentTypes()),
-                () -> assertEquals(new BigDecimal("10000000"), condition.minDeposit()),
-                () -> assertEquals(new BigDecimal("70000000"), condition.maxDeposit()),
-                () -> assertEquals(new BigDecimal("100000"), condition.minMonthlyRent()),
-                () -> assertEquals(new BigDecimal("300000"), condition.maxMonthlyRent()),
-                () -> assertEquals(new BigDecimal("36.12"), condition.minExclusiveArea()),
-                () -> assertEquals(new BigDecimal("44.87"), condition.maxExclusiveArea()),
-                () -> assertEquals(2018, condition.builtYearFrom()),
-                () -> assertEquals(2026, condition.builtYearTo()),
-                () -> assertEquals(true, condition.hasElevator()),
-                () -> assertEquals(LocalDate.of(2026, 8, 27), condition.today()),
+                        filters.recruitmentTypes()),
+                () -> assertEquals(new BigDecimal("10000000"), filters.minDeposit()),
+                () -> assertEquals(new BigDecimal("70000000"), filters.maxDeposit()),
+                () -> assertEquals(new BigDecimal("100000"), filters.minMonthlyRent()),
+                () -> assertEquals(new BigDecimal("300000"), filters.maxMonthlyRent()),
+                () -> assertEquals(new BigDecimal("36.12"), filters.minExclusiveArea()),
+                () -> assertEquals(new BigDecimal("44.87"), filters.maxExclusiveArea()),
+                () -> assertEquals(2018, filters.builtYearFrom()),
+                () -> assertEquals(2026, filters.builtYearTo()),
+                () -> assertEquals(true, filters.hasElevator()),
+                () -> assertEquals(true, filters.hasActiveAnnouncement()),
+                () -> assertEquals(LocalDate.of(2026, 8, 27), filters.today()),
                 () -> assertThrows(UnsupportedOperationException.class,
-                        () -> condition.rentalTypes().add(RentalType.ETC))
+                        () -> filters.rentalTypes().add(RentalType.ETC))
         );
     }
 
@@ -159,10 +167,10 @@ class HousingComplexListQueryTest {
                 eq(21)
         );
         assertAll(
-                () -> assertNull(conditionCaptor.getValue().provinceCode()),
+                () -> assertNull(conditionCaptor.getValue().filters().provinceCode()),
                 () -> assertEquals(
                         Set.of("12110", "12210", "29110", "46110"),
-                        conditionCaptor.getValue().cityCountyDistrictCodes()
+                        conditionCaptor.getValue().filters().cityCountyDistrictCodes()
                 )
         );
     }
@@ -182,9 +190,9 @@ class HousingComplexListQueryTest {
                 eq(21)
         );
         assertAll(
-                () -> assertNull(conditionCaptor.getValue().provinceCode()),
+                () -> assertNull(conditionCaptor.getValue().filters().provinceCode()),
                 () -> assertEquals(Set.of("12210", "29110"),
-                        conditionCaptor.getValue().cityCountyDistrictCodes())
+                        conditionCaptor.getValue().filters().cityCountyDistrictCodes())
         );
     }
 
@@ -203,9 +211,9 @@ class HousingComplexListQueryTest {
                 eq(21)
         );
         assertAll(
-                () -> assertNull(conditionCaptor.getValue().provinceCode()),
+                () -> assertNull(conditionCaptor.getValue().filters().provinceCode()),
                 () -> assertEquals(Set.of("41110", "41111", "41113"),
-                        conditionCaptor.getValue().cityCountyDistrictCodes())
+                        conditionCaptor.getValue().filters().cityCountyDistrictCodes())
         );
     }
 
@@ -497,7 +505,12 @@ class HousingComplexListQueryTest {
                 new HousingComplexCodeMapper(),
                 regionCodeResolver
         );
-        service = new HousingComplexQueryService(repository, summaryMapper, regionCodeResolver, advancingClock);
+        service = new HousingComplexQueryService(
+                repository,
+                summaryMapper,
+                new HousingComplexSearchRequestNormalizer(regionCodeResolver, advancingClock),
+                advancingClock
+        );
         when(repository.findPage(any(), eq(ComplexSort.LATEST_ANNOUNCEMENT), isNull(), eq(2))).thenReturn(List.of(row(
                 1L,
                 LocalDate.of(2026, 8, 20),
@@ -519,7 +532,7 @@ class HousingComplexListQueryTest {
         );
         HousingComplexListItemResponse item = response.items().getFirst();
         assertAll(
-                () -> assertEquals(LocalDate.of(2026, 8, 27), conditionCaptor.getValue().today()),
+                () -> assertEquals(LocalDate.of(2026, 8, 27), conditionCaptor.getValue().filters().today()),
                 () -> assertEquals("APPLYING", item.representativeAnnouncement().applicationStatus()),
                 () -> assertEquals(0, item.representativeAnnouncement().dDay())
         );
@@ -676,17 +689,27 @@ class HousingComplexListQueryTest {
     }
 
     private static HousingComplexSearchRequest fullSearchRequest(String regionCode) {
-        return request(
-                " 행복 단지 ", regionCode,
+        return new HousingComplexSearchRequest(
+                " 행복 단지 ",
+                regionCode,
                 List.of(RentalType.HAPPY_HOUSING, RentalType.NATIONAL_RENTAL),
                 List.of(ApplicationStatus.APPLYING, ApplicationStatus.CLOSED),
                 List.of(AgencyCode.LH, AgencyCode.SH),
                 List.of(RecruitmentType.NEW, RecruitmentType.WAITLIST),
-                10_000_000L, 70_000_000L, 100_000L, 300_000L,
-                new BigDecimal("36.12"), new BigDecimal("44.87"),
-                2018, 2026, true,
-                new BigDecimal("37.400000"), new BigDecimal("126.800000"),
-                new BigDecimal("37.600000"), new BigDecimal("127.100000")
+                10_000_000L,
+                70_000_000L,
+                100_000L,
+                300_000L,
+                new BigDecimal("36.12"),
+                new BigDecimal("44.87"),
+                2018,
+                2026,
+                true,
+                new BigDecimal("37.400000"),
+                new BigDecimal("126.800000"),
+                new BigDecimal("37.600000"),
+                new BigDecimal("127.100000"),
+                true
         );
     }
 

--- a/backend/src/test/java/com/toadzip/backend/housing/service/HousingComplexMapQueryTest.java
+++ b/backend/src/test/java/com/toadzip/backend/housing/service/HousingComplexMapQueryTest.java
@@ -21,6 +21,7 @@ import com.toadzip.backend.housing.dto.response.HousingComplexMapResponse;
 import com.toadzip.backend.housing.exception.InvalidRegionCodeException;
 import com.toadzip.backend.housing.repository.ComplexSummaryQueryRepository;
 import com.toadzip.backend.housing.repository.ComplexSummaryRow;
+import com.toadzip.backend.housing.repository.HousingComplexFilterCondition;
 import com.toadzip.backend.housing.repository.HousingComplexSearchCondition;
 import com.toadzip.backend.region.repository.RegionCodeResolver;
 import java.math.BigDecimal;
@@ -74,7 +75,12 @@ class HousingComplexMapQueryTest {
         when(regionCodeResolver.filterCodes("99")).thenReturn(Optional.empty());
         HousingComplexCodeMapper codeMapper = new HousingComplexCodeMapper();
         HousingComplexSummaryMapper summaryMapper = new HousingComplexSummaryMapper(codeMapper);
-        service = new HousingComplexQueryService(repository, summaryMapper, regionCodeResolver, CLOCK);
+        service = new HousingComplexQueryService(
+                repository,
+                summaryMapper,
+                new HousingComplexSearchRequestNormalizer(regionCodeResolver, CLOCK),
+                CLOCK
+        );
     }
 
     @Test
@@ -87,28 +93,30 @@ class HousingComplexMapQueryTest {
                 ArgumentCaptor.forClass(HousingComplexSearchCondition.class);
         verify(repository).findAll(conditionCaptor.capture());
         HousingComplexSearchCondition condition = conditionCaptor.getValue();
+        HousingComplexFilterCondition filters = condition.filters();
         assertAll(
                 () -> assertEquals(BOUNDS, condition.bounds()),
-                () -> assertEquals("행복 단지", condition.keyword()),
-                () -> assertNull(condition.provinceCode()),
-                () -> assertEquals(Set.of("12210", "29110"), condition.cityCountyDistrictCodes()),
+                () -> assertEquals("행복 단지", filters.keyword()),
+                () -> assertNull(filters.provinceCode()),
+                () -> assertEquals(Set.of("12210", "29110"), filters.cityCountyDistrictCodes()),
                 () -> assertEquals(Set.of(RentalType.HAPPY_HOUSING, RentalType.NATIONAL_RENTAL),
-                        condition.rentalTypes()),
+                        filters.rentalTypes()),
                 () -> assertEquals(Set.of(ApplicationStatus.APPLYING, ApplicationStatus.CLOSED),
-                        condition.applicationStatuses()),
-                () -> assertEquals(Set.of(AgencyCode.LH, AgencyCode.SH), condition.agencyCodes()),
+                        filters.applicationStatuses()),
+                () -> assertEquals(Set.of(AgencyCode.LH, AgencyCode.SH), filters.agencyCodes()),
                 () -> assertEquals(Set.of(RecruitmentType.NEW, RecruitmentType.WAITLIST),
-                        condition.recruitmentTypes()),
-                () -> assertEquals(new BigDecimal("10000000"), condition.minDeposit()),
-                () -> assertEquals(new BigDecimal("70000000"), condition.maxDeposit()),
-                () -> assertEquals(new BigDecimal("100000"), condition.minMonthlyRent()),
-                () -> assertEquals(new BigDecimal("300000"), condition.maxMonthlyRent()),
-                () -> assertEquals(new BigDecimal("36.12"), condition.minExclusiveArea()),
-                () -> assertEquals(new BigDecimal("44.87"), condition.maxExclusiveArea()),
-                () -> assertEquals(2018, condition.builtYearFrom()),
-                () -> assertEquals(2026, condition.builtYearTo()),
-                () -> assertEquals(true, condition.hasElevator()),
-                () -> assertEquals(LocalDate.of(2026, 8, 27), condition.today())
+                        filters.recruitmentTypes()),
+                () -> assertEquals(new BigDecimal("10000000"), filters.minDeposit()),
+                () -> assertEquals(new BigDecimal("70000000"), filters.maxDeposit()),
+                () -> assertEquals(new BigDecimal("100000"), filters.minMonthlyRent()),
+                () -> assertEquals(new BigDecimal("300000"), filters.maxMonthlyRent()),
+                () -> assertEquals(new BigDecimal("36.12"), filters.minExclusiveArea()),
+                () -> assertEquals(new BigDecimal("44.87"), filters.maxExclusiveArea()),
+                () -> assertEquals(2018, filters.builtYearFrom()),
+                () -> assertEquals(2026, filters.builtYearTo()),
+                () -> assertEquals(true, filters.hasElevator()),
+                () -> assertEquals(true, filters.hasActiveAnnouncement()),
+                () -> assertEquals(LocalDate.of(2026, 8, 27), filters.today())
         );
     }
 
@@ -123,10 +131,10 @@ class HousingComplexMapQueryTest {
         verify(repository).findAll(conditionCaptor.capture());
         HousingComplexSearchCondition condition = conditionCaptor.getValue();
         assertAll(
-                () -> assertNull(condition.provinceCode()),
+                () -> assertNull(condition.filters().provinceCode()),
                 () -> assertEquals(
                         Set.of("12110", "12210", "29110", "46110"),
-                        condition.cityCountyDistrictCodes()
+                        condition.filters().cityCountyDistrictCodes()
                 )
         );
     }
@@ -142,7 +150,7 @@ class HousingComplexMapQueryTest {
     }
 
     @Test
-    void 상위_시_지역은_하위_구를_포함하고_다른_시는_제외해_지도_검색조건으로_전달한다() {
+    void 상위_시_지역은_하위_구만_지도_검색조건에_포함한다() {
         when(repository.findAll(any(HousingComplexSearchCondition.class))).thenReturn(List.of());
 
         service.getComplexesForMap(fullSearchRequest("41110"));
@@ -152,8 +160,11 @@ class HousingComplexMapQueryTest {
         verify(repository).findAll(conditionCaptor.capture());
         HousingComplexSearchCondition condition = conditionCaptor.getValue();
         assertAll(
-                () -> assertNull(condition.provinceCode()),
-                () -> assertEquals(Set.of("41110", "41111", "41113"), condition.cityCountyDistrictCodes())
+                () -> assertNull(condition.filters().provinceCode()),
+                () -> assertEquals(
+                        Set.of("41110", "41111", "41113"),
+                        condition.filters().cityCountyDistrictCodes()
+                )
         );
     }
 
@@ -363,7 +374,8 @@ class HousingComplexMapQueryTest {
                 new BigDecimal("37.400000"),
                 new BigDecimal("126.800000"),
                 new BigDecimal("37.600000"),
-                new BigDecimal("127.100000")
+                new BigDecimal("127.100000"),
+                true
         );
     }
 

--- a/backend/src/test/java/com/toadzip/backend/housing/service/HousingComplexSearchRequestNormalizerTest.java
+++ b/backend/src/test/java/com/toadzip/backend/housing/service/HousingComplexSearchRequestNormalizerTest.java
@@ -1,0 +1,168 @@
+package com.toadzip.backend.housing.service;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import com.toadzip.backend.announcement.domain.ApplicationStatus;
+import com.toadzip.backend.announcement.domain.RecruitmentType;
+import com.toadzip.backend.housing.domain.AgencyCode;
+import com.toadzip.backend.housing.domain.MapBounds;
+import com.toadzip.backend.housing.domain.RentalType;
+import com.toadzip.backend.housing.dto.request.HousingComplexSearchRequest;
+import com.toadzip.backend.housing.exception.InvalidComplexRequestException;
+import com.toadzip.backend.housing.repository.HousingComplexFilterCondition;
+import com.toadzip.backend.region.repository.RegionCodeResolver;
+
+class HousingComplexSearchRequestNormalizerTest {
+
+    private static final Clock CLOCK = Clock.fixed(
+            Instant.parse("2026-08-26T15:30:00Z"),
+            ZoneOffset.UTC
+    );
+
+    private RegionCodeResolver regionCodeResolver;
+
+    private HousingComplexSearchRequestNormalizer normalizer;
+
+    @BeforeEach
+    void setUp() {
+        regionCodeResolver = mock(RegionCodeResolver.class);
+        when(regionCodeResolver.filterCodes("12210"))
+                .thenReturn(Optional.of(Set.of("12210", "29110")));
+        normalizer = new HousingComplexSearchRequestNormalizer(regionCodeResolver, CLOCK);
+    }
+
+    @Test
+    void bounds_정규화는_검색필터를_검증하지_않는다() {
+        HousingComplexSearchRequest request = request("   ", null, validBounds());
+
+        MapBounds bounds = normalizer.normalizeBounds(request);
+
+        assertEquals(validBounds(), bounds);
+    }
+
+    @Test
+    void 필터_정규화는_bounds를_검증하지_않는다() {
+        HousingComplexSearchRequest request = request(" 행복 단지 ", true, null);
+
+        HousingComplexFilterCondition filters = normalizer.normalizeFilters(request);
+
+        assertEquals("행복 단지", filters.keyword());
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(booleans = {true, false})
+    void 필터를_정규화하며_모집중_공고_여부의_세_상태를_보존한다(
+            Boolean hasActiveAnnouncement
+    ) {
+        HousingComplexSearchRequest request = request(" 행복 단지 ", hasActiveAnnouncement, null);
+
+        HousingComplexFilterCondition filters = normalizer.normalizeFilters(request);
+
+        assertAll(
+                () -> assertEquals("행복 단지", filters.keyword()),
+                () -> assertNull(filters.provinceCode()),
+                () -> assertEquals(Set.of("12210", "29110"), filters.cityCountyDistrictCodes()),
+                () -> assertEquals(Set.of(RentalType.HAPPY_HOUSING, RentalType.NATIONAL_RENTAL),
+                        filters.rentalTypes()),
+                () -> assertEquals(Set.of(ApplicationStatus.APPLYING, ApplicationStatus.CLOSED),
+                        filters.applicationStatuses()),
+                () -> assertEquals(Set.of(AgencyCode.LH, AgencyCode.SH), filters.agencyCodes()),
+                () -> assertEquals(Set.of(RecruitmentType.NEW, RecruitmentType.WAITLIST),
+                        filters.recruitmentTypes()),
+                () -> assertEquals(new BigDecimal("10000000"), filters.minDeposit()),
+                () -> assertEquals(new BigDecimal("70000000"), filters.maxDeposit()),
+                () -> assertEquals(new BigDecimal("100000"), filters.minMonthlyRent()),
+                () -> assertEquals(new BigDecimal("300000"), filters.maxMonthlyRent()),
+                () -> assertEquals(new BigDecimal("36.12"), filters.minExclusiveArea()),
+                () -> assertEquals(new BigDecimal("44.87"), filters.maxExclusiveArea()),
+                () -> assertEquals(2018, filters.builtYearFrom()),
+                () -> assertEquals(2026, filters.builtYearTo()),
+                () -> assertEquals(true, filters.hasElevator()),
+                () -> assertEquals(hasActiveAnnouncement, filters.hasActiveAnnouncement()),
+                () -> assertEquals(LocalDate.of(2026, 8, 27), filters.today()),
+                () -> assertThrows(UnsupportedOperationException.class,
+                        () -> filters.rentalTypes().add(RentalType.ETC))
+        );
+    }
+
+    @Test
+    void null_요청은_bounds와_필터_정규화에서_각각_거부한다() {
+        assertAll(
+                () -> assertThrows(InvalidComplexRequestException.class,
+                        () -> normalizer.normalizeBounds(null)),
+                () -> assertThrows(InvalidComplexRequestException.class,
+                        () -> normalizer.normalizeFilters(null))
+        );
+    }
+
+    private HousingComplexSearchRequest request(
+            String keyword,
+            Boolean hasActiveAnnouncement,
+            MapBounds bounds
+    ) {
+        return new HousingComplexSearchRequest(
+                keyword,
+                "12210",
+                List.of(RentalType.HAPPY_HOUSING, RentalType.NATIONAL_RENTAL),
+                List.of(ApplicationStatus.APPLYING, ApplicationStatus.CLOSED),
+                List.of(AgencyCode.LH, AgencyCode.SH),
+                List.of(RecruitmentType.NEW, RecruitmentType.WAITLIST),
+                10_000_000L,
+                70_000_000L,
+                100_000L,
+                300_000L,
+                new BigDecimal("36.12"),
+                new BigDecimal("44.87"),
+                2018,
+                2026,
+                true,
+                coordinate(bounds, MapBounds::southWestLat),
+                coordinate(bounds, MapBounds::southWestLng),
+                coordinate(bounds, MapBounds::northEastLat),
+                coordinate(bounds, MapBounds::northEastLng),
+                hasActiveAnnouncement
+        );
+    }
+
+    private BigDecimal coordinate(MapBounds bounds, Coordinate coordinate) {
+        if (bounds == null) {
+            return null;
+        }
+        return coordinate.from(bounds);
+    }
+
+    private MapBounds validBounds() {
+        return MapBounds.of(
+                new BigDecimal("37.400000"),
+                new BigDecimal("126.800000"),
+                new BigDecimal("37.600000"),
+                new BigDecimal("127.100000")
+        );
+    }
+
+    @FunctionalInterface
+    private interface Coordinate {
+
+        BigDecimal from(MapBounds bounds);
+    }
+}

--- a/backend/src/test/java/com/toadzip/backend/region/service/RegionQueryServiceTest.java
+++ b/backend/src/test/java/com/toadzip/backend/region/service/RegionQueryServiceTest.java
@@ -35,6 +35,16 @@ class RegionQueryServiceTest {
         ));
     }
 
+    @Test
+    void 검색어의_연속_공백을_하나로_정규화한다() {
+        RecordingRegionSearchRepository repository = new RecordingRegionSearchRepository();
+        RegionQueryService service = new RegionQueryService(repository);
+
+        service.searchRegions("  서울    중구  ");
+
+        assertEquals("서울 중구", repository.keyword);
+    }
+
     private static class SeoulOnlyRegionSearchRepository implements RegionSearchRepository {
 
         @Override
@@ -45,6 +55,17 @@ class RegionQueryServiceTest {
                         new RegionSearchResult("11110", "서울특별시", "종로구", "서울특별시 종로구")
                 );
             }
+            return List.of();
+        }
+    }
+
+    private static class RecordingRegionSearchRepository implements RegionSearchRepository {
+
+        private String keyword;
+
+        @Override
+        public List<RegionSearchResult> findByKeyword(String normalizedKeyword) {
+            keyword = normalizedKeyword;
             return List.of();
         }
     }

--- a/backend/src/test/java/com/toadzip/backend/search/controller/IntegratedSearchControllerTest.java
+++ b/backend/src/test/java/com/toadzip/backend/search/controller/IntegratedSearchControllerTest.java
@@ -37,20 +37,17 @@ class IntegratedSearchControllerTest {
         when(service.search(any())).thenReturn(new IntegratedSearchResponse(
                 "서울",
                 List.of(),
+                List.of(),
                 List.of(new SearchResultItemResponse(
                         SearchType.REGION,
                         "11",
                         "서울특별시 전체",
                         "서울특별시",
-                        "서울특별시 전체",
-                        "행정구역",
                         null,
                         null,
                         null,
                         null,
-                        false,
-                        "11",
-                        0
+                        "11"
                 )),
                 List.of(),
                 0,
@@ -65,10 +62,11 @@ class IntegratedSearchControllerTest {
                         .param("size", "20"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.query").value("서울"))
-                .andExpect(jsonPath("$.data.housingInformation.length()").value(0))
-                .andExpect(jsonPath("$.data.locations[0].type").value("REGION"))
-                .andExpect(jsonPath("$.data.locations[0].title").value("서울특별시 전체"))
-                .andExpect(jsonPath("$.data.locations[0].regionCode").value("11"))
+                .andExpect(jsonPath("$.data.announcements.length()").value(0))
+                .andExpect(jsonPath("$.data.complexes.length()").value(0))
+                .andExpect(jsonPath("$.data.regions[0].type").value("REGION"))
+                .andExpect(jsonPath("$.data.regions[0].title").value("서울특별시 전체"))
+                .andExpect(jsonPath("$.data.regions[0].regionCode").value("11"))
                 .andExpect(jsonPath("$.data.failures.length()").value(0))
                 .andExpect(jsonPath("$.data.size").value(8));
     }

--- a/backend/src/test/java/com/toadzip/backend/search/controller/IntegratedSearchControllerTest.java
+++ b/backend/src/test/java/com/toadzip/backend/search/controller/IntegratedSearchControllerTest.java
@@ -1,0 +1,87 @@
+package com.toadzip.backend.search.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.toadzip.backend.search.domain.SearchType;
+import com.toadzip.backend.search.dto.response.IntegratedSearchResponse;
+import com.toadzip.backend.search.dto.response.SearchResultItemResponse;
+import com.toadzip.backend.search.exception.InvalidSearchRequestException;
+import com.toadzip.backend.search.service.IntegratedSearchService;
+import java.math.BigDecimal;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(IntegratedSearchController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@Import(SearchExceptionAdvice.class)
+class IntegratedSearchControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private IntegratedSearchService service;
+
+    @Test
+    void 입력중_통합_검색_계약을_반환한다() throws Exception {
+        when(service.search(any())).thenReturn(new IntegratedSearchResponse(
+                "서울",
+                List.of(),
+                List.of(new SearchResultItemResponse(
+                        SearchType.REGION,
+                        "11",
+                        "서울특별시 전체",
+                        "서울특별시",
+                        "서울특별시 전체",
+                        "행정구역",
+                        null,
+                        null,
+                        null,
+                        null,
+                        false,
+                        "11",
+                        0
+                )),
+                List.of(),
+                0,
+                8,
+                false
+        ));
+
+        mockMvc.perform(get("/api/v1/search")
+                        .param("query", "서울")
+                        .param("preview", "true")
+                        .param("page", "0")
+                        .param("size", "20"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.query").value("서울"))
+                .andExpect(jsonPath("$.data.housingInformation.length()").value(0))
+                .andExpect(jsonPath("$.data.locations[0].type").value("REGION"))
+                .andExpect(jsonPath("$.data.locations[0].title").value("서울특별시 전체"))
+                .andExpect(jsonPath("$.data.locations[0].regionCode").value("11"))
+                .andExpect(jsonPath("$.data.failures.length()").value(0))
+                .andExpect(jsonPath("$.data.size").value(8));
+    }
+
+    @Test
+    void 잘못된_검색어는_고정된_오류_계약을_반환한다() throws Exception {
+        when(service.search(any())).thenThrow(new InvalidSearchRequestException(
+                "검색어는 공백 제외 2자 이상 50자 이하여야 한다."
+        ));
+
+        mockMvc.perform(get("/api/v1/search").param("query", "서"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_SEARCH_REQUEST"))
+                .andExpect(jsonPath("$.traceId").isNotEmpty());
+    }
+}

--- a/backend/src/test/java/com/toadzip/backend/search/domain/SearchMatchTest.java
+++ b/backend/src/test/java/com/toadzip/backend/search/domain/SearchMatchTest.java
@@ -1,0 +1,26 @@
+package com.toadzip.backend.search.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class SearchMatchTest {
+
+    @Test
+    void 앞뒤와_연속_공백을_정규화하고_모든_단어가_있어야_일치한다() {
+        SearchMatch match = SearchMatch.from("  서울    행복  ");
+
+        assertEquals("서울 행복", match.normalizedQuery());
+        assertTrue(match.matches("서울 강남구", "행복주택"));
+        assertFalse(match.matches("서울 강남구", "국민임대"));
+    }
+
+    @Test
+    void 완전_일치_시작_일치_부분_일치_순으로_등급을_계산한다() {
+        assertEquals(0, SearchMatch.from("서울").rank("서울"));
+        assertEquals(1, SearchMatch.from("서울").rank("서울특별시"));
+        assertEquals(2, SearchMatch.from("서울").rank("동대문 서울 주택"));
+    }
+}

--- a/backend/src/test/java/com/toadzip/backend/search/repository/InternalSearchRepositoryTest.java
+++ b/backend/src/test/java/com/toadzip/backend/search/repository/InternalSearchRepositoryTest.java
@@ -57,7 +57,7 @@ class InternalSearchRepositoryTest {
 
         assertThat(results).extracting(SearchSourceItem::id)
                 .containsExactlyInAnyOrder(correction.getId().toString(), cancellation.getId().toString());
-        assertThat(results).filteredOn(SearchSourceItem::cancelled)
+        assertThat(results).filteredOn(result -> "CANCELLED".equals(result.applicationStatus()))
                 .singleElement()
                 .extracting(SearchSourceItem::applicationStatus)
                 .isEqualTo("CANCELLED");

--- a/backend/src/test/java/com/toadzip/backend/search/repository/InternalSearchRepositoryTest.java
+++ b/backend/src/test/java/com/toadzip/backend/search/repository/InternalSearchRepositoryTest.java
@@ -1,0 +1,177 @@
+package com.toadzip.backend.search.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.toadzip.backend.announcement.domain.Announcement;
+import com.toadzip.backend.announcement.domain.ApplicationStatus;
+import com.toadzip.backend.announcement.domain.ReceptionPlace;
+import com.toadzip.backend.announcement.domain.SupplyCategory;
+import com.toadzip.backend.announcement.domain.SupplyRow;
+import com.toadzip.backend.housing.domain.Address;
+import com.toadzip.backend.housing.domain.HousingComplex;
+import com.toadzip.backend.search.domain.SearchMatch;
+import jakarta.persistence.EntityManager;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
+@Import(InternalSearchRepository.class)
+class InternalSearchRepositoryTest {
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Autowired
+    private InternalSearchRepository repository;
+
+    @Test
+    void 모든_단어를_포함하는_최신_정정과_취소_공고만_검색한다() {
+        HousingComplex complex = persistComplex("서울 행복 단지", "37.5", "126.9");
+        Announcement original = persistAnnouncement(null, "ORIGINAL", "서울 행복 원공고", "original");
+        persistSupplyRow(original, complex, "original-row");
+        Announcement correction = persistAnnouncement(
+                original, "CORRECTION", "서울 행복 정정공고", "correction"
+        );
+        persistSupplyRow(correction, complex, "correction-row");
+        Announcement cancelledOriginal = persistAnnouncement(
+                null, "ORIGINAL", "서울 행복 다른 공고", "cancelled-original"
+        );
+        persistSupplyRow(cancelledOriginal, complex, "cancelled-original-row");
+        Announcement cancellation = persistAnnouncement(
+                cancelledOriginal, "CANCELLATION", "서울 행복 취소공고", "cancellation"
+        );
+        persistSupplyRow(cancellation, complex, "cancellation-row");
+        entityManager.flush();
+
+        var results = repository.findAnnouncements(condition("서울 행복", Set.of()), 20);
+
+        assertThat(results).extracting(SearchSourceItem::id)
+                .containsExactlyInAnyOrder(correction.getId().toString(), cancellation.getId().toString());
+        assertThat(results).filteredOn(SearchSourceItem::cancelled)
+                .singleElement()
+                .extracting(SearchSourceItem::applicationStatus)
+                .isEqualTo("CANCELLED");
+        assertThat(results).allSatisfy(result -> {
+            assertThat(result.latitude()).isEqualByComparingTo("37.5");
+            assertThat(result.longitude()).isEqualByComparingTo("126.9");
+        });
+    }
+
+    @Test
+    void 공고가_없는_단지도_검색하고_취소_필터는_최신_취소공고_단지에만_적용한다() {
+        HousingComplex withoutAnnouncement = persistComplex("서울 행복 무공고", "37.5", "126.9");
+        HousingComplex cancelled = persistComplex("서울 행복 취소", "37.51", "126.91");
+        Announcement original = persistAnnouncement(null, "ORIGINAL", "취소 전", "complex-original");
+        persistSupplyRow(original, cancelled, "complex-original-row");
+        Announcement cancellation = persistAnnouncement(
+                original, "CANCELLATION", "취소 후", "complex-cancellation"
+        );
+        persistSupplyRow(cancellation, cancelled, "complex-cancellation-row");
+        entityManager.flush();
+
+        assertThat(repository.findComplexes(condition("서울 행복", Set.of()), 20))
+                .extracting(SearchSourceItem::id)
+                .containsExactlyInAnyOrder(
+                        withoutAnnouncement.getId().toString(),
+                        cancelled.getId().toString()
+                );
+        assertThat(repository.findComplexes(
+                condition("서울 행복", Set.of(ApplicationStatus.CANCELLED)),
+                20
+        )).extracting(SearchSourceItem::id).containsExactly(cancelled.getId().toString());
+    }
+
+    private IntegratedSearchCondition condition(String query, Set<ApplicationStatus> statuses) {
+        return new IntegratedSearchCondition(
+                SearchMatch.from(query),
+                Set.of(),
+                statuses,
+                null,
+                LocalDate.of(2026, 9, 1)
+        );
+    }
+
+    private HousingComplex persistComplex(String name, String latitude, String longitude) {
+        HousingComplex complex = HousingComplex.create(
+                name,
+                "source-" + name,
+                "행복주택",
+                Address.create(
+                        "서울특별시 중구 세종대로 110",
+                        "1114010100100010000",
+                        "1114010100",
+                        "11",
+                        "11140",
+                        new BigDecimal(latitude),
+                        new BigDecimal(longitude)
+                ),
+                100,
+                "LH",
+                LocalDate.of(2020, 1, 1),
+                null,
+                null,
+                null,
+                true,
+                80,
+                null,
+                null
+        );
+        entityManager.persist(complex);
+        return complex;
+    }
+
+    private Announcement persistAnnouncement(
+            Announcement previous,
+            String status,
+            String name,
+            String suffix
+    ) {
+        Announcement announcement = Announcement.create(
+                "source-" + suffix,
+                previous == null ? null : previous.getSourceAnnouncementIdentifier(),
+                previous,
+                name,
+                status,
+                "행복주택",
+                "신규모집",
+                "LH",
+                LocalDate.of(2026, 8, 1),
+                LocalDate.of(2026, 8, 10),
+                LocalDate.of(2026, 8, 20),
+                LocalDate.of(2026, 9, 1),
+                "https://example.com/" + suffix,
+                null,
+                0,
+                ReceptionPlace.create("LH 청약센터", "인터넷", null, null, null)
+        );
+        entityManager.persist(announcement);
+        return announcement;
+    }
+
+    private void persistSupplyRow(Announcement announcement, HousingComplex complex, String sourceId) {
+        entityManager.persist(SupplyRow.create(
+                announcement,
+                complex,
+                null,
+                sourceId,
+                1,
+                complex.getName(),
+                "36A",
+                "1114010100100010000",
+                YearMonth.of(2027, 3),
+                SupplyCategory.NEW_SUPPLY,
+                null,
+                10
+        ));
+    }
+}

--- a/backend/src/test/java/com/toadzip/backend/search/service/IntegratedSearchServiceTest.java
+++ b/backend/src/test/java/com/toadzip/backend/search/service/IntegratedSearchServiceTest.java
@@ -2,6 +2,7 @@ package com.toadzip.backend.search.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -62,11 +63,11 @@ class IntegratedSearchServiceTest {
 
         IntegratedSearchResponse response = service.search(request("서울"));
 
-        assertEquals(8, response.housingInformation().size() + response.locations().size());
+        assertEquals(8, response.announcements().size() + response.complexes().size() + response.regions().size());
         assertTrue(count(response, SearchType.ANNOUNCEMENT) <= 3);
         assertTrue(count(response, SearchType.COMPLEX) <= 3);
         assertTrue(count(response, SearchType.REGION) <= 3);
-        assertEquals("서울", response.housingInformation().getFirst().title());
+        assertEquals("서울", response.announcements().getFirst().title());
     }
 
     @Test
@@ -78,9 +79,29 @@ class IntegratedSearchServiceTest {
 
         IntegratedSearchResponse response = service.search(request("서울"));
 
-        assertEquals(1, response.housingInformation().size());
+        assertEquals(1, response.announcements().size());
         assertEquals(1, response.failures().size());
         assertEquals(SearchType.REGION, response.failures().getFirst().type());
+    }
+
+    @Test
+    void 한_유형에_미리보기_제한보다_결과가_많으면_전체_결과가_있음을_알린다() {
+        when(internalRepository.findAnnouncements(any(), anyInt())).thenReturn(List.of());
+        List<SearchSourceItem> complexes = List.of(
+                item(SearchType.COMPLEX, "1", "서울 단지 1"),
+                item(SearchType.COMPLEX, "2", "서울 단지 2"),
+                item(SearchType.COMPLEX, "3", "서울 단지 3"),
+                item(SearchType.COMPLEX, "4", "서울 단지 4")
+        );
+        when(internalRepository.findComplexes(any(), anyInt())).thenAnswer(invocation -> {
+            int limit = invocation.getArgument(1);
+            return complexes.subList(0, Math.min(limit, complexes.size()));
+        });
+
+        IntegratedSearchResponse response = service.search(request("서울"));
+
+        assertEquals(3, response.complexes().size());
+        assertTrue(response.hasNext());
     }
 
     @Test
@@ -94,10 +115,18 @@ class IntegratedSearchServiceTest {
         IntegratedSearchResponse first = service.search(fullRequest("서울", 0));
         IntegratedSearchResponse second = service.search(fullRequest("서울", 1));
 
-        assertEquals(20, first.housingInformation().size());
+        assertEquals(20, first.announcements().size());
         assertTrue(first.hasNext());
-        assertEquals(5, second.housingInformation().size());
+        assertEquals(5, second.announcements().size());
         assertFalse(second.hasNext());
+    }
+
+    @Test
+    void 과도한_페이지_요청을_거부한다() {
+        assertThrows(
+                com.toadzip.backend.search.exception.InvalidSearchRequestException.class,
+                () -> service.search(fullRequest("서울", Integer.MAX_VALUE))
+        );
     }
 
     private IntegratedSearchRequest request(String query) {
@@ -110,7 +139,7 @@ class IntegratedSearchServiceTest {
 
     private SearchSourceItem item(SearchType type, String id, String title) {
         return new SearchSourceItem(
-                type, id, title, "대한민국", "대한민국", type.name(), null, null, null, null, false, null
+                type, id, title, "대한민국", "대한민국", null, null, null, null, null
         );
     }
 
@@ -119,9 +148,8 @@ class IntegratedSearchServiceTest {
     }
 
     private long count(IntegratedSearchResponse response, SearchType type) {
-        return java.util.stream.Stream.concat(
-                response.housingInformation().stream(),
-                response.locations().stream()
-        ).filter(item -> item.type() == type).count();
+        return java.util.stream.Stream.of(
+                response.announcements(), response.complexes(), response.regions()
+        ).flatMap(List::stream).filter(item -> item.type() == type).count();
     }
 }

--- a/backend/src/test/java/com/toadzip/backend/search/service/IntegratedSearchServiceTest.java
+++ b/backend/src/test/java/com/toadzip/backend/search/service/IntegratedSearchServiceTest.java
@@ -1,0 +1,127 @@
+package com.toadzip.backend.search.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.toadzip.backend.region.repository.RegionSearchRepository;
+import com.toadzip.backend.region.repository.RegionSearchResult;
+import com.toadzip.backend.search.domain.SearchType;
+import com.toadzip.backend.search.dto.request.IntegratedSearchRequest;
+import com.toadzip.backend.search.dto.response.IntegratedSearchResponse;
+import com.toadzip.backend.search.repository.InternalSearchRepository;
+import com.toadzip.backend.search.repository.SearchSourceItem;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class IntegratedSearchServiceTest {
+
+    private InternalSearchRepository internalRepository;
+    private RegionSearchRepository regionRepository;
+    private IntegratedSearchService service;
+
+    @BeforeEach
+    void setUp() {
+        internalRepository = mock(InternalSearchRepository.class);
+        regionRepository = mock(RegionSearchRepository.class);
+        service = new IntegratedSearchService(
+                internalRepository,
+                regionRepository,
+                Clock.fixed(Instant.parse("2026-09-01T00:00:00Z"), ZoneOffset.UTC)
+        );
+        when(regionRepository.findByKeyword(any())).thenReturn(List.of());
+    }
+
+    @Test
+    void 입력중_결과는_전체_여덟개와_유형별_세개를_넘지_않고_일치도순이다() {
+        when(internalRepository.findAnnouncements(any(), anyInt())).thenReturn(List.of(
+                item(SearchType.ANNOUNCEMENT, "1", "서울"),
+                item(SearchType.ANNOUNCEMENT, "2", "서울 행복주택"),
+                item(SearchType.ANNOUNCEMENT, "3", "강남 서울주택"),
+                item(SearchType.ANNOUNCEMENT, "4", "마포 서울주택")
+        ));
+        when(internalRepository.findComplexes(any(), anyInt())).thenReturn(List.of(
+                item(SearchType.COMPLEX, "1", "서울"),
+                item(SearchType.COMPLEX, "2", "서울 단지"),
+                item(SearchType.COMPLEX, "3", "강동 서울단지"),
+                item(SearchType.COMPLEX, "4", "은평 서울단지")
+        ));
+        when(regionRepository.findByKeyword("서울")).thenReturn(List.of(
+                region("11", "서울특별시"),
+                region("11110", "서울특별시 종로구"),
+                region("11140", "서울특별시 중구")
+        ));
+
+        IntegratedSearchResponse response = service.search(request("서울"));
+
+        assertEquals(8, response.housingInformation().size() + response.locations().size());
+        assertTrue(count(response, SearchType.ANNOUNCEMENT) <= 3);
+        assertTrue(count(response, SearchType.COMPLEX) <= 3);
+        assertTrue(count(response, SearchType.REGION) <= 3);
+        assertEquals("서울", response.housingInformation().getFirst().title());
+    }
+
+    @Test
+    void 지역_검색만_실패하면_주택_결과와_실패_유형을_함께_반환한다() {
+        when(internalRepository.findAnnouncements(any(), anyInt()))
+                .thenReturn(List.of(item(SearchType.ANNOUNCEMENT, "1", "서울 공고")));
+        when(internalRepository.findComplexes(any(), anyInt())).thenReturn(List.of());
+        when(regionRepository.findByKeyword(any())).thenThrow(new IllegalStateException("지역 실패"));
+
+        IntegratedSearchResponse response = service.search(request("서울"));
+
+        assertEquals(1, response.housingInformation().size());
+        assertEquals(1, response.failures().size());
+        assertEquals(SearchType.REGION, response.failures().getFirst().type());
+    }
+
+    @Test
+    void 전체_결과는_페이지당_스물개를_반환한다() {
+        List<SearchSourceItem> announcements = java.util.stream.IntStream.rangeClosed(1, 25)
+                .mapToObj(index -> item(SearchType.ANNOUNCEMENT, String.valueOf(index), "서울 공고 " + index))
+                .toList();
+        when(internalRepository.findAnnouncements(any(), anyInt())).thenReturn(announcements);
+        when(internalRepository.findComplexes(any(), anyInt())).thenReturn(List.of());
+
+        IntegratedSearchResponse first = service.search(fullRequest("서울", 0));
+        IntegratedSearchResponse second = service.search(fullRequest("서울", 1));
+
+        assertEquals(20, first.housingInformation().size());
+        assertTrue(first.hasNext());
+        assertEquals(5, second.housingInformation().size());
+        assertFalse(second.hasNext());
+    }
+
+    private IntegratedSearchRequest request(String query) {
+        return new IntegratedSearchRequest(query, true, 0, 20, List.of(), List.of(), null);
+    }
+
+    private IntegratedSearchRequest fullRequest(String query, int page) {
+        return new IntegratedSearchRequest(query, false, page, 20, List.of(), List.of(), null);
+    }
+
+    private SearchSourceItem item(SearchType type, String id, String title) {
+        return new SearchSourceItem(
+                type, id, title, "대한민국", "대한민국", type.name(), null, null, null, null, false, null
+        );
+    }
+
+    private RegionSearchResult region(String code, String displayName) {
+        return new RegionSearchResult(code, "서울특별시", null, displayName);
+    }
+
+    private long count(IntegratedSearchResponse response, SearchType type) {
+        return java.util.stream.Stream.concat(
+                response.housingInformation().stream(),
+                response.locations().stream()
+        ).filter(item -> item.type() == type).count();
+    }
+}

--- a/docs/INTEGRATED_SEARCH.md
+++ b/docs/INTEGRATED_SEARCH.md
@@ -1,0 +1,25 @@
+# 통합 검색 API
+
+## 검색
+
+`GET /api/v1/search`
+
+| 파라미터 | 설명 |
+| --- | --- |
+| `query` | 공백 제외 2자 이상의 검색어 |
+| `preview` | `true`면 입력 중 결과 8개, 유형별 3개 제한 |
+| `page` | 0부터 시작하는 전체 결과 페이지 |
+| `size` | 전체 결과는 20으로 고정 |
+| `rentalTypes` | 임대 유형 필터 |
+| `applicationStatuses` | 모집 상태 필터 |
+| `hasActiveAnnouncement` | 모집 중 공고가 있는 단지 필터 |
+
+응답은 `data.housingInformation`에 공고·단지, `data.locations`에 지역을 담는다.
+일부 유형만 실패하면 성공 결과를 유지하고 `data.failures`에 실패 유형과 재시도 메시지를 담는다.
+잘못된 검색 요청은 `400 INVALID_SEARCH_REQUEST`를 반환한다.
+
+## 지역 단지 조회
+
+`GET /api/v1/complexes` 또는 `GET /api/v1/complexes/map`에 `regionCode`를 보낸다.
+
+지도와 목록에는 같은 행정구역과 필터를 적용한다.

--- a/docs/INTEGRATED_SEARCH.md
+++ b/docs/INTEGRATED_SEARCH.md
@@ -8,13 +8,13 @@
 | --- | --- |
 | `query` | 공백 제외 2자 이상의 검색어 |
 | `preview` | `true`면 입력 중 결과 8개, 유형별 3개 제한 |
-| `page` | 0부터 시작하는 전체 결과 페이지 |
+| `page` | 0부터 100까지의 전체 결과 페이지 |
 | `size` | 전체 결과는 20으로 고정 |
 | `rentalTypes` | 임대 유형 필터 |
 | `applicationStatuses` | 모집 상태 필터 |
 | `hasActiveAnnouncement` | 모집 중 공고가 있는 단지 필터 |
 
-응답은 `data.housingInformation`에 공고·단지, `data.locations`에 지역을 담는다.
+응답은 `data.announcements`, `data.complexes`, `data.regions`에 유형별 결과를 담는다.
 일부 유형만 실패하면 성공 결과를 유지하고 `data.failures`에 실패 유형과 재시도 메시지를 담는다.
 잘못된 검색 요청은 `400 INVALID_SEARCH_REQUEST`를 반환한다.
 

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -27,6 +27,9 @@ describe('App', () => {
     expect(screen.getByRole('banner', { name: '서비스 헤더' })).toBeVisible()
     expect(screen.getByRole('link', { name: '두꺼비집 홈' })).toBeVisible()
     expect(
+      screen.getByRole('searchbox', { name: '공고, 단지, 지역 검색' }),
+    ).toBeVisible()
+    expect(
       screen.getByRole('region', { name: '공공임대주택 지도' }),
     ).toBeVisible()
     expect(screen.getByRole('alert')).toHaveTextContent(

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -14,6 +14,98 @@
   --surface: #ffffff;
 }
 
+.integrated-search {
+  display: grid;
+  gap: 0.65rem;
+  padding: 0 1rem 1rem;
+}
+
+.integrated-search.is-active {
+  min-height: 0;
+  flex: 1;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+}
+
+.integrated-search__input input {
+  width: 100%;
+  border: 1px solid #cbd5e1;
+  border-radius: 0.75rem;
+  padding: 0.75rem 0.9rem;
+  font: inherit;
+}
+
+.integrated-search__hint {
+  margin: 0;
+  color: #64748b;
+  font-size: 0.8rem;
+}
+
+.integrated-search__results {
+  max-height: 22rem;
+  overflow: auto;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.75rem;
+  background: #fff;
+}
+
+.integrated-search.is-active .integrated-search__results {
+  max-height: none;
+}
+
+.integrated-search__results h2 {
+  margin: 0;
+  padding: 0.65rem 0.75rem 0.35rem;
+  color: #475569;
+  font-size: 0.75rem;
+}
+
+.integrated-search__results ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.integrated-search__results li button {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0.2rem 0.6rem;
+  width: 100%;
+  border: 0;
+  border-top: 1px solid #f1f5f9;
+  padding: 0.65rem 0.75rem;
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
+}
+
+.integrated-search__results li button:hover,
+.integrated-search__results li button:focus-visible {
+  background: #f0fdf4;
+}
+
+.integrated-search__results li span,
+.integrated-search__results li time {
+  color: #64748b;
+  font-size: 0.75rem;
+}
+
+.integrated-search__partial-error {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.6rem 0.75rem;
+  color: #9f1239;
+  font-size: 0.75rem;
+}
+
+.integrated-search__pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+}
+
 * {
   box-sizing: border-box;
 }

--- a/frontend/src/maps/naver/NaverMap.test.tsx
+++ b/frontend/src/maps/naver/NaverMap.test.tsx
@@ -36,6 +36,7 @@ interface FakeSdk {
   markerSetMap: ReturnType<typeof vi.fn>
   markerSetZIndex: ReturnType<typeof vi.fn>
   maps: typeof naver.maps
+  morphMap: ReturnType<typeof vi.fn>
   panToMap: ReturnType<typeof vi.fn>
   removeListener: ReturnType<typeof vi.fn>
   setCurrentZoom: (zoom: number) => void
@@ -52,6 +53,10 @@ function createFakeSdk(): FakeSdk {
   const autoResizeMap = vi.fn()
   const panToMap = vi.fn((coordinate: unknown) => {
     currentCenter = coordinate as typeof currentCenter
+  })
+  const morphMap = vi.fn((coordinate: unknown, zoom: number) => {
+    currentCenter = coordinate as typeof currentCenter
+    currentZoom = zoom
   })
   const setZoomMap = vi.fn((zoom: number) => {
     currentZoom = zoom
@@ -89,6 +94,7 @@ function createFakeSdk(): FakeSdk {
     getMinZoom: getMinZoomMap,
     getProjection: () => ({ fromCoordToOffset }),
     getZoom: () => currentZoom,
+    morph: morphMap,
     panTo: panToMap,
     setZoom: setZoomMap,
   }
@@ -170,6 +176,7 @@ function createFakeSdk(): FakeSdk {
     markerConstructor,
     markerSetMap,
     markerSetZIndex,
+    morphMap,
     maps: {
       Event: {
         addListener,
@@ -394,6 +401,29 @@ describe('NaverMap', () => {
     expect(fakeSdk.setZoomMap).toHaveBeenCalledOnce()
     expect(fakeSdk.setZoomMap).toHaveBeenLastCalledWith(16)
     expect(fakeSdk.mapConstructor).toHaveBeenCalledOnce()
+  })
+
+  it('좌표와 확대 수준이 함께 바뀌면 한 번의 카메라 이동으로 적용한다', async () => {
+    const fakeSdk = createFakeSdk()
+    loadNaverMapsSdkMock.mockResolvedValue(fakeSdk.maps)
+
+    const { rerender } = render(
+      <NaverMap
+        cameraTarget={{ latitude: 37.51, longitude: 127.02, zoom: 14 }}
+      />,
+    )
+
+    await waitFor(() => expect(fakeSdk.mapConstructor).toHaveBeenCalledOnce())
+
+    rerender(
+      <NaverMap
+        cameraTarget={{ latitude: 35.18, longitude: 129.08, zoom: 16 }}
+      />,
+    )
+
+    expect(fakeSdk.morphMap).toHaveBeenCalledOnce()
+    expect(fakeSdk.panToMap).not.toHaveBeenCalled()
+    expect(fakeSdk.setZoomMap).not.toHaveBeenCalled()
   })
 
   it('URL 직렬화 정밀도 안의 camera 차이는 무시하고 더 큰 차이만 적용한다', async () => {

--- a/frontend/src/maps/naver/NaverMap.test.tsx
+++ b/frontend/src/maps/naver/NaverMap.test.tsx
@@ -426,6 +426,25 @@ describe('NaverMap', () => {
     expect(fakeSdk.setZoomMap).not.toHaveBeenCalled()
   })
 
+  it('같은 검색 결과를 다시 선택하면 동일한 위치로 카메라를 다시 이동한다', async () => {
+    const fakeSdk = createFakeSdk()
+    loadNaverMapsSdkMock.mockResolvedValue(fakeSdk.maps)
+    const cameraTarget = { latitude: 37.51, longitude: 127.02, zoom: 16 }
+
+    const { rerender } = render(
+      <NaverMap cameraRequestId={1} cameraTarget={cameraTarget} />,
+    )
+    await waitFor(() => expect(fakeSdk.mapConstructor).toHaveBeenCalledOnce())
+
+    rerender(<NaverMap cameraRequestId={2} cameraTarget={cameraTarget} />)
+
+    expect(fakeSdk.morphMap).toHaveBeenCalledOnce()
+    expect(fakeSdk.morphMap).toHaveBeenCalledWith(
+      expect.objectContaining({ latitude: 37.51, longitude: 127.02 }),
+      16,
+    )
+  })
+
   it('URL 직렬화 정밀도 안의 camera 차이는 무시하고 더 큰 차이만 적용한다', async () => {
     const fakeSdk = createFakeSdk()
     loadNaverMapsSdkMock.mockResolvedValue(fakeSdk.maps)

--- a/frontend/src/maps/naver/NaverMap.tsx
+++ b/frontend/src/maps/naver/NaverMap.tsx
@@ -53,6 +53,7 @@ export interface NaverMapCameraTarget {
 }
 
 export interface NaverMapProps {
+  cameraRequestId?: number
   cameraTarget?: NaverMapCameraTarget
   dataBusy?: boolean
   markers?: NaverMapMarker[]
@@ -155,6 +156,7 @@ function MapUnavailable({ onRetry, reason }: MapUnavailableProps) {
 }
 
 export default function NaverMap({
+  cameraRequestId,
   cameraTarget,
   dataBusy = false,
   markers = [],
@@ -167,12 +169,15 @@ export default function NaverMap({
   const mapsRef = useRef<typeof naver.maps | null>(null)
   const cameraTargetRef = useRef(cameraTarget)
   cameraTargetRef.current = cameraTarget
+  const cameraRequestIdRef = useRef(cameraRequestId)
+  cameraRequestIdRef.current = cameraRequestId
   const createdMarkersRef = useRef<CreatedMarker[]>([])
   const markersRef = useRef(markers)
   markersRef.current = markers
   const markerOverlaysRef = useRef<naver.maps.Marker[]>([])
   const markerFocusTimerRef = useRef<number | undefined>(undefined)
   const appliedCameraTargetRef = useRef<NaverMapCameraTarget | null>(null)
+  const appliedCameraRequestIdRef = useRef<number | undefined>(undefined)
   const pendingClusterFocusRef = useRef<PendingClusterFocus | null>(null)
   const onMarkerHighlightRef = useRef(onMarkerHighlight)
   const onMarkerSelectRef = useRef(onMarkerSelect)
@@ -269,6 +274,7 @@ export default function NaverMap({
           mapInstanceRef.current = createdMap
           mapsRef.current = maps
           appliedCameraTargetRef.current = initialCamera
+          appliedCameraRequestIdRef.current = cameraRequestIdRef.current
 
           const emitViewport = () => {
             setProjectionRevision((current) => current + 1)
@@ -302,6 +308,7 @@ export default function NaverMap({
           mapInstanceRef.current = null
           mapsRef.current = null
           appliedCameraTargetRef.current = null
+          appliedCameraRequestIdRef.current = undefined
           setStatus({ kind: 'unavailable', reason: 'initialization' })
           destroyMapSafely(failedMap)
         }
@@ -325,6 +332,7 @@ export default function NaverMap({
       mapInstanceRef.current = null
       mapsRef.current = null
       appliedCameraTargetRef.current = null
+      appliedCameraRequestIdRef.current = undefined
       pendingClusterFocusRef.current = null
       destroyMapSafely(mapInstance)
     }
@@ -431,11 +439,20 @@ export default function NaverMap({
       zoom: cameraZoom,
     }
     const previousTarget = appliedCameraTargetRef.current
+    const cameraRequested = cameraRequestId !== undefined
+      && cameraRequestId !== appliedCameraRequestIdRef.current
     const coordinatesChanged = cameraCoordinatesChanged(previousTarget, nextTarget)
     const zoomChanged = cameraZoom !== undefined
       && cameraZoomChanged(previousTarget?.zoom, cameraZoom)
 
-    if (coordinatesChanged && zoomChanged) {
+    if (cameraRequested && cameraZoom !== undefined) {
+      mapInstance.morph(
+        new maps.LatLng(cameraLatitude, cameraLongitude),
+        cameraZoom,
+      )
+    } else if (cameraRequested) {
+      mapInstance.panTo(new maps.LatLng(cameraLatitude, cameraLongitude))
+    } else if (coordinatesChanged && zoomChanged) {
       mapInstance.morph(
         new maps.LatLng(cameraLatitude, cameraLongitude),
         cameraZoom,
@@ -450,7 +467,8 @@ export default function NaverMap({
       ...nextTarget,
       zoom: cameraZoom ?? previousTarget?.zoom,
     }
-  }, [cameraLatitude, cameraLongitude, cameraZoom, status.kind])
+    appliedCameraRequestIdRef.current = cameraRequestId
+  }, [cameraLatitude, cameraLongitude, cameraRequestId, cameraZoom, status.kind])
 
   const retry = () => {
     setStatus({ kind: 'loading' })

--- a/frontend/src/maps/naver/NaverMap.tsx
+++ b/frontend/src/maps/naver/NaverMap.tsx
@@ -431,15 +431,18 @@ export default function NaverMap({
       zoom: cameraZoom,
     }
     const previousTarget = appliedCameraTargetRef.current
-
-    if (cameraCoordinatesChanged(previousTarget, nextTarget)) {
-      mapInstance.panTo(new maps.LatLng(cameraLatitude, cameraLongitude))
-    }
-
-    if (
-      cameraZoom !== undefined
+    const coordinatesChanged = cameraCoordinatesChanged(previousTarget, nextTarget)
+    const zoomChanged = cameraZoom !== undefined
       && cameraZoomChanged(previousTarget?.zoom, cameraZoom)
-    ) {
+
+    if (coordinatesChanged && zoomChanged) {
+      mapInstance.morph(
+        new maps.LatLng(cameraLatitude, cameraLongitude),
+        cameraZoom,
+      )
+    } else if (coordinatesChanged) {
+      mapInstance.panTo(new maps.LatLng(cameraLatitude, cameraLongitude))
+    } else if (zoomChanged) {
       mapInstance.setZoom(cameraZoom)
     }
 

--- a/frontend/src/public-housing/PublicHousingExplorer.test.tsx
+++ b/frontend/src/public-housing/PublicHousingExplorer.test.tsx
@@ -1944,16 +1944,17 @@ function createRegionRepository(): PublicHousingRegionRepository {
 }
 
 function searchRepository(
-  housingInformation: readonly SearchResultItem[],
-  locations: readonly SearchResultItem[],
+  results: readonly SearchResultItem[],
+  regions: readonly SearchResultItem[],
 ): IntegratedSearchRepository {
   const response: IntegratedSearchResponse = {
+    announcements: results.filter(({ type }) => type === 'ANNOUNCEMENT'),
+    complexes: results.filter(({ type }) => type === 'COMPLEX'),
     failures: [],
     hasNext: false,
-    housingInformation,
-    locations,
     page: 0,
     query: '서울',
+    regions,
     size: 8,
   }
   return { search: vi.fn().mockResolvedValue(response) }
@@ -1967,10 +1968,7 @@ function searchItem(
   longitude: number | null,
 ): SearchResultItem {
   return {
-    address: '서울특별시',
     applicationStatus: null,
-    cancelled: false,
-    category: type,
     id,
     latitude,
     longitude,

--- a/frontend/src/public-housing/PublicHousingExplorer.test.tsx
+++ b/frontend/src/public-housing/PublicHousingExplorer.test.tsx
@@ -33,6 +33,11 @@ import type {
   RawMapComplex,
 } from './model/publicHousing.ts'
 import { PublicHousingExplorer } from './PublicHousingExplorer.tsx'
+import type {
+  IntegratedSearchRepository,
+  IntegratedSearchResponse,
+  SearchResultItem,
+} from './search/integratedSearchRepository.ts'
 
 vi.mock('../maps/naver/NaverMap.tsx', () => ({
   default: FakeNaverMap,
@@ -110,18 +115,18 @@ afterEach(() => {
 })
 
 describe('PublicHousingExplorer', () => {
-  it('연속 idle은 마지막 유효 영역만 300ms 뒤 요청한다', async () => {
+  it('지도 이동은 자동 조회하지 않고 이 지역에서 검색을 선택한 영역만 요청한다', async () => {
     const repository = createRepository()
     renderExplorer(repository)
 
     fireEvent.click(screen.getByRole('button', { name: '초기 영역 알림' }))
+    await screen.findByRole('heading', { name: '서울가람 행복주택' })
     fireEvent.click(screen.getByRole('button', { name: '다음 영역 알림' }))
 
-    await waitFor(() => {
-      expect(repository.findMapComplexes).toHaveBeenCalledOnce()
-      expect(repository.findComplexPage).toHaveBeenCalledOnce()
-    })
-    expect(repository.findMapComplexes).toHaveBeenCalledWith(
+    expect(repository.findMapComplexes).toHaveBeenCalledOnce()
+    fireEvent.click(screen.getByRole('button', { name: '이 지역에서 검색' }))
+    await waitFor(() => expect(repository.findMapComplexes).toHaveBeenCalledTimes(2))
+    expect(repository.findMapComplexes).toHaveBeenLastCalledWith(
       NEXT_BOUNDS,
       expect.any(AbortSignal),
     )
@@ -622,13 +627,15 @@ describe('PublicHousingExplorer', () => {
     expect(marker).toHaveAttribute('data-monthly-rent-label', '20만~30만 원')
   })
 
-  it('이후 지도 이동도 idle 뒤 자동으로 마지막 영역을 요청한다', async () => {
+  it('이후 지도 이동은 버튼을 선택할 때 같은 영역을 지도와 목록에 적용한다', async () => {
     const repository = createRepository()
     renderExplorer(repository)
 
     fireEvent.click(screen.getByRole('button', { name: '초기 영역 알림' }))
     await screen.findByRole('heading', { name: '서울가람 행복주택' })
     fireEvent.click(screen.getByRole('button', { name: '다음 영역 알림' }))
+    expect(repository.findMapComplexes).toHaveBeenCalledOnce()
+    fireEvent.click(screen.getByRole('button', { name: '이 지역에서 검색' }))
 
     await waitFor(() => {
       expect(repository.findMapComplexes).toHaveBeenCalledTimes(2)
@@ -638,9 +645,70 @@ describe('PublicHousingExplorer', () => {
       NEXT_BOUNDS,
       expect.any(AbortSignal),
     )
-    expect(screen.queryByRole('button', {
-      name: '이 지역에서 다시 찾기',
-    })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: '이 지역에서 검색' }))
+      .not.toBeInTheDocument()
+  })
+
+  it('검색 중에는 왼쪽 패널 전체에 통합 검색 결과만 표시한다', async () => {
+    const repository = createRepository()
+    const complex = searchItem('COMPLEX', '17', '서울가람 행복주택', 37.5, 126.9)
+    renderExplorer(repository, '/', false, searchRepository([complex], []))
+    fireEvent.click(screen.getByRole('button', { name: '초기 영역 알림' }))
+    await screen.findByRole('heading', { name: '서울가람 행복주택' })
+
+    fireEvent.change(screen.getByRole('searchbox'), { target: { value: '서울' } })
+
+    expect(await screen.findByRole('heading', { name: '단지' })).toBeVisible()
+    expect(screen.queryByRole('tab', { name: '단지 목록' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: '이 지역에서 검색' })).not.toBeInTheDocument()
+
+    fireEvent.change(screen.getByRole('searchbox'), { target: { value: '' } })
+
+    expect(screen.getByRole('tab', { name: '단지 목록' })).toBeVisible()
+  })
+
+  it('검색한 단지를 선택하면 해당 좌표로 이동하고 중앙 마커를 선택 강조한다', async () => {
+    const repository = createRepository()
+    const complex = searchItem('COMPLEX', '99', '검색된 행복주택', 37.5, 126.9)
+    renderExplorer(repository, '/', false, searchRepository([complex], []))
+
+    fireEvent.change(screen.getByRole('searchbox'), { target: { value: '서울가람' } })
+    fireEvent.click(await screen.findByRole('button', { name: /검색된 행복주택/ }))
+
+    expect(await screen.findByText('카메라 37.5,126.9')).toBeVisible()
+    expect(await screen.findByRole('button', {
+      name: '검색된 행복주택 지도 마커 선택',
+    })).toHaveAttribute('data-selected', 'true')
+  })
+
+  it('검색한 공고를 선택하면 연결 단지 좌표로 이동한다', async () => {
+    const repository = createRepository()
+    const announcement = searchItem('ANNOUNCEMENT', '201', '서울 행복주택 공고', 37.5, 126.9)
+    renderExplorer(repository, '/', false, searchRepository([announcement], []))
+
+    fireEvent.change(screen.getByRole('searchbox'), { target: { value: '서울 행복' } })
+    fireEvent.click(await screen.findByRole('button', { name: /서울 행복주택 공고/ }))
+
+    expect(await screen.findByText('카메라 37.5,126.9')).toBeVisible()
+  })
+
+  it('지역을 선택하면 사각형 대신 행정구역 코드 조건으로 즉시 조회한다', async () => {
+    const repository = createRepository()
+    const region = searchItem('REGION', '11', '서울특별시 전체', null, null)
+    renderExplorer(repository, '/', false, searchRepository([], [region]))
+    fireEvent.click(screen.getByRole('button', { name: '초기 영역 알림' }))
+    await screen.findByRole('heading', { name: '서울가람 행복주택' })
+
+    fireEvent.change(screen.getByRole('searchbox'), { target: { value: '서울' } })
+    fireEvent.click(await screen.findByRole('button', { name: /서울특별시 전체/ }))
+
+    await waitFor(() => expect(repository.findMapComplexes).toHaveBeenCalledTimes(2))
+    expect(repository.findMapComplexes).toHaveBeenLastCalledWith(
+      expect.any(Object),
+      expect.any(AbortSignal),
+      expect.objectContaining({ regionCode: '11' }),
+    )
+    expect(await screen.findByText('카메라 37.56,126.98')).toBeVisible()
   })
 
   it('이미 적용한 동일 request key는 다시 요청하지 않는다', async () => {
@@ -698,6 +766,7 @@ describe('PublicHousingExplorer', () => {
     fireEvent.click(screen.getByRole('button', { name: '초기 영역 알림' }))
     await screen.findByRole('heading', { name: '서울가람 행복주택' })
     fireEvent.click(screen.getByRole('button', { name: '다음 영역 알림' }))
+    fireEvent.click(screen.getByRole('button', { name: '이 지역에서 검색' }))
     await waitFor(() => {
       expect(repository.findMapComplexes).toHaveBeenCalledTimes(2)
       expect(repository.findComplexPage).toHaveBeenCalledTimes(2)
@@ -723,7 +792,7 @@ describe('PublicHousingExplorer', () => {
     })).toBeVisible()
   })
 
-  it('새 영역은 이전 요청을 abort하고 늦은 응답을 폐기한다', async () => {
+  it('조회 중 지도 이동은 기존 요청을 유지하고 버튼 선택 전 새 요청을 만들지 않는다', async () => {
     const repository = createRepository()
     const previousMap = createDeferred<readonly MapComplex[]>()
     const previousPage = createDeferred<ComplexPage>()
@@ -741,8 +810,16 @@ describe('PublicHousingExplorer', () => {
     await waitFor(() => expect(repository.findComplexPage).toHaveBeenCalledOnce())
     const previousSignal = repository.findComplexPage.mock.calls[0][3]
     fireEvent.click(screen.getByRole('button', { name: '다음 영역 알림' }))
+    expect(repository.findComplexPage).toHaveBeenCalledOnce()
+    expect(previousSignal).toHaveProperty('aborted', false)
+
+    await act(async () => {
+      previousMap.resolve([mapComplex()])
+      previousPage.resolve(complexPage())
+    })
+    await screen.findByRole('heading', { name: '서울가람 행복주택' })
+    fireEvent.click(screen.getByRole('button', { name: '이 지역에서 검색' }))
     await waitFor(() => expect(repository.findComplexPage).toHaveBeenCalledTimes(2))
-    expect(previousSignal).toHaveProperty('aborted', true)
 
     await act(async () => {
       nextMap.resolve([mapComplexFor(18, '서울마루 국민임대')])
@@ -751,14 +828,6 @@ describe('PublicHousingExplorer', () => {
     expect(await screen.findByRole('heading', {
       name: '서울마루 국민임대',
     })).toBeVisible()
-
-    await act(async () => {
-      previousMap.resolve([mapComplex()])
-      previousPage.resolve(complexPage())
-    })
-    expect(screen.queryByRole('heading', {
-      name: '서울가람 행복주택',
-    })).not.toBeInTheDocument()
   })
 
   it('새 영역 한쪽이 실패하면 직전 지도와 목록 쌍을 유지하고 재시도한다', async () => {
@@ -776,6 +845,7 @@ describe('PublicHousingExplorer', () => {
     fireEvent.click(screen.getByRole('button', { name: '초기 영역 알림' }))
     await screen.findByRole('heading', { name: '서울가람 행복주택' })
     fireEvent.click(screen.getByRole('button', { name: '다음 영역 알림' }))
+    fireEvent.click(screen.getByRole('button', { name: '이 지역에서 검색' }))
     await screen.findByText('지도 조회 실패')
 
     expect(screen.getAllByRole('alert')).toHaveLength(1)
@@ -993,6 +1063,7 @@ describe('PublicHousingExplorer', () => {
     })
 
     fireEvent.click(screen.getByRole('button', { name: '다음 영역 알림' }))
+    fireEvent.click(screen.getByRole('button', { name: '이 지역에서 검색' }))
 
     await screen.findByRole('heading', { name: '서울마루 국민임대' })
     expect(screen.getByRole('button', {
@@ -1004,6 +1075,7 @@ describe('PublicHousingExplorer', () => {
       name: '서울가람 행복주택 단지 상세 정보',
     })).not.toBeInTheDocument())
     fireEvent.click(screen.getByRole('button', { name: '초기 영역 알림' }))
+    fireEvent.click(screen.getByRole('button', { name: '이 지역에서 검색' }))
 
     const returnedMarker = await screen.findByRole('button', {
       name: '서울가람 행복주택 지도 마커 선택',
@@ -1788,7 +1860,7 @@ describe('PublicHousingExplorer', () => {
     expect(complexTab).toHaveAttribute('aria-selected', 'true')
   })
 
-  it('공고 탭에서 viewport가 자동 갱신돼도 공고는 유지한다', async () => {
+  it('공고 탭에서 현재 지도 영역을 검색해도 공고 목록은 유지한다', async () => {
     const repository = createRepository()
     renderExplorer(repository)
     fireEvent.click(screen.getByRole('button', { name: '초기 영역 알림' }))
@@ -1799,6 +1871,7 @@ describe('PublicHousingExplorer', () => {
     })
 
     fireEvent.click(screen.getByRole('button', { name: '다음 영역 알림' }))
+    fireEvent.click(screen.getByRole('button', { name: '이 지역에서 검색' }))
 
     await waitFor(() => {
       expect(repository.findMapComplexes).toHaveBeenCalledTimes(2)
@@ -1846,6 +1919,7 @@ function renderExplorer(
   repository: PublicHousingRepository,
   initialEntry = '/',
   localMockEnabled = false,
+  integratedSearchRepository?: IntegratedSearchRepository,
   regionRepository = createRegionRepository(),
 ) {
   return render(
@@ -1854,6 +1928,7 @@ function renderExplorer(
         localMockEnabled={localMockEnabled}
         regionRepository={regionRepository}
         repository={repository}
+        searchRepository={integratedSearchRepository}
       />
       <LocationSearch />
     </MemoryRouter>,
@@ -1865,6 +1940,45 @@ function createRegionRepository(): PublicHousingRegionRepository {
     search: vi.fn().mockImplementation((keyword: string) => Promise.resolve(
       TEST_REGIONS.filter(({ provinceName }) => provinceName === keyword),
     )),
+  }
+}
+
+function searchRepository(
+  housingInformation: readonly SearchResultItem[],
+  locations: readonly SearchResultItem[],
+): IntegratedSearchRepository {
+  const response: IntegratedSearchResponse = {
+    failures: [],
+    hasNext: false,
+    housingInformation,
+    locations,
+    page: 0,
+    query: '서울',
+    size: 8,
+  }
+  return { search: vi.fn().mockResolvedValue(response) }
+}
+
+function searchItem(
+  type: SearchResultItem['type'],
+  id: string,
+  title: string,
+  latitude: number | null,
+  longitude: number | null,
+): SearchResultItem {
+  return {
+    address: '서울특별시',
+    applicationStatus: null,
+    cancelled: false,
+    category: type,
+    id,
+    latitude,
+    longitude,
+    publishedAt: null,
+    regionCode: type === 'REGION' ? id : null,
+    subtitle: '서울특별시',
+    title,
+    type,
   }
 }
 

--- a/frontend/src/public-housing/PublicHousingExplorer.tsx
+++ b/frontend/src/public-housing/PublicHousingExplorer.tsx
@@ -75,9 +75,13 @@ import {
   presentComplexDetailMarker,
   presentMapComplexMarker,
 } from './presentation/mapMarkerPresentation.ts'
+import { IntegratedSearch } from './search/IntegratedSearch.tsx'
+import type {
+  IntegratedSearchRepository,
+  SearchResultItem,
+} from './search/integratedSearchRepository.ts'
 
 const PAGE_SIZE = 20
-const VIEWPORT_DEBOUNCE_MS = 300
 const DEFAULT_MAP_LOCATION = {
   center: {
     latitude: 37.5666103,
@@ -87,6 +91,12 @@ const DEFAULT_MAP_LOCATION = {
 }
 const DETAIL_HISTORY_STATE_KEY = 'toadzipDetailEntry'
 const DETAIL_RETURN_FOCUS_STACK_KEY = 'toadzipDetailReturnFocusStack'
+const KOREA_BOUNDS: MapBounds = {
+  southWestLat: 33,
+  southWestLng: 124,
+  northEastLat: 39,
+  northEastLng: 132,
+}
 
 type ResultTab = 'complexes' | 'announcements'
 
@@ -108,8 +118,13 @@ interface ComplexResultsState {
 
 interface AppliedViewport {
   readonly bounds: MapBounds
+  readonly options: ComplexSearchFilters
   readonly signature: string
 }
+
+type SearchContext =
+  | { readonly kind: 'none' }
+  | { readonly kind: 'region'; readonly regionCode: string }
 
 type DetailStatus =
   | 'closed'
@@ -152,6 +167,7 @@ export interface PublicHousingExplorerProps {
   localMockEnabled?: boolean
   regionRepository?: PublicHousingRegionRepository
   repository?: PublicHousingRepository
+  searchRepository?: IntegratedSearchRepository
 }
 
 const INITIAL_MAP_RESULTS: MapResultsState = {
@@ -186,10 +202,16 @@ export function PublicHousingExplorer({
   localMockEnabled = false,
   regionRepository = publicHousingRegionRepository,
   repository = defaultPublicHousingRepository,
+  searchRepository,
 }: PublicHousingExplorerProps) {
   const location = useLocation()
   const navigate = useNavigate()
   const [viewport, setViewport] = useState<ViewportSnapshot | null>(null)
+  const [searchContext, setSearchContext] = useState<SearchContext>({ kind: 'none' })
+  const [searchMapTarget, setSearchMapTarget] = useState<NaverMapCameraTarget | null>(null)
+  const [selectedSearchComplex, setSelectedSearchComplex] =
+    useState<SearchResultItem | null>(null)
+  const [integratedSearchActive, setIntegratedSearchActive] = useState(false)
   const [activeResultTab, setActiveResultTab] =
     useState<ResultTab>('complexes')
   const [announcementListRequested, setAnnouncementListRequested] =
@@ -224,7 +246,6 @@ export function PublicHousingExplorer({
   const requestRevisionRef = useRef(0)
   const searchAbortRef = useRef<AbortController | null>(null)
   const paginationAbortRef = useRef<AbortController | null>(null)
-  const viewportDebounceRef = useRef<number | null>(null)
   const viewportWasBlockedRef = useRef(false)
   const detailTabChangedRef = useRef(false)
   const previousDetailKindRef = useRef<ResultTab | null>(null)
@@ -717,12 +738,19 @@ export function PublicHousingExplorer({
   )
 
   const applyViewport = useCallback(
-    (nextViewport: ViewportSnapshot, force = false) => {
+    (
+      nextViewport: ViewportSnapshot,
+      force = false,
+      options: ComplexSearchFilters = complexFilters,
+    ) => {
       const decision = evaluateViewportRequest(nextViewport)
-      if (!decision.allowed) {
+      if (!decision.allowed && !options.regionCode) {
         return
       }
-      const signature = `${decision.boundsSignature}|${complexFiltersKey}`
+      const boundsSignature = decision.allowed
+        ? decision.boundsSignature
+        : JSON.stringify(nextViewport.bounds)
+      const signature = `${boundsSignature}|${searchFiltersSignature(options)}`
       if (!force && pendingViewportSignatureRef.current === signature) {
         return
       }
@@ -754,34 +782,27 @@ export function PublicHousingExplorer({
         status: 'loading',
       }))
 
-      const mapRequest = hasSearchFilters(complexFilters)
-        ? repository.findMapComplexes(
-            nextViewport.bounds,
-            controller.signal,
-            complexFilters,
-          )
-        : repository.findMapComplexes(nextViewport.bounds, controller.signal)
-      const complexRequest = hasSearchFilters(complexFilters)
-        ? repository.findComplexPage(
-            nextViewport.bounds,
-            null,
-            PAGE_SIZE,
-            controller.signal,
-            complexFilters,
-          )
-        : repository.findComplexPage(
-            nextViewport.bounds,
-            null,
-            PAGE_SIZE,
-            controller.signal,
-          )
-
-      Promise.all([mapRequest, complexRequest])
+      Promise.all([
+        findMapComplexes(
+          repository,
+          nextViewport.bounds,
+          controller.signal,
+          options,
+        ),
+        findComplexPage(
+          repository,
+          nextViewport.bounds,
+          null,
+          PAGE_SIZE,
+          controller.signal,
+          options,
+        ),
+      ])
         .then(([mapItems, page]) => {
           if (requestRevisionRef.current !== revision) {
             return
           }
-          const applied = { bounds: nextViewport.bounds, signature }
+          const applied = { bounds: nextViewport.bounds, options, signature }
           appliedViewportRef.current = applied
           failedViewportRef.current = null
           pendingViewportSignatureRef.current = null
@@ -800,6 +821,13 @@ export function PublicHousingExplorer({
           })
           setCardHighlightedComplexId(null)
           setMarkerHighlightedComplexId(null)
+          if (options.regionCode && mapItems[0]) {
+            setSearchMapTarget({
+              latitude: mapItems[0].latitude,
+              longitude: mapItems[0].longitude,
+              zoom: 13,
+            })
+          }
           if (complexResultsScrollRef.current) {
             complexResultsScrollRef.current.scrollTop = 0
           }
@@ -824,7 +852,7 @@ export function PublicHousingExplorer({
           }))
         })
     },
-    [complexFilters, complexFiltersKey, repository],
+    [complexFilters, repository],
   )
 
   const previousComplexFiltersKeyRef = useRef(complexFiltersKey)
@@ -847,32 +875,78 @@ export function PublicHousingExplorer({
     (nextViewport: ViewportSnapshot) => {
       setViewport(nextViewport)
       replaceMapLocation(nextViewport)
-      if (viewportDebounceRef.current !== null) {
-        window.clearTimeout(viewportDebounceRef.current)
-        viewportDebounceRef.current = null
-      }
       const decision = evaluateViewportRequest(nextViewport)
       if (!decision.allowed) {
-        searchAbortRef.current?.abort()
-        paginationAbortRef.current?.abort()
-        requestRevisionRef.current += 1
-        pendingViewportSignatureRef.current = null
         viewportWasBlockedRef.current = true
         return
       }
-      viewportDebounceRef.current = window.setTimeout(() => {
-        viewportDebounceRef.current = null
+      if (appliedViewportRef.current === null
+        && pendingViewportSignatureRef.current === null) {
         applyViewport(nextViewport)
-      }, VIEWPORT_DEBOUNCE_MS)
+      }
     },
     [applyViewport, replaceMapLocation],
   )
 
+  const handleIntegratedSearchSelect = useCallback((item: SearchResultItem) => {
+    if (item.type === 'ANNOUNCEMENT') {
+      setSelectedSearchComplex(null)
+      if (item.latitude !== null && item.longitude !== null) {
+        setSearchMapTarget({
+          latitude: item.latitude,
+          longitude: item.longitude,
+          zoom: 14,
+        })
+      }
+      openAnnouncementDetail(item.id)
+      return
+    }
+    if (item.type === 'COMPLEX') {
+      setSelectedSearchComplex(item)
+      setSearchContext({ kind: 'none' })
+      if (item.latitude !== null && item.longitude !== null) {
+        setSearchMapTarget({
+          latitude: item.latitude,
+          longitude: item.longitude,
+          zoom: 16,
+        })
+      }
+      openComplexDetail(item.id)
+      return
+    }
+    if (item.type === 'REGION' && item.regionCode) {
+      setSelectedSearchComplex(null)
+      const options = { ...complexFilters, regionCode: item.regionCode }
+      setSearchContext({ kind: 'region', regionCode: item.regionCode })
+      setSearchMapTarget({ ...DEFAULT_MAP_LOCATION.center, zoom: 7 })
+      applyViewport(viewportForBounds(KOREA_BOUNDS), true, options)
+    }
+  }, [applyViewport, complexFilters, openAnnouncementDetail, openComplexDetail])
+
+  const searchCurrentViewport = useCallback(() => {
+    if (viewport === null) {
+      return
+    }
+    setSearchContext({ kind: 'none' })
+    applyViewport(viewport, true, complexFilters)
+  }, [applyViewport, complexFilters, viewport])
+
+  useEffect(() => {
+    if (
+      searchContext.kind !== 'region'
+      || mapResults.status !== 'ready'
+      || appliedViewport?.options.regionCode !== searchContext.regionCode
+    ) {
+      return
+    }
+    const target = mapTargetForComplexes(mapResults.items)
+    if (target !== null) {
+      setSearchMapTarget(target)
+    }
+  }, [appliedViewport, mapResults.items, mapResults.status, searchContext])
+
   useEffect(() => {
     return () => {
-      if (viewportDebounceRef.current !== null) {
-        window.clearTimeout(viewportDebounceRef.current)
-      }
       searchAbortRef.current?.abort()
       paginationAbortRef.current?.abort()
     }
@@ -929,22 +1003,14 @@ export function PublicHousingExplorer({
       status: 'loading-more',
     }))
 
-    const request = hasSearchFilters(complexFilters)
-      ? repository.findComplexPage(
-          appliedViewport.bounds,
-          cursor,
-          PAGE_SIZE,
-          controller.signal,
-          complexFilters,
-        )
-      : repository.findComplexPage(
-          appliedViewport.bounds,
-          cursor,
-          PAGE_SIZE,
-          controller.signal,
-        )
-
-    request
+    findComplexPage(
+      repository,
+      appliedViewport.bounds,
+      cursor,
+      PAGE_SIZE,
+      controller.signal,
+      appliedViewport.options,
+    )
       .then((page) => {
         if (requestRevisionRef.current !== revision) {
           return
@@ -969,7 +1035,7 @@ export function PublicHousingExplorer({
           status: 'error',
         }))
       })
-  }, [appliedViewport, complexFilters, complexResults, repository])
+  }, [appliedViewport, complexResults, repository])
 
   const retryComplexResults = useCallback(() => {
     if (failedPaginationCursorRef.current) {
@@ -998,7 +1064,7 @@ export function PublicHousingExplorer({
         longitude: DEFAULT_MAP_LOCATION.center.longitude,
         zoom: DEFAULT_MAP_LOCATION.zoom,
       }
-  const activeMapTarget = detailMapTarget ?? urlMapTarget
+  const activeMapTarget = detailMapTarget ?? searchMapTarget ?? urlMapTarget
   const highlightedComplexIds = useMemo(() => new Set([
     cardHighlightedComplexId,
     markerHighlightedComplexId,
@@ -1014,6 +1080,7 @@ export function PublicHousingExplorer({
           selectedComplexId,
           highlightedComplexIds,
           complexDetail.detail,
+          selectedSearchComplex,
         ),
     [
       complexDetail.detail,
@@ -1021,6 +1088,7 @@ export function PublicHousingExplorer({
       mapResults.items,
       requestBlocked,
       selectedComplexId,
+      selectedSearchComplex,
     ],
   )
   const resultCount = resultCountLabel(
@@ -1060,21 +1128,34 @@ export function PublicHousingExplorer({
           </span>
         </header>
 
-        <ViewportAction
-          announcementsActive={activeResultTab === 'announcements'}
-          decision={viewportDecision}
+        <IntegratedSearch
+          onActiveChange={setIntegratedSearchActive}
+          onSelect={handleIntegratedSearchSelect}
+          repository={searchRepository}
         />
 
-        {!requestBlocked && (
+        {!integratedSearchActive && <>
+          <ViewportAction
+          announcementsActive={activeResultTab === 'announcements'}
+          decision={viewportDecision}
+          onSearch={searchCurrentViewport}
+          searchAvailable={Boolean(
+            viewportDecision?.allowed
+            && appliedViewport
+            && viewportDecision.boundsSignature !== appliedViewport.signature
+          )}
+          />
+
+          {!requestBlocked && (
           <ComplexRequestFeedback
             state={complexResults}
             onRetry={retryComplexResults}
           />
-        )}
+          )}
 
-        <ResultTabs activeTab={activeResultTab} onSelect={selectResultTab} />
+          <ResultTabs activeTab={activeResultTab} onSelect={selectResultTab} />
 
-        <div
+          <div
           className="housing-results__panel"
           id="complex-results-panel"
           role="tabpanel"
@@ -1109,9 +1190,9 @@ export function PublicHousingExplorer({
                   : '단지 더 보기'}
               </button>
             )}
-        </div>
+          </div>
 
-        <div
+          <div
           className="housing-results__panel"
           id="announcement-results-panel"
           role="tabpanel"
@@ -1149,7 +1230,8 @@ export function PublicHousingExplorer({
                   : '공고 더 보기'}
               </button>
             )}
-        </div>
+          </div>
+        </>}
       </aside>
 
       <main className="housing-map-workspace">
@@ -1584,14 +1666,26 @@ function resultCountLabel(
 function ViewportAction({
   announcementsActive,
   decision,
+  onSearch,
+  searchAvailable,
 }: {
   announcementsActive: boolean
   decision: ReturnType<typeof evaluateViewportRequest> | null
+  onSearch: () => void
+  searchAvailable: boolean
 }) {
   if (decision && !decision.allowed) {
     return (
       <div className="housing-viewport-action housing-viewport-action--blocked" role="status">
         <span>{viewportGuidance(decision.reason, announcementsActive)}</span>
+      </div>
+    )
+  }
+
+  if (searchAvailable) {
+    return (
+      <div className="housing-viewport-action">
+        <button type="button" onClick={onSearch}>이 지역에서 검색</button>
       </div>
     )
   }
@@ -1771,6 +1865,7 @@ function toNaverMapMarkers(
   selectedComplexId: string | null,
   highlightedComplexIds: ReadonlySet<string>,
   detail: ComplexDetail | null,
+  searchComplex: SearchResultItem | null,
 ): NaverMapMarker[] {
   const markers = complexes.map((complex) => ({
     ...presentMapComplexMarker(complex),
@@ -1782,23 +1877,44 @@ function toNaverMapMarkers(
     selected: complex.complexId === selectedComplexId,
   }))
   const target = toDetailMapTarget(detail)
+  const markersWithDetail = detail !== null
+    && target !== undefined
+    && !markers.some((marker) => marker.id === detail.complexId)
+    ? [
+        ...markers,
+        {
+          ...presentComplexDetailMarker(detail),
+          highlighted: highlightedComplexIds.has(detail.complexId),
+          id: detail.complexId,
+          latitude: target.latitude,
+          longitude: target.longitude,
+          name: detail.name ?? '단지명 정보 확인 중',
+          selected: true,
+        },
+      ]
+    : markers
   if (
-    detail === null ||
-    target === undefined ||
-    markers.some((marker) => marker.id === detail.complexId)
+    searchComplex?.type !== 'COMPLEX'
+    || searchComplex.id !== selectedComplexId
+    || searchComplex.latitude === null
+    || searchComplex.longitude === null
+    || markersWithDetail.some((marker) => marker.id === searchComplex.id)
   ) {
-    return markers
+    return markersWithDetail
   }
 
   return [
-    ...markers,
+    ...markersWithDetail,
     {
-      ...presentComplexDetailMarker(detail),
-      highlighted: highlightedComplexIds.has(detail.complexId),
-      id: detail.complexId,
-      latitude: target.latitude,
-      longitude: target.longitude,
-      name: detail.name ?? '단지명 정보 확인 중',
+      agencyLabel: '기관 확인 중',
+      areaLabel: '면적 확인 중',
+      highlighted: false,
+      id: searchComplex.id,
+      latitude: searchComplex.latitude,
+      longitude: searchComplex.longitude,
+      monthlyRentLabel: '정보 확인 중',
+      name: searchComplex.title,
+      rentalTypeLabel: '임대유형 확인 중',
       selected: true,
     },
   ]
@@ -2180,6 +2296,61 @@ function appendUniqueComplexes(
     ...current,
     ...next.filter((complex) => !knownIds.has(complex.complexId)),
   ]
+}
+
+function findMapComplexes(
+  repository: PublicHousingRepository,
+  bounds: MapBounds,
+  signal: AbortSignal,
+  options: ComplexSearchFilters,
+) {
+  if (Object.keys(options).length === 0) {
+    return repository.findMapComplexes(bounds, signal)
+  }
+  return repository.findMapComplexes(bounds, signal, options)
+}
+
+function findComplexPage(
+  repository: PublicHousingRepository,
+  bounds: MapBounds,
+  cursor: string | null,
+  size: number,
+  signal: AbortSignal,
+  options: ComplexSearchFilters,
+) {
+  if (Object.keys(options).length === 0) {
+    return repository.findComplexPage(bounds, cursor, size, signal)
+  }
+  return repository.findComplexPage(bounds, cursor, size, signal, options)
+}
+
+function viewportForBounds(bounds: MapBounds): ViewportSnapshot {
+  return {
+    bounds,
+    center: {
+      latitude: (bounds.southWestLat + bounds.northEastLat) / 2,
+      longitude: (bounds.southWestLng + bounds.northEastLng) / 2,
+    },
+    zoom: 14,
+  }
+}
+
+function mapTargetForComplexes(
+  complexes: readonly MapComplex[],
+): NaverMapCameraTarget | null {
+  if (complexes.length === 0) {
+    return null
+  }
+  const latitudes = complexes.map(({ latitude }) => latitude)
+  const longitudes = complexes.map(({ longitude }) => longitude)
+  const latitudeSpan = Math.max(...latitudes) - Math.min(...latitudes)
+  const longitudeSpan = Math.max(...longitudes) - Math.min(...longitudes)
+  const span = Math.max(latitudeSpan, longitudeSpan)
+  return {
+    latitude: (Math.min(...latitudes) + Math.max(...latitudes)) / 2,
+    longitude: (Math.min(...longitudes) + Math.max(...longitudes)) / 2,
+    zoom: span < 0.02 ? 15 : span < 0.08 ? 13 : 11,
+  }
 }
 
 function viewportGuidance(

--- a/frontend/src/public-housing/PublicHousingExplorer.tsx
+++ b/frontend/src/public-housing/PublicHousingExplorer.tsx
@@ -38,7 +38,6 @@ import { HousingComplexDetailPanel } from './components/HousingComplexDetailPane
 import { ComplexFilterToolbar } from './filters/ComplexFilterToolbar.tsx'
 import { SearchFilterPanel } from './filters/SearchFilterPanel.tsx'
 import {
-  hasSearchFilters,
   parseAnnouncementSearchFilters,
   parseComplexSearchFilters,
   searchFiltersSignature,
@@ -209,6 +208,7 @@ export function PublicHousingExplorer({
   const [viewport, setViewport] = useState<ViewportSnapshot | null>(null)
   const [searchContext, setSearchContext] = useState<SearchContext>({ kind: 'none' })
   const [searchMapTarget, setSearchMapTarget] = useState<NaverMapCameraTarget | null>(null)
+  const [cameraRequestId, setCameraRequestId] = useState(0)
   const [selectedSearchComplex, setSelectedSearchComplex] =
     useState<SearchResultItem | null>(null)
   const [integratedSearchActive, setIntegratedSearchActive] = useState(false)
@@ -821,13 +821,6 @@ export function PublicHousingExplorer({
           })
           setCardHighlightedComplexId(null)
           setMarkerHighlightedComplexId(null)
-          if (options.regionCode && mapItems[0]) {
-            setSearchMapTarget({
-              latitude: mapItems[0].latitude,
-              longitude: mapItems[0].longitude,
-              zoom: 13,
-            })
-          }
           if (complexResultsScrollRef.current) {
             complexResultsScrollRef.current.scrollTop = 0
           }
@@ -862,10 +855,6 @@ export function PublicHousingExplorer({
       return
     }
     previousComplexFiltersKeyRef.current = complexFiltersKey
-    if (viewportDebounceRef.current !== null) {
-      window.clearTimeout(viewportDebounceRef.current)
-      viewportDebounceRef.current = null
-    }
     if (viewport !== null) {
       applyViewport(viewport, true)
     }
@@ -897,6 +886,7 @@ export function PublicHousingExplorer({
           longitude: item.longitude,
           zoom: 14,
         })
+        setCameraRequestId((current) => current + 1)
       }
       openAnnouncementDetail(item.id)
       return
@@ -910,6 +900,7 @@ export function PublicHousingExplorer({
           longitude: item.longitude,
           zoom: 16,
         })
+        setCameraRequestId((current) => current + 1)
       }
       openComplexDetail(item.id)
       return
@@ -919,6 +910,7 @@ export function PublicHousingExplorer({
       const options = { ...complexFilters, regionCode: item.regionCode }
       setSearchContext({ kind: 'region', regionCode: item.regionCode })
       setSearchMapTarget({ ...DEFAULT_MAP_LOCATION.center, zoom: 7 })
+      setCameraRequestId((current) => current + 1)
       applyViewport(viewportForBounds(KOREA_BOUNDS), true, options)
     }
   }, [applyViewport, complexFilters, openAnnouncementDetail, openComplexDetail])
@@ -1052,6 +1044,9 @@ export function PublicHousingExplorer({
     ? evaluateViewportRequest(viewport)
     : null
   const requestBlocked = viewportDecision !== null && !viewportDecision.allowed
+  const currentViewportSignature = viewportDecision?.allowed
+    ? `${viewportDecision.boundsSignature}|${complexFiltersKey}`
+    : null
   const detailMapTarget = toDetailMapTarget(complexDetail.detail)
   const urlMapTarget = mapLocation.kind === 'valid'
     ? {
@@ -1140,9 +1135,9 @@ export function PublicHousingExplorer({
           decision={viewportDecision}
           onSearch={searchCurrentViewport}
           searchAvailable={Boolean(
-            viewportDecision?.allowed
+            currentViewportSignature
             && appliedViewport
-            && viewportDecision.boundsSignature !== appliedViewport.signature
+            && currentViewportSignature !== appliedViewport.signature
           )}
           />
 
@@ -1244,6 +1239,7 @@ export function PublicHousingExplorer({
           />
         </div>
         <NaverMap
+          cameraRequestId={cameraRequestId}
           cameraTarget={activeMapTarget}
           dataBusy={!requestBlocked && mapResults.status === 'loading'}
           markers={markers}

--- a/frontend/src/public-housing/api/publicHousingRepository.ts
+++ b/frontend/src/public-housing/api/publicHousingRepository.ts
@@ -75,7 +75,6 @@ export interface ComplexSearchFilters extends SharedSearchFilters {
 }
 
 export type AnnouncementSearchFilters = SharedSearchFilters
-
 export interface PublicHousingRepository {
   findComplexPage(
     bounds: MapBounds,
@@ -134,7 +133,6 @@ export function createHttpPublicHousingRepository(
         search.set('cursor', cursor)
       }
       search.set('size', String(size))
-
       const payload = await requestJson(
         fetcher,
         `${apiBaseUrl}${COMPLEXES_PATH}?${search.toString()}`,

--- a/frontend/src/public-housing/search/IntegratedSearch.test.tsx
+++ b/frontend/src/public-housing/search/IntegratedSearch.test.tsx
@@ -12,7 +12,7 @@ describe('IntegratedSearch', () => {
     const announcement = item('ANNOUNCEMENT', '1', '서울 행복주택 공고')
     const complex = item('COMPLEX', '2', '서울 행복주택 단지')
     const region = item('REGION', '11', '서울특별시 전체')
-    const repository = repositoryWith(response([announcement, complex], [region]))
+    const repository = repositoryWith(response([announcement], [complex], [region]))
     const onSelect = vi.fn()
     render(<IntegratedSearch repository={repository} onSelect={onSelect} />)
 
@@ -40,16 +40,30 @@ describe('IntegratedSearch', () => {
     await waitFor(() => expect(search).toHaveBeenCalledTimes(1))
     fireEvent.change(screen.getByRole('searchbox'), { target: { value: '부산' } })
     await waitFor(() => expect(search).toHaveBeenCalledTimes(2))
-    second.resolve(response([item('COMPLEX', '2', '부산 단지')], []))
+    second.resolve(response([], [item('COMPLEX', '2', '부산 단지')], []))
     expect(await screen.findByText('부산 단지')).toBeVisible()
-    first.resolve(response([item('COMPLEX', '1', '서울 단지')], []))
+    first.resolve(response([], [item('COMPLEX', '1', '서울 단지')], []))
 
     await waitFor(() => expect(screen.queryByText('서울 단지')).not.toBeInTheDocument())
     expect(screen.getByText('부산 단지')).toBeVisible()
   })
 
+  it('검색어를 지운 뒤 늦게 끝난 요청 결과를 표시하지 않는다', async () => {
+    const pending = deferred<IntegratedSearchResponse>()
+    const search = vi.fn().mockReturnValue(pending.promise)
+    render(<IntegratedSearch repository={{ search }} onSelect={vi.fn()} />)
+
+    fireEvent.change(screen.getByRole('searchbox'), { target: { value: '서울' } })
+    await waitFor(() => expect(search).toHaveBeenCalledOnce())
+    fireEvent.change(screen.getByRole('searchbox'), { target: { value: '' } })
+    pending.resolve(response([], [item('COMPLEX', '1', '서울 단지')], []))
+
+    expect(await screen.findByText('두 글자 이상 입력해 주세요.')).toBeVisible()
+    await waitFor(() => expect(screen.queryByText('서울 단지')).not.toBeInTheDocument())
+  })
+
   it('일부 유형 실패 시 성공 결과와 해당 유형 재시도를 함께 표시한다', async () => {
-    const successful = response([item('COMPLEX', '1', '서울 단지')], [], [{
+    const successful = response([], [item('COMPLEX', '1', '서울 단지')], [], [{
       message: '지역 검색에 실패했습니다. 다시 시도해 주세요.',
       type: 'REGION',
     }])
@@ -64,7 +78,7 @@ describe('IntegratedSearch', () => {
   })
 
   it('검색어가 바뀌면 입력 중 결과 첫 페이지로 돌아간다', async () => {
-    const result = { ...response([item('COMPLEX', '1', '서울 단지')], []), hasNext: true }
+    const result = { ...response([], [item('COMPLEX', '1', '서울 단지')], []), hasNext: true }
     const repository = repositoryWith(result)
     render(<IntegratedSearch repository={repository} onSelect={vi.fn()} />)
     fireEvent.change(screen.getByRole('searchbox'), { target: { value: '서울' } })
@@ -92,17 +106,19 @@ function repositoryWith(result: IntegratedSearchResponse): IntegratedSearchRepos
 }
 
 function response(
-  housingInformation: readonly SearchResultItem[],
-  locations: readonly SearchResultItem[],
+  announcements: readonly SearchResultItem[],
+  complexes: readonly SearchResultItem[],
+  regions: readonly SearchResultItem[],
   failures: IntegratedSearchResponse['failures'] = [],
 ): IntegratedSearchResponse {
   return {
+    announcements,
+    complexes,
     failures,
     hasNext: false,
-    housingInformation,
-    locations,
     page: 0,
     query: '서울',
+    regions,
     size: 8,
   }
 }
@@ -113,10 +129,7 @@ function item(
   title: string,
 ): SearchResultItem {
   return {
-    address: '서울특별시 중구',
     applicationStatus: type === 'ANNOUNCEMENT' ? 'APPLYING' : null,
-    cancelled: false,
-    category: type,
     id,
     latitude: type === 'COMPLEX' ? 37.5 : null,
     longitude: type === 'COMPLEX' ? 127 : null,

--- a/frontend/src/public-housing/search/IntegratedSearch.test.tsx
+++ b/frontend/src/public-housing/search/IntegratedSearch.test.tsx
@@ -1,0 +1,137 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { IntegratedSearch } from './IntegratedSearch.tsx'
+import type {
+  IntegratedSearchRepository,
+  IntegratedSearchResponse,
+  SearchResultItem,
+} from './integratedSearchRepository.ts'
+
+describe('IntegratedSearch', () => {
+  it('두 글자를 입력하면 공고 단지 지역으로 구분하고 선택한 공고를 전달한다', async () => {
+    const announcement = item('ANNOUNCEMENT', '1', '서울 행복주택 공고')
+    const complex = item('COMPLEX', '2', '서울 행복주택 단지')
+    const region = item('REGION', '11', '서울특별시 전체')
+    const repository = repositoryWith(response([announcement, complex], [region]))
+    const onSelect = vi.fn()
+    render(<IntegratedSearch repository={repository} onSelect={onSelect} />)
+
+    fireEvent.change(screen.getByRole('searchbox'), { target: { value: '  서울  ' } })
+
+    expect(await screen.findByRole('heading', { name: '공고' })).toBeVisible()
+    expect(screen.getByRole('heading', { name: '단지' })).toBeVisible()
+    expect(screen.getByRole('heading', { name: '지역' })).toBeVisible()
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+    expect(screen.queryByRole('heading', { name: '주택 정보' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('heading', { name: '위치' })).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /서울 행복주택 공고/ }))
+    expect(onSelect).toHaveBeenCalledWith(announcement)
+  })
+
+  it('늦게 끝난 이전 요청이 최신 검색 결과를 덮어쓰지 않는다', async () => {
+    const first = deferred<IntegratedSearchResponse>()
+    const second = deferred<IntegratedSearchResponse>()
+    const search = vi.fn()
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise)
+    render(<IntegratedSearch repository={{ search }} onSelect={vi.fn()} />)
+
+    fireEvent.change(screen.getByRole('searchbox'), { target: { value: '서울' } })
+    await waitFor(() => expect(search).toHaveBeenCalledTimes(1))
+    fireEvent.change(screen.getByRole('searchbox'), { target: { value: '부산' } })
+    await waitFor(() => expect(search).toHaveBeenCalledTimes(2))
+    second.resolve(response([item('COMPLEX', '2', '부산 단지')], []))
+    expect(await screen.findByText('부산 단지')).toBeVisible()
+    first.resolve(response([item('COMPLEX', '1', '서울 단지')], []))
+
+    await waitFor(() => expect(screen.queryByText('서울 단지')).not.toBeInTheDocument())
+    expect(screen.getByText('부산 단지')).toBeVisible()
+  })
+
+  it('일부 유형 실패 시 성공 결과와 해당 유형 재시도를 함께 표시한다', async () => {
+    const successful = response([item('COMPLEX', '1', '서울 단지')], [], [{
+      message: '지역 검색에 실패했습니다. 다시 시도해 주세요.',
+      type: 'REGION',
+    }])
+    const repository = repositoryWith(successful)
+    render(<IntegratedSearch repository={repository} onSelect={vi.fn()} />)
+
+    fireEvent.change(screen.getByRole('searchbox'), { target: { value: '서울' } })
+
+    expect(await screen.findByText('서울 단지')).toBeVisible()
+    fireEvent.click(screen.getByRole('button', { name: '지역 다시 시도' }))
+    await waitFor(() => expect(repository.search).toHaveBeenCalledTimes(2))
+  })
+
+  it('검색어가 바뀌면 입력 중 결과 첫 페이지로 돌아간다', async () => {
+    const result = { ...response([item('COMPLEX', '1', '서울 단지')], []), hasNext: true }
+    const repository = repositoryWith(result)
+    render(<IntegratedSearch repository={repository} onSelect={vi.fn()} />)
+    fireEvent.change(screen.getByRole('searchbox'), { target: { value: '서울' } })
+    fireEvent.click(await screen.findByRole('button', { name: '전체 결과 보기' }))
+    await waitFor(() => expect(repository.search).toHaveBeenLastCalledWith(
+      '서울', false, 0, expect.any(AbortSignal),
+    ))
+    fireEvent.click(screen.getByRole('button', { name: '다음' }))
+    await waitFor(() => expect(repository.search).toHaveBeenLastCalledWith(
+      '서울', false, 1, expect.any(AbortSignal),
+    ))
+
+    fireEvent.change(screen.getByRole('searchbox'), {
+      target: { value: '부산' },
+    })
+
+    await waitFor(() => expect(repository.search).toHaveBeenLastCalledWith(
+      '부산', true, 0, expect.any(AbortSignal),
+    ))
+  })
+})
+
+function repositoryWith(result: IntegratedSearchResponse): IntegratedSearchRepository {
+  return { search: vi.fn().mockResolvedValue(result) }
+}
+
+function response(
+  housingInformation: readonly SearchResultItem[],
+  locations: readonly SearchResultItem[],
+  failures: IntegratedSearchResponse['failures'] = [],
+): IntegratedSearchResponse {
+  return {
+    failures,
+    hasNext: false,
+    housingInformation,
+    locations,
+    page: 0,
+    query: '서울',
+    size: 8,
+  }
+}
+
+function item(
+  type: SearchResultItem['type'],
+  id: string,
+  title: string,
+): SearchResultItem {
+  return {
+    address: '서울특별시 중구',
+    applicationStatus: type === 'ANNOUNCEMENT' ? 'APPLYING' : null,
+    cancelled: false,
+    category: type,
+    id,
+    latitude: type === 'COMPLEX' ? 37.5 : null,
+    longitude: type === 'COMPLEX' ? 127 : null,
+    publishedAt: type === 'ANNOUNCEMENT' ? '2026-09-01' : null,
+    regionCode: type === 'REGION' ? id : null,
+    subtitle: '서울특별시 중구',
+    title,
+    type,
+  }
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}

--- a/frontend/src/public-housing/search/IntegratedSearch.tsx
+++ b/frontend/src/public-housing/search/IntegratedSearch.tsx
@@ -1,0 +1,231 @@
+import { useEffect, useRef, useState } from 'react'
+import {
+  integratedSearchRepository,
+  type IntegratedSearchRepository,
+  type IntegratedSearchResponse,
+  type SearchResultItem,
+  type SearchType,
+} from './integratedSearchRepository.ts'
+
+type SearchState =
+  | { readonly kind: 'before' }
+  | { readonly kind: 'loading' }
+  | { readonly kind: 'ready'; readonly response: IntegratedSearchResponse }
+  | { readonly kind: 'error' }
+
+export interface IntegratedSearchProps {
+  readonly onActiveChange?: (active: boolean) => void
+  readonly onSelect: (item: SearchResultItem) => void
+  readonly repository?: IntegratedSearchRepository
+}
+
+export function IntegratedSearch({
+  onActiveChange,
+  onSelect,
+  repository = integratedSearchRepository,
+}: IntegratedSearchProps) {
+  const [query, setQuery] = useState('')
+  const [preview, setPreview] = useState(true)
+  const [page, setPage] = useState(0)
+  const [retryRevision, setRetryRevision] = useState(0)
+  const [state, setState] = useState<SearchState>({ kind: 'before' })
+  const requestRevision = useRef(0)
+  const normalizedQuery = normalizeQuery(query)
+  const active = normalizedQuery.replaceAll(' ', '').length >= 2
+
+  useEffect(() => {
+    onActiveChange?.(active)
+  }, [active, onActiveChange])
+
+  useEffect(() => {
+    if (!active) {
+      setState({ kind: 'before' })
+      return
+    }
+    const controller = new AbortController()
+    const revision = requestRevision.current + 1
+    requestRevision.current = revision
+    setState({ kind: 'loading' })
+    const timer = window.setTimeout(() => {
+      repository.search(normalizedQuery, preview, page, controller.signal)
+        .then((response) => {
+          if (requestRevision.current === revision) {
+            setState({ kind: 'ready', response })
+          }
+        })
+        .catch((error: unknown) => {
+          if (!isAbortError(error) && requestRevision.current === revision) {
+            setState({ kind: 'error' })
+          }
+        })
+    }, 200)
+    return () => {
+      window.clearTimeout(timer)
+      controller.abort()
+    }
+  }, [active, normalizedQuery, page, preview, repository, retryRevision])
+
+  return (
+    <section className={`integrated-search${active ? ' is-active' : ''}`} aria-label="통합 검색">
+      <label className="integrated-search__input">
+        <span className="visually-hidden">공고, 단지, 지역 검색</span>
+        <input
+          type="search"
+          value={query}
+          placeholder="공고, 단지, 지역 검색"
+          onChange={(event) => {
+            setQuery(event.target.value)
+            setPage(0)
+            setPreview(true)
+          }}
+        />
+      </label>
+      <SearchContent
+        state={state}
+        preview={preview}
+        onSelect={onSelect}
+        onRetry={() => setRetryRevision((current) => current + 1)}
+      />
+      {state.kind === 'ready' && preview && state.response.hasNext && (
+        <button type="button" onClick={() => { setPreview(false); setPage(0) }}>
+          전체 결과 보기
+        </button>
+      )}
+      {state.kind === 'ready' && !preview && (
+        <nav className="integrated-search__pagination" aria-label="검색 결과 페이지">
+          <button
+            type="button"
+            disabled={page === 0}
+            onClick={() => setPage((current) => Math.max(0, current - 1))}
+          >
+            이전
+          </button>
+          <span>{page + 1}페이지</span>
+          <button
+            type="button"
+            disabled={!state.response.hasNext}
+            onClick={() => setPage((current) => current + 1)}
+          >
+            다음
+          </button>
+        </nav>
+      )}
+    </section>
+  )
+}
+
+function SearchContent({
+  onRetry,
+  onSelect,
+  preview,
+  state,
+}: {
+  readonly onRetry: () => void
+  readonly onSelect: (item: SearchResultItem) => void
+  readonly preview: boolean
+  readonly state: SearchState
+}) {
+  if (state.kind === 'before') {
+    return <p className="integrated-search__hint">두 글자 이상 입력해 주세요.</p>
+  }
+  if (state.kind === 'loading') {
+    return <p role="status">검색 중입니다.</p>
+  }
+  if (state.kind === 'error') {
+    return <SearchError title="검색 결과를 불러오지 못했습니다." onRetry={onRetry} />
+  }
+  const { response } = state
+  const resultCount = response.housingInformation.length + response.locations.length
+  if (resultCount === 0 && response.failures.length === 3) {
+    return <SearchError title="전체 검색에 실패했습니다." onRetry={onRetry} />
+  }
+  return (
+    <div className="integrated-search__results" data-mode={preview ? 'preview' : 'all'}>
+      {resultCount === 0 && <p role="status">검색 결과가 없습니다.</p>}
+      <SearchGroup
+        title="공고"
+        items={response.housingInformation.filter((item) => item.type === 'ANNOUNCEMENT')}
+        onSelect={onSelect}
+      />
+      <SearchGroup
+        title="단지"
+        items={response.housingInformation.filter((item) => item.type === 'COMPLEX')}
+        onSelect={onSelect}
+      />
+      <SearchGroup
+        title="지역"
+        items={response.locations.filter((item) => item.type === 'REGION')}
+        onSelect={onSelect}
+      />
+      {response.failures.map((failure) => (
+        <div className="integrated-search__partial-error" key={failure.type} role="alert">
+          <span>{failure.message}</span>
+          <button type="button" onClick={onRetry}>{typeLabel(failure.type)} 다시 시도</button>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function SearchGroup({
+  items,
+  onSelect,
+  title,
+}: {
+  readonly items: readonly SearchResultItem[]
+  readonly onSelect: (item: SearchResultItem) => void
+  readonly title: string
+}) {
+  if (items.length === 0) {
+    return null
+  }
+  return (
+    <section aria-labelledby={`search-${title}`}>
+      <h2 id={`search-${title}`}>{title}</h2>
+      <ul>
+        {items.map((item) => (
+          <li key={`${item.type}-${item.id}`}>
+            <button type="button" onClick={() => onSelect(item)}>
+              <strong>{item.title}</strong>
+              <span>{typeLabel(item.type)}</span>
+              {item.subtitle && <span>{item.subtitle}</span>}
+              {item.publishedAt && <time dateTime={item.publishedAt}>{item.publishedAt}</time>}
+              {item.applicationStatus && <span>{statusLabel(item.applicationStatus)}</span>}
+              {item.cancelled && <span>취소 공고</span>}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}
+
+function SearchError({ title, onRetry }: { readonly title: string; readonly onRetry: () => void }) {
+  return (
+    <div role="alert">
+      <span>{title}</span>
+      <button type="button" onClick={onRetry}>다시 시도</button>
+    </div>
+  )
+}
+
+function normalizeQuery(value: string) {
+  return value.trim().replace(/\s+/g, ' ')
+}
+
+function typeLabel(type: SearchType) {
+  return { ANNOUNCEMENT: '공고', COMPLEX: '단지', REGION: '지역' }[type]
+}
+
+function statusLabel(status: string) {
+  return {
+    APPLYING: '접수 중',
+    BEFORE_APPLICATION: '접수 예정',
+    CANCELLED: '취소',
+    CLOSED: '접수 종료',
+  }[status] ?? status
+}
+
+function isAbortError(error: unknown) {
+  return typeof error === 'object' && error !== null && 'name' in error && error.name === 'AbortError'
+}

--- a/frontend/src/public-housing/search/IntegratedSearch.tsx
+++ b/frontend/src/public-housing/search/IntegratedSearch.tsx
@@ -38,13 +38,13 @@ export function IntegratedSearch({
   }, [active, onActiveChange])
 
   useEffect(() => {
+    const revision = requestRevision.current + 1
+    requestRevision.current = revision
     if (!active) {
       setState({ kind: 'before' })
       return
     }
     const controller = new AbortController()
-    const revision = requestRevision.current + 1
-    requestRevision.current = revision
     setState({ kind: 'loading' })
     const timer = window.setTimeout(() => {
       repository.search(normalizedQuery, preview, page, controller.signal)
@@ -135,7 +135,9 @@ function SearchContent({
     return <SearchError title="검색 결과를 불러오지 못했습니다." onRetry={onRetry} />
   }
   const { response } = state
-  const resultCount = response.housingInformation.length + response.locations.length
+  const resultCount = response.announcements.length
+    + response.complexes.length
+    + response.regions.length
   if (resultCount === 0 && response.failures.length === 3) {
     return <SearchError title="전체 검색에 실패했습니다." onRetry={onRetry} />
   }
@@ -144,17 +146,17 @@ function SearchContent({
       {resultCount === 0 && <p role="status">검색 결과가 없습니다.</p>}
       <SearchGroup
         title="공고"
-        items={response.housingInformation.filter((item) => item.type === 'ANNOUNCEMENT')}
+        items={response.announcements}
         onSelect={onSelect}
       />
       <SearchGroup
         title="단지"
-        items={response.housingInformation.filter((item) => item.type === 'COMPLEX')}
+        items={response.complexes}
         onSelect={onSelect}
       />
       <SearchGroup
         title="지역"
-        items={response.locations.filter((item) => item.type === 'REGION')}
+        items={response.regions}
         onSelect={onSelect}
       />
       {response.failures.map((failure) => (
@@ -187,11 +189,9 @@ function SearchGroup({
           <li key={`${item.type}-${item.id}`}>
             <button type="button" onClick={() => onSelect(item)}>
               <strong>{item.title}</strong>
-              <span>{typeLabel(item.type)}</span>
               {item.subtitle && <span>{item.subtitle}</span>}
               {item.publishedAt && <time dateTime={item.publishedAt}>{item.publishedAt}</time>}
               {item.applicationStatus && <span>{statusLabel(item.applicationStatus)}</span>}
-              {item.cancelled && <span>취소 공고</span>}
             </button>
           </li>
         ))}

--- a/frontend/src/public-housing/search/integratedSearchRepository.test.ts
+++ b/frontend/src/public-housing/search/integratedSearchRepository.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createIntegratedSearchRepository } from './integratedSearchRepository.ts'
+
+describe('integratedSearchRepository', () => {
+  it('공고 단지 지역으로 분리된 최소 응답을 해석한다', async () => {
+    const fetcher = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      data: {
+        announcements: [item('ANNOUNCEMENT', '1')],
+        complexes: [item('COMPLEX', '2')],
+        failures: [],
+        hasNext: false,
+        page: 0,
+        query: '서울',
+        regions: [item('REGION', '11')],
+        size: 8,
+      },
+    }), { status: 200 }))
+
+    const result = await createIntegratedSearchRepository(fetcher).search(
+      '서울',
+      true,
+      0,
+      new AbortController().signal,
+    )
+
+    expect(result.announcements).toHaveLength(1)
+    expect(result.complexes).toHaveLength(1)
+    expect(result.regions).toHaveLength(1)
+  })
+})
+
+function item(type: 'ANNOUNCEMENT' | 'COMPLEX' | 'REGION', id: string) {
+  return {
+    applicationStatus: null,
+    id,
+    latitude: null,
+    longitude: null,
+    publishedAt: null,
+    regionCode: type === 'REGION' ? id : null,
+    subtitle: null,
+    title: '서울',
+    type,
+  }
+}

--- a/frontend/src/public-housing/search/integratedSearchRepository.ts
+++ b/frontend/src/public-housing/search/integratedSearchRepository.ts
@@ -1,0 +1,167 @@
+export type SearchType = 'ANNOUNCEMENT' | 'COMPLEX' | 'REGION'
+
+export interface SearchResultItem {
+  readonly address: string | null
+  readonly applicationStatus: string | null
+  readonly cancelled: boolean
+  readonly category: string | null
+  readonly id: string
+  readonly latitude: number | null
+  readonly longitude: number | null
+  readonly publishedAt: string | null
+  readonly regionCode: string | null
+  readonly subtitle: string | null
+  readonly title: string
+  readonly type: SearchType
+}
+
+export interface SearchFailure {
+  readonly message: string
+  readonly type: SearchType
+}
+
+export interface IntegratedSearchResponse {
+  readonly failures: readonly SearchFailure[]
+  readonly hasNext: boolean
+  readonly housingInformation: readonly SearchResultItem[]
+  readonly locations: readonly SearchResultItem[]
+  readonly page: number
+  readonly query: string
+  readonly size: number
+}
+
+export interface IntegratedSearchRepository {
+  search(
+    query: string,
+    preview: boolean,
+    page: number,
+    signal: AbortSignal,
+  ): Promise<IntegratedSearchResponse>
+}
+
+export function createIntegratedSearchRepository(
+  fetcher: typeof globalThis.fetch = globalThis.fetch,
+): IntegratedSearchRepository {
+  return {
+    async search(query, preview, page, signal) {
+      const params = new URLSearchParams({
+        page: String(page),
+        preview: String(preview),
+        query,
+        size: '20',
+      })
+      const response = await fetcher(`${apiBaseUrl()}/api/v1/search?${params}`, {
+        headers: { Accept: 'application/json' },
+        signal,
+      })
+      if (!response.ok) {
+        throw new Error('통합 검색 결과를 불러오지 못했습니다.')
+      }
+      return decodeResponse((await response.json()) as unknown)
+    },
+  }
+}
+
+export const integratedSearchRepository = createIntegratedSearchRepository()
+
+function decodeResponse(value: unknown): IntegratedSearchResponse {
+  const envelope = record(value, '$')
+  const data = record(envelope.data, '$.data')
+  return {
+    failures: array(data.failures, '$.data.failures').map(decodeFailure),
+    hasNext: boolean(data.hasNext, '$.data.hasNext'),
+    housingInformation: array(
+      data.housingInformation,
+      '$.data.housingInformation',
+    ).map(decodeItem),
+    locations: array(data.locations, '$.data.locations').map(decodeItem),
+    page: number(data.page, '$.data.page'),
+    query: string(data.query, '$.data.query'),
+    size: number(data.size, '$.data.size'),
+  }
+}
+
+function decodeItem(value: unknown, index: number): SearchResultItem {
+  const item = record(value, `item[${index}]`)
+  const type = string(item.type, 'item.type')
+  if (!isSearchType(type)) {
+    throw new Error('통합 검색 결과 유형이 올바르지 않습니다.')
+  }
+  return {
+    address: nullableString(item.address),
+    applicationStatus: nullableString(item.applicationStatus),
+    cancelled: boolean(item.cancelled, 'item.cancelled'),
+    category: nullableString(item.category),
+    id: string(item.id, 'item.id'),
+    latitude: nullableNumber(item.latitude),
+    longitude: nullableNumber(item.longitude),
+    publishedAt: nullableString(item.publishedAt),
+    regionCode: nullableString(item.regionCode),
+    subtitle: nullableString(item.subtitle),
+    title: string(item.title, 'item.title'),
+    type,
+  }
+}
+
+function decodeFailure(value: unknown, index: number): SearchFailure {
+  const failure = record(value, `failure[${index}]`)
+  const type = string(failure.type, 'failure.type')
+  if (!isSearchType(type)) {
+    throw new Error('통합 검색 실패 유형이 올바르지 않습니다.')
+  }
+  return { message: string(failure.message, 'failure.message'), type }
+}
+
+function isSearchType(value: string): value is SearchType {
+  return ['ANNOUNCEMENT', 'COMPLEX', 'REGION'].includes(value)
+}
+
+function record(value: unknown, path: string): Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error(`${path} 응답 형식이 올바르지 않습니다.`)
+  }
+  return value as Record<string, unknown>
+}
+
+function array(value: unknown, path: string): readonly unknown[] {
+  if (!Array.isArray(value)) {
+    throw new Error(`${path} 응답 형식이 올바르지 않습니다.`)
+  }
+  return value
+}
+
+function string(value: unknown, path: string): string {
+  if (typeof value !== 'string') {
+    throw new Error(`${path} 응답 형식이 올바르지 않습니다.`)
+  }
+  return value
+}
+
+function number(value: unknown, path: string): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new Error(`${path} 응답 형식이 올바르지 않습니다.`)
+  }
+  return value
+}
+
+function boolean(value: unknown, path: string): boolean {
+  if (typeof value !== 'boolean') {
+    throw new Error(`${path} 응답 형식이 올바르지 않습니다.`)
+  }
+  return value
+}
+
+function nullableString(value: unknown): string | null {
+  return value === null ? null : string(value, 'nullable string')
+}
+
+function nullableNumber(value: unknown): number | null {
+  return value === null ? null : number(value, 'nullable number')
+}
+
+function apiBaseUrl() {
+  if (import.meta.env.VITE_API_BASE_URL) {
+    return import.meta.env.VITE_API_BASE_URL
+  }
+  return import.meta.env.DEV ? 'http://localhost:8080' : ''
+}

--- a/frontend/src/public-housing/search/integratedSearchRepository.ts
+++ b/frontend/src/public-housing/search/integratedSearchRepository.ts
@@ -1,10 +1,7 @@
 export type SearchType = 'ANNOUNCEMENT' | 'COMPLEX' | 'REGION'
 
 export interface SearchResultItem {
-  readonly address: string | null
   readonly applicationStatus: string | null
-  readonly cancelled: boolean
-  readonly category: string | null
   readonly id: string
   readonly latitude: number | null
   readonly longitude: number | null
@@ -21,12 +18,13 @@ export interface SearchFailure {
 }
 
 export interface IntegratedSearchResponse {
+  readonly announcements: readonly SearchResultItem[]
+  readonly complexes: readonly SearchResultItem[]
   readonly failures: readonly SearchFailure[]
   readonly hasNext: boolean
-  readonly housingInformation: readonly SearchResultItem[]
-  readonly locations: readonly SearchResultItem[]
   readonly page: number
   readonly query: string
+  readonly regions: readonly SearchResultItem[]
   readonly size: number
 }
 
@@ -68,15 +66,13 @@ function decodeResponse(value: unknown): IntegratedSearchResponse {
   const envelope = record(value, '$')
   const data = record(envelope.data, '$.data')
   return {
+    announcements: array(data.announcements, '$.data.announcements').map(decodeItem),
+    complexes: array(data.complexes, '$.data.complexes').map(decodeItem),
     failures: array(data.failures, '$.data.failures').map(decodeFailure),
     hasNext: boolean(data.hasNext, '$.data.hasNext'),
-    housingInformation: array(
-      data.housingInformation,
-      '$.data.housingInformation',
-    ).map(decodeItem),
-    locations: array(data.locations, '$.data.locations').map(decodeItem),
     page: number(data.page, '$.data.page'),
     query: string(data.query, '$.data.query'),
+    regions: array(data.regions, '$.data.regions').map(decodeItem),
     size: number(data.size, '$.data.size'),
   }
 }
@@ -88,10 +84,7 @@ function decodeItem(value: unknown, index: number): SearchResultItem {
     throw new Error('통합 검색 결과 유형이 올바르지 않습니다.')
   }
   return {
-    address: nullableString(item.address),
     applicationStatus: nullableString(item.applicationStatus),
-    cancelled: boolean(item.cancelled, 'item.cancelled'),
-    category: nullableString(item.category),
     id: string(item.id, 'item.id'),
     latitude: nullableNumber(item.latitude),
     longitude: nullableNumber(item.longitude),


### PR DESCRIPTION
## 관련 이슈

Refs #95

## 작업 목적

지난 PR #102에서는 클러스터링 단계마다 어떤 지역을 하나의 마커로 묶을지 정했습니다.

다음 단계에서 서버가 지역별 단지 수를 계산하려면 사용자가 선택한 검색 및 필터가 기존 지도 조회와 클러스터링 집계에 똑같이 적용되어야 합니다.

예를 들어 사용자가 `경기`, `행복주택`, `모집 중`을 선택했다면 지도에 표시되는 단지와 지역 마커의 숫자가 같은 조건으로 계산되어야 합니다. 기능마다 필터를 별도로 구현하면 서로 다른 결과가 나올 수 있으므로, 이번 PR에서는 필터 처리 기준을 한 곳에서 재사용할 수 있도록 정리합니다.

이 작업은 PR #103에서 추가된 검색 및 필터 변경을 기반으로 합니다. 병합 순서는 PR #103 → 이번 PR입니다.

## 작업 내역

- 지도 화면 범위와 검색 및 필터 조건을 분리했습니다.
- 키워드, 지역, 임대 유형, 공급 기관, 모집 유형, 모집 상태, 가격, 면적, 준공 연도, 엘리베이터 여부를 공통 필터 조건으로 관리합니다.
- `모집 중인 공고 있음`, `없음`, `선택하지 않음` 조건도 공통 필터에 포함했습니다.
- 검색 요청의 입력값 검증과 변환을 별도 구성 요소로 분리했습니다.
- 지도 조회와 목록 조회가 동일한 필터 조건과 SQL 생성 로직을 사용하도록 변경했습니다.
- 기존 v1 API 요청과 응답 형식, 검색 및 필터 결과는 변경하지 않았습니다.

이번 PR에서는 클러스터링 마커나 지역별 단지 수를 아직 응답하지 않습니다. 후속 서버 클러스터링 PR에서 이번에 분리한 공통 필터를 지역별 집계에도 사용합니다.

## 리뷰 포인트

- 같은 검색 및 필터가 지도 조회와 목록 조회에서 동일하게 적용되는지
- 지도 화면 범위와 공통 필터가 이후 지역별 집계에서 재사용할 수 있도록 분리됐는지
- PR #103에서 추가된 검색 및 필터 동작이 그대로 유지되는지
- 기존 v1 API와 사용자에게 보이는 결과가 달라지지 않았는지

## 검증 결과

- 새 필터 조건과 입력값 변환 단위 테스트 10건 통과
- 지도와 목록의 필터 결과 일치 테스트 통과
- 백엔드 전체 테스트 922건 통과: `./gradlew --rerun-tasks check`
- 저장소 기본 검사 통과: `sh scripts/validate-harness.sh`
